### PR TITLE
ASK-0035: Make Linear dependencies optional

### DIFF
--- a/delegation/tasks/3-in-progress/ASK-0035-linear-deps-optional.md
+++ b/delegation/tasks/3-in-progress/ASK-0035-linear-deps-optional.md
@@ -1,6 +1,6 @@
 # ASK-0035: Make Linear Dependencies Optional
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: medium
 **Assigned To**: feature-developer
 **Estimated Effort**: 1-2 hours

--- a/delegation/tasks/5-done/ASK-0034-clean-the-template.md
+++ b/delegation/tasks/5-done/ASK-0034-clean-the-template.md
@@ -1,6 +1,6 @@
 # ASK-0034: Clean the Template
 
-**Status**: In Progress
+**Status**: Done
 **Priority**: medium
 **Assigned To**: feature-developer
 **Estimated Effort**: 1-2 hours

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,13 @@ license = {text = "MIT"}
 authors = [
     {name = "Your Name", email = "you@example.com"},  # TODO: Update author
 ]
-dependencies = [
-    # Linear sync (included by default - most projects use it)
+dependencies = []
+
+[project.optional-dependencies]
+linear = [
     "gql[requests]>=3.4.0",    # GraphQL client for Linear API
     "python-dotenv>=1.0.0",    # Load .env files
 ]
-
-[project.optional-dependencies]
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",


### PR DESCRIPTION
## Summary
- Move `gql[requests]` and `python-dotenv` from required to optional dependencies
- Install via `pip install -e ".[linear]"` when Linear sync is needed
- `pip install -e .` works without Linear dependencies
- Graceful import guards already existed in `scripts/sync_tasks_to_linear.py`

## Test Plan
- [x] All 123 tests pass
- [x] `requires_gql` marker correctly skips Linear-dependent tests
- [x] pyproject.toml has `[project.optional-dependencies] linear = [...]`
- [x] `[project] dependencies = []` (no required deps)

Part of Wave 2 dispatch-kit dogfooding trial.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change plus task doc status updates; main risk is downstream install flows that previously assumed Linear deps were always present.
> 
> **Overview**
> The base package install is simplified by removing `gql[requests]` and `python-dotenv` from required `[project] dependencies` and exposing them via a new optional extra, `[project.optional-dependencies].linear`.
> 
> Also updates internal task-tracking markdown to reflect progress (`ASK-0035` in progress, `ASK-0034` done).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be7df59560e580f31c744cde145c401f9ab7fe06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->