### PR TITLE
ASK-0040: Consolidate env templates — make .env.template canonical

### DIFF
--- a/.adversarial/scripts/evaluate_plan.sh
+++ b/.adversarial/scripts/evaluate_plan.sh
@@ -24,7 +24,7 @@ else
   echo "     adversarial init --interactive"
   echo ""
   echo "   Option 2: Copy example and add your keys manually"
-  echo "     cp .env.example .env"
+  echo "     cp .env.template .env"
   echo "     # Then edit .env and add your API keys"
   echo ""
   echo -e "${BOLD}GET API KEYS:${RESET}"

--- a/.adversarial/scripts/proofread_content.sh
+++ b/.adversarial/scripts/proofread_content.sh
@@ -24,7 +24,7 @@ else
   echo "     adversarial init --interactive"
   echo ""
   echo "   Option 2: Copy example and add your keys manually"
-  echo "     cp .env.example .env"
+  echo "     cp .env.template .env"
   echo "     # Then edit .env and add your API keys"
   echo ""
   echo -e "${BOLD}GET API KEYS:${RESET}"

--- a/.adversarial/scripts/review_implementation.sh
+++ b/.adversarial/scripts/review_implementation.sh
@@ -24,7 +24,7 @@ else
   echo "     adversarial init --interactive"
   echo ""
   echo "   Option 2: Copy example and add your keys manually"
-  echo "     cp .env.example .env"
+  echo "     cp .env.template .env"
   echo "     # Then edit .env and add your API keys"
   echo ""
   echo -e "${BOLD}GET API KEYS:${RESET}"

--- a/.adversarial/scripts/validate_tests.sh
+++ b/.adversarial/scripts/validate_tests.sh
@@ -24,7 +24,7 @@ else
   echo "     adversarial init --interactive"
   echo ""
   echo "   Option 2: Copy example and add your keys manually"
-  echo "     cp .env.example .env"
+  echo "     cp .env.template .env"
   echo "     # Then edit .env and add your API keys"
   echo ""
   echo -e "${BOLD}GET API KEYS:${RESET}"

--- a/.claude/agents/feature-developer-v3.md
+++ b/.claude/agents/feature-developer-v3.md
@@ -346,7 +346,7 @@ Reference: `.agent-context/workflows/WORKFLOW-FREEZE-POLICY.md`
 
 ## Restrictions
 
-- Never modify `.env` files (use `.env.example`)
+- Never modify `.env` files (use `.env.template`)
 - Don't change core architecture without coordinator approval
 - Always preserve backward compatibility
 - Don't skip pre-commit hooks

