### PR TITLE
feat: Add file location standards to agent template and operational rules

### DIFF
--- a/.claude/agents/AGENT-TEMPLATE.md
+++ b/.claude/agents/AGENT-TEMPLATE.md
@@ -224,6 +224,20 @@ This will help me proceed without further evaluation loops."
 - [Restriction 4 - e.g., "Should not work on tasks outside assigned role"]
 - [Add role-specific restrictions]
 
+## File Location Standards (MANDATORY)
+
+When creating project documentation, use the correct locations:
+
+| Document Type | Location | Example |
+|---------------|----------|---------|
+| **ADRs** | `docs/decisions/adr/` | `ADR-004-feature-name.md` |
+| **Tasks** | `delegation/tasks/1-backlog/` | `TASK-0030-task-name.md` |
+| **Research** | `[project-specific]/research/<topic>/` | `analysis.md` |
+
+**DO NOT create ADRs or documentation in `.claude/`** - that directory is for agent definitions and settings only.
+
+**Before creating an ADR**: Read `.agent-context/workflows/ADR-CREATION-WORKFLOW.md` for template and numbering.
+
 ## CI/CD Verification (When Making Commits)
 
 **⚠️ CRITICAL: When making git commits, verify CI/CD passes before task completion**
@@ -285,6 +299,6 @@ To set a model, edit the `model:` line in the frontmatter above with one of the 
 
 ---
 
-**Template Version**: 1.1.0
-**Last Updated**: 2025-11-27
+**Template Version**: 1.2.0
+**Last Updated**: 2025-01-28
 **Project**: agentive-starter-kit

--- a/.claude/agents/OPERATIONAL-RULES.md
+++ b/.claude/agents/OPERATIONAL-RULES.md
@@ -1,7 +1,7 @@
 # Operational Rules for All Agents
 
-**Version**: 2.0
-**Last Updated**: 2025-11-12
+**Version**: 2.1
+**Last Updated**: 2025-01-28
 **Applies To**: ALL agents in this project
 
 ---
@@ -108,3 +108,47 @@ If any verification fails, check:
 ## Questions?
 
 If subagents report creating files but nothing appears on disk, check `.claude/settings.local.json` permissions first.
+
+---
+
+## 📁 File Location Standards
+
+### ADRs (Architecture Decision Records)
+
+**Correct location**: `docs/decisions/adr/ADR-NNNN-short-title.md`
+
+**DO NOT create ADRs in**:
+- ❌ `.claude/` (agent/settings directory, not for project documentation)
+- ❌ Root directory
+- ❌ `.agent-context/` (coordination files only)
+
+**Before creating an ADR**: Read `.agent-context/workflows/ADR-CREATION-WORKFLOW.md` for template and numbering.
+
+### Tasks
+
+**Correct location**: `delegation/tasks/[status-folder]/TASK-NNNN-title.md`
+
+Status folders:
+- `1-backlog/` - Planned but not started
+- `2-todo/` - Ready for work
+- `3-in-progress/` - Currently being worked on
+- `5-done/` - Completed
+
+### Research Documents
+
+**Correct location**: Project-specific research folder (e.g., `docs/research/`, `research/`, or project-defined location)
+
+### Agent Definitions
+
+**Correct location**: `.claude/agents/[agent-name].md`
+
+This is the ONLY documentation type that belongs in `.claude/`.
+
+---
+
+## Why File Locations Matter
+
+1. **Discoverability**: Standard locations make it easy to find documents
+2. **Tool Integration**: Linear sync, ADR numbering, and other tools expect specific paths
+3. **Separation of Concerns**: Agent definitions (`.claude/`) vs. project documentation (`docs/`)
+4. **Template Inheritance**: New agents copy the template; correct locations propagate automatically


### PR DESCRIPTION
## Summary
- Adds **File Location Standards** section to `AGENT-TEMPLATE.md` (inherited by all new agents)
- Adds **File Location Standards** section to `OPERATIONAL-RULES.md` (applies to all agents)
- Prevents common mistake of creating ADRs and documentation in `.claude/` instead of proper locations

## Motivation
In downstream projects, agents were creating ADRs in `.claude/` directory instead of `docs/decisions/adr/`. This happened because agent instructions didn't explicitly specify file locations.

Adding explicit standards to:
1. **AGENT-TEMPLATE.md** ensures new agents inherit correct guidance
2. **OPERATIONAL-RULES.md** provides reference for all existing agents

## Changes

### AGENT-TEMPLATE.md
```markdown
## File Location Standards (MANDATORY)

| Document Type | Location | Example |
|---------------|----------|---------|
| **ADRs** | `docs/decisions/adr/` | `ADR-004-feature-name.md` |
| **Tasks** | `delegation/tasks/1-backlog/` | `TASK-0030-task-name.md` |
| **Research** | `[project-specific]/research/<topic>/` | `analysis.md` |

**DO NOT create ADRs or documentation in `.claude/`** - that directory is for agent definitions and settings only.
```

### OPERATIONAL-RULES.md
- Added comprehensive file location standards section
- Explains WHY file locations matter (discoverability, tool integration, separation of concerns)
- Lists correct/incorrect locations for ADRs, tasks, research, and agent definitions

## Test plan
- [x] Verify AGENT-TEMPLATE.md has new section
- [x] Verify OPERATIONAL-RULES.md has new section
- [ ] Create a new agent from template and verify it includes the standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)