### PR TITLE
docs(pyproject): Improve tool.setuptools comment clarity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-# Prevent auto-discovery of non-Python directories (agents/, delegation/)
-# Add your packages here when you create them, e.g.: packages = ["your_project"]
+# This section has no Python packages yet. Add them when you create your package.
+# When you create packages, add them to this section, e.g. packages = ["your_project"].
+# Note: we have set this section up this way to prevent auto-discovery of non-Python directories such as agents/, delegation/, etc.
 packages = []
 
 [project]


### PR DESCRIPTION
## Summary

Improves the `[tool.setuptools]` comment in `pyproject.toml` to be more comprehensive and beginner-friendly.

## Changes

**Before:**
```toml
# Prevent auto-discovery of non-Python directories (agents/, delegation/)
# Add your packages here when you create them, e.g.: packages = ["your_project"]
```

**After:**
```toml
# This section has no Python packages yet. Add them when you create your package.
# When you create packages, add them to this section, e.g. packages = ["your_project"].
# Note: we have set this section up this way to prevent auto-discovery of non-Python directories such as agents/, delegation/, etc.
```

## Benefits

- ✅ **Clearer current state**: Explicitly states "no packages yet"
- ✅ **Better flow**: Problem → Solution → Example → Explanation
- ✅ **More explicit purpose**: Explains why `packages = []` is configured this way
- ✅ **Beginner-friendly**: Easier to understand for developers new to the starter kit

## Testing

- ✅ All pre-commit hooks pass
- ✅ TOML syntax valid
- ✅ Tests pass (5 passed, 1 skipped)

## Context

This improvement came from real-world usage in the Agentive Lotion 2 project where the original comment wasn't clear enough about why the packages list was empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)