--- a/.claude/agents/feature-developer.md
+++ b/.claude/agents/feature-developer.md
@@ -563,7 +563,7 @@ dispatch emit changes_addressed --agent feature-developer \
 ```
 
 ## Restrictions
-- Never modify `.env` files directly (use `.env.example`)
+- Never modify `.env` files directly (use `.env.template`)
 - Don't change core architecture without coordinator approval
 - Always preserve backward compatibility
 - Don't skip pre-commit hooks (use `SKIP_TESTS=1` only for WIP commits)

--- a/.env.example
+++ b/.env.example
@@ -1,49 +1,125 @@
-# Adversarial Workflow - API Keys Configuration
-# ================================================
-#
-# This file configures which AI models power your adversarial workflow.
-# The workflow uses TWO models for quality assurance:
-#
-#   1. IMPLEMENTATION Agent: Writes code based on your task
-#   2. EVALUATOR Agent: Reviews code for quality and correctness
-#
-# Why two models? Different perspectives catch more issues!
-#
-# ================================================
-# RECOMMENDED SETUP
-# ================================================
-#
-# Claude Code uses your Anthropic API key automatically.
-# Evaluators can use OpenAI, Google, Mistral, or Anthropic.
-#
-# Run `adversarial list-evaluators` to see available options.
+# NOTE: This file is kept in sync with .env.template.
+# The canonical template is .env.template — edit that file, not this one.
+# This file exists because adversarial-workflow's `init` command expects it.
 
-# Anthropic API Key (for Claude agents)
-# Get yours at: https://console.anthropic.com/settings/keys
-# Starts with: sk-ant-
-ANTHROPIC_API_KEY=your-anthropic-api-key-here
+# Agentive Starter Kit - Environment Configuration
+# Copy this file to .env and fill in your API keys
+#
+# IMPORTANT: Never commit .env to version control!
+# The .gitignore file already excludes it.
 
-# OpenAI API Key (for built-in evaluators)
-# Get yours at: https://platform.openai.com/api-keys
-# Starts with: sk-proj- or sk-
-OPENAI_API_KEY=your-openai-api-key-here
+# ============================================================================
+# ANTHROPIC API KEY (Optional for Claude Code users)
+# ============================================================================
+# If you're using Claude Code with your claude.ai account, you're already
+# authenticated and don't need this key.
+#
+# Only needed for programmatic API access outside of Claude Code.
+# Get your key at: https://console.anthropic.com/settings/keys
+#
+# ANTHROPIC_API_KEY=sk-ant-your-key-here
 
-# ================================================
-# OPTIONAL: Additional Evaluator Providers
-# ================================================
+# ============================================================================
+# OPENAI API KEY (Required for Adversarial Evaluation)
+# ============================================================================
+# The adversarial evaluation system uses GPT-4o to review task specifications
+# before implementation. This catches design flaws early.
 #
-# Install more evaluators: ./scripts/project install-evaluators
-# Then set keys for providers you want to use:
+# Cost: ~$0.04-0.08 per evaluation (typically 2-3 evaluations per task)
+# Get your key at: https://platform.openai.com/api-keys
 #
-# GOOGLE_API_KEY=your-google-api-key-here
-# MISTRAL_API_KEY=your-mistral-api-key-here
+# Without this key, the evaluator won't work, but everything else will.
 #
-# ================================================
-# SECURITY NOTE
-# ================================================
+OPENAI_API_KEY=
+
+# ============================================================================
+# LINEAR API KEY (Optional - for task synchronization)
+# ============================================================================
+# Enables one-way sync from your task files to Linear issues.
+# Get your key at: https://linear.app/{workspace}/settings/account/security
+# (Replace {workspace} with your Linear workspace name, scroll to "Personal API keys")
 #
-# This file (.env) is automatically added to .gitignore.
-# Your API keys will NOT be committed to git.
-# Never share this file or commit it to version control.
+# Without this key, tasks work perfectly - they just won't sync to Linear.
 #
-# Need help? Run: adversarial check
+# To sync tasks:
+#   ./scripts/project linearsync                 # Manual sync
+#   (or push to main branch)             # Auto-sync via GitHub Actions
+#
+LINEAR_API_KEY=
+
+# ============================================================================
+# LINEAR TEAM CONFIGURATION (Optional)
+# ============================================================================
+# How team resolution works:
+#   1. If LINEAR_TEAM_ID is set → uses that team
+#   2. If LINEAR_TEAM_ID is unset → auto-detects first team in workspace
+#
+# Accepts THREE formats:
+#   - Team KEY: "AL2" (recommended - human-readable)
+#   - Team UUID: "89b26800-e1e6-4998-bedf-04195e592cd9"
+#   - Empty/unset: Auto-detects first team
+#
+# For SINGLE-TEAM workspaces:
+#   Leave unset (auto-detection works great)
+#
+# For MULTI-TEAM workspaces:
+#   Set to your team's KEY (e.g., "AL2", "ENG", "PROD")
+#   To see available teams: ./scripts/project linearsync (first run will show detected team)
+#
+LINEAR_TEAM_ID=
+
+# GitHub repository URL (optional - auto-detected from git remote)
+# Used for generating task file links in Linear issues
+# Example: https://github.com/yourorg/yourrepo
+# GITHUB_REPO_URL=
+
+# ============================================================================
+# PROJECT CONFIGURATION
+# ============================================================================
+# These are set during the planner onboarding process
+
+# Your project name (used in configurations)
+PROJECT_NAME=
+
+# Project ID prefix for tasks (e.g., "PROJ" creates PROJ-0001, PROJ-0002, etc.)
+TASK_PREFIX=TASK
+
+# ============================================================================
+# LOGGING CONFIGURATION
+# ============================================================================
+# Controls verbosity and optional file logging for scripts.
+# See: ADR-0009 Logging & Observability
+
+# LOG_LEVEL: Logging verbosity (DEBUG, INFO, WARNING, ERROR)
+# Default: INFO - shows standard operational messages
+# Use DEBUG for troubleshooting, ERROR for quiet operation
+# LOG_LEVEL=INFO
+
+# LOG_FILE: Path to log file (enables file logging with rotation)
+# If set, logs are written to this file in addition to console output.
+# Files rotate at 10MB with 5 backups (e.g., app.log, app.log.1, etc.)
+# LOG_FILE=logs/agentive.log
+
+# ============================================================================
+# GOOGLE / GEMINI API KEY (For Athena Knowledge Evaluator)
+# ============================================================================
+# Used by the Athena evaluator for knowledge work (research, documentation).
+# Athena uses Gemini 2.5 Pro to provide a different perspective than GPT-4o.
+#
+# Cost: ~$0.003 per evaluation (very affordable)
+# Get your key at: https://aistudio.google.com/app/apikey
+#
+# Without this key, `adversarial athena` won't work, but standard evaluation will.
+#
+GEMINI_API_KEY=
+
+# ============================================================================
+# MISTRAL API KEY (For Codestral code evaluator)
+# ============================================================================
+# Used for Codestral-based evaluators - Mistral's specialized code model.
+# Codestral excels at code review, refactoring suggestions, and technical analysis.
+#
+# Cost: Competitive pricing, see https://mistral.ai/products/la-plateforme#pricing
+# Get your key at: https://console.mistral.ai/codestral
+#
+# MISTRAL_API_KEY=

--- a/delegation/tasks/3-in-progress/ASK-0040-consolidate-env-templates.md
+++ b/delegation/tasks/3-in-progress/ASK-0040-consolidate-env-templates.md
@@ -1,6 +1,6 @@
 # ASK-0040: Consolidate .env.example and .env.template
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: low
 **Assigned To**: feature-developer-v3
 **Estimated Effort**: 30 min


### PR DESCRIPTION
## Summary
- Synced `.env.example` content to match `.env.template` (added sync header comment explaining it's a copy)
- Updated 2 agent definitions (`feature-developer-v3.md`, `feature-developer.md`) to reference `.env.template`
- Updated 4 adversarial scripts to reference `.env.template` instead of `.env.example`

## Test plan
- [x] Verification grep returns zero stale `.env.example` references in project files
- [x] `.env.example` content matches `.env.template` (with 3-line sync header)
- [x] All pre-commit hooks pass (154 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, docs/config-only changes; main impact is on developer onboarding guidance and the copy command shown by workflow scripts if `.env.template` were missing or out of date.
> 
> **Overview**
> Makes `.env.template` the canonical environment template by replacing `.env.example` with the full template content and adding a header explaining it is a synced copy kept for `adversarial init` compatibility.
> 
> Updates agent restrictions and four `.adversarial` helper scripts to instruct users to create `.env` from `.env.template` (instead of `.env.example`), and marks task `ASK-0040` as **In Progress**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fab1d7669c72288632ed7f5f219c3ca5fbbd899e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->