### PR TITLE
feat(KIT-0033): portable downstream agents via KIT-LOCAL markers

### DIFF
--- a/.claude/agents/feature-developer.md
+++ b/.claude/agents/feature-developer.md
@@ -35,7 +35,14 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > A vague agent performs worse than a specific one — fill this in.
 > Below it is filled for this repo (the kit itself) and doubles as the
 > worked example for downstream projects to model their own fill on.
+>
+> Everything between the `KIT-LOCAL: project-context` markers below is
+> consumer-owned. `bootstrap-consumer.sh` overwrites it with project
+> values on first bootstrap and preserves it across re-bootstraps;
+> upstream refreshes everything outside the markers. Keep the marker
+> comments intact when editing.
 
+<!-- BEGIN KIT-LOCAL: project-context -->
 This is the **agentive-starter-kit** project — the starter kit itself,
 the upstream source for agentive project tooling:
 
@@ -63,6 +70,7 @@ the upstream source for agentive project tooling:
   (MOSS-, SWP-, LBL-) outside example blocks
 - The untracked `.kit/adversarial/` directory is user-owned — never
   stage or delete it
+<!-- END KIT-LOCAL: project-context -->
 
 ## Repository Topology
 
@@ -191,7 +199,12 @@ For each change:
 > hydration), CMS/MCP tool distinctions, and anything an implementer
 > coming in cold would get wrong about this stack. Filled for the kit
 > repo below.
+>
+> Everything between the `KIT-LOCAL: stack-notes` markers below is
+> consumer-owned and is overwritten/preserved by `bootstrap-consumer.sh`
+> exactly like Project Context above. Keep the marker comments intact.
 
+<!-- BEGIN KIT-LOCAL: stack-notes -->
 - **Test/lint loop**: `pytest` (fast suite also runs as a pre-commit
   hook), `python3 scripts/core/pattern_lint.py <files>` for DK rules,
   `black` (line-length 88) + `isort` (black profile) + `flake8`
@@ -211,6 +224,7 @@ For each change:
   `.adversarial/evaluators/` (NOT `.kit/adversarial/`)
 - **Task lifecycle**: `./scripts/core/project start|move|complete
   <KIT-NNNN>` moves task files between status folders
+<!-- END KIT-LOCAL: stack-notes -->
 
 ## Phase 4: Self-Review (GATE)
 

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -38,6 +38,13 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > prefix, content language, deployment targets, and project rules.
 > A vague agent performs worse than a specific one — fill this in.
 >
+> Everything between the `KIT-LOCAL: project-context` markers below is
+> consumer-owned. `bootstrap-consumer.sh` overwrites it with project
+> values on first bootstrap and preserves it across re-bootstraps;
+> upstream refreshes everything outside the markers. Keep the marker
+> comments intact when editing.
+
+<!-- BEGIN KIT-LOCAL: project-context -->
 > Worked example (fictional project, delete when filling in):
 >
 > ```markdown
@@ -52,6 +59,8 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > - Tasks always start in `2-todo/` after evaluation; backlog ideas in `1-backlog/`
 > - Linear sync is enabled; verify after status moves
 > ```
+<!-- END KIT-LOCAL: project-context -->
+
 
 ## Repository Topology
 

--- a/.kit/context/KIT-0033-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0033-REVIEW-STARTER.md
@@ -1,0 +1,99 @@
+# Review Starter: KIT-0033
+
+**Task**: KIT-0033 — Make planner + feature-developer truly portable downstream
+**Task File**: `.kit/tasks/4-in-review/KIT-0033-portable-agents-downstream.md`
+**Branch**: feature/KIT-0033-portable-agents-downstream → main
+**PR**: https://github.com/movito/agentive-starter-kit/pull/58
+
+## Implementation Summary
+
+Makes the consolidated V2 **planner** and **feature-developer** agents portable to
+consumer projects bootstrapped via `bootstrap-consumer.sh`. Resolves the four
+PR #57 bot threads on under-scaffolded downstream bootstrap.
+
+- **Markers (N2)**: the consumer-customizable sections — Project Context (both
+  agents) and Stack Notes (feature-developer) — are wrapped in stable
+  `<!-- BEGIN/END KIT-LOCAL: <region> -->` markers. ASK's own filled content is
+  byte-unchanged; the diff is purely additive (N1).
+- **`scripts/local/kit_markers.py`** (stdlib-only) merges marker regions:
+  - *Fresh bootstrap* → regions seeded with consumer-neutral placeholders derived
+    from the project name (no kit identity, no KIT-NNNN, no kit-only paths).
+  - *Re-bootstrap* → consumer's filled regions preserved **byte-for-byte** while
+    structure *outside* the markers refreshes from upstream. Without markers,
+    `--ignore-existing` is the only safe rsync mode and consumers get stuck on
+    whatever agent version they first bootstrapped (the gap #3 root cause).
+  - *Markerless pre-consolidation agent* → reseeds from placeholders, never
+    inheriting kit identity. *Malformed marker* (BEGIN without END) → fails fast
+    with `ValueError` rather than clobbering trapped content. *CRLF endings* →
+    parsed and preserved.
+- **`.kit/` skeleton (F1)**: bootstrap provisions `tasks/1-backlog … 7-blocked`,
+  `context/`, and `templates/TASK-STARTER-TEMPLATE.md`; the shipped
+  `./scripts/core/project` makes the lifecycle work on day one.
+- **`--no-kit` opt-out (F3)**: skips the `.kit/` scaffold and drops planner /
+  feature-developer, with a one-line skip summary. Self-target guard refuses to
+  bootstrap into the kit source repo itself.
+
+## Files Changed
+
+- `.claude/agents/feature-developer.md` — KIT-LOCAL markers around Project Context
+  + Stack Notes (additive only)
+- `.claude/agents/planner.md` — KIT-LOCAL markers around Project Context (additive)
+- `scripts/local/kit_markers.py` (new) — stdlib marker merge helper + CLI
+- `scripts/local/bootstrap-consumer.sh` — `.kit/` skeleton, marker-merge of the two
+  agents, `--no-kit` flag, self-target guard, stale-test sweep
+- `tests/test_kit_markers.py` (new) — 35 tests over merge logic, re-bootstrap
+  byte-preservation, edge cases, and the CLI surface
+- `CHANGELOG.md` — Unreleased → Added entry
+- `.kit/context/reviews/KIT-0033-evaluator-review.md` (new) — Phase-7 evaluator trail
+- `.kit/tasks/{1-backlog → 3-in-progress}/KIT-0033-*.md` (moved)
+
+## Verification
+
+All acceptance criteria exercised end-to-end against scratch consumer dirs:
+
+- ✅ `.kit/` skeleton created; `project start` then `project complete` move a stub
+  task `2-todo → 3-in-progress → 5-done` and update `**Status**`
+- ✅ Fresh bootstrap identity-clean (no KIT-NNNN / kit paths in customizable regions)
+- ✅ Re-bootstrap: both regions byte-identical preserved; outside-marker structure
+  refreshed from upstream (stale heading replaced)
+- ✅ Opt-out: no `.kit/`, no planner/feature-developer, clean summary; other agents
+  still ship
+- ✅ Markerless pre-consolidation agent reseeds to placeholders (no identity leak)
+- ✅ Stale orphan `tests/test_kit_markers.py` swept on re-bootstrap
+- ✅ N1: ASK agent diff purely additive (markers + mechanism note)
+- Full suite: 290 passed, 12 skipped; coverage 89.8% (`kit_markers.py` 100%);
+  black / isort / flake8 / pattern-lint clean; CI green on PR #58
+
+## Review History
+
+**Evaluator** (Phase 7, code-reviewer-fast / Gemini): FAIL → all findings fixed
+(self-bootstrap guard, duplicate-region handling, blank-name fallback) + CLI tests
+added. Trail: `.kit/context/reviews/KIT-0033-evaluator-review.md`.
+
+**Bots** (PR #58): 7 threads across 4 rounds — all valid, all fixed and resolved:
+1. Consumer pytest import failure (test shipped, helper not) → exclude from sync +
+   module-skip guard + stale-orphan `rm -f` sweep
+2. Fail-fast on malformed consumer marker → `merge()` raises `ValueError`
+3. CLI handler/`main()` coverage → `TestCLI` class (restored 80% gate)
+4. CRLF line endings broke marker parsing → `\r?\n`-tolerant pattern
+
+## Areas for Review Focus
+
+1. **Marker scheme robustness** — confirm the `\r?\n` region pattern and the
+   fail-fast-on-malformed behavior are the right trade-offs; that the body is
+   preserved byte-for-byte across re-bootstrap regardless of line endings.
+2. **N1 (no ASK regression)** — that the agent diffs are purely additive and ASK's
+   filled Project Context / Stack Notes are unchanged.
+3. **Placeholder content** — that the seeded placeholders are genuinely
+   consumer-neutral (no kit identity) and useful as a fill-in starting point.
+4. **Bootstrap orchestration** — the merge branch (fresh vs. re-bootstrap), the
+   `--no-kit` path, and the self-target / stale-test guards.
+
+## Related Tasks
+
+- Resolves the four PR #57 threads (r3484524391, r3484524395, r3484592020,
+  r3484585878). Coordinate with **KIT-0026** (peer-repo agent/skill sync — different
+  mechanism, different target). No new ADR.
+
+---
+**Ready for human / code-reviewer review.**

--- a/.kit/context/retros/KIT-0033-retro.md
+++ b/.kit/context/retros/KIT-0033-retro.md
@@ -1,0 +1,89 @@
+## KIT-0033 — Make planner + feature-developer truly portable downstream (PR #58)
+
+**Date**: 2026-06-27
+**Agent**: feature-developer
+**Mode**: single-repo
+**Scorecard**: 9 threads, 0 regressions, 5 fix rounds (1 evaluator + 4 bot), 7 commits
+
+### What Worked
+
+1. **Extracting the merge logic into a stdlib Python helper** — putting the
+   marker merge in `scripts/local/kit_markers.py` (functions + thin CLI) instead
+   of inline `sed`/`awk` in bash made the N2/F4 core directly unit-testable. Every
+   subsequent bot finding (CRLF, malformed-marker fail-fast, duplicate regions)
+   landed as a 3-line function change plus a focused test, not a bash rewrite.
+2. **Scratch-consumer end-to-end verification via `mktemp`** — running the real
+   `bootstrap-consumer.sh` against throwaway dirs caught behaviors unit tests
+   can't: the `.kit/` skeleton, lifecycle `project start`/`complete`, the stale-
+   orphan sweep, and the atomicity abort all proven against actual filesystem
+   state before and after each fix.
+3. **Running the Phase-7 evaluator while CI was pending** — code-reviewer-fast
+   returned FAIL and surfaced the `rm -f`-on-source footgun and duplicate-region
+   bug *before* the bots did, so those were already fixed in `40f732d` by the time
+   the bots posted.
+4. **`gh-review-helper.sh` for thread triage** — `threads`/`reply`/`resolve`
+   subcommands made the reply-and-resolve loop mechanical across all 9 threads;
+   no hand-rolled GraphQL for thread node IDs.
+
+### What Was Surprising
+
+1. **The bots found a real bug I'd shipped, not just nitpicks** — both BugBot and
+   CodeRabbit independently flagged that `tests/test_kit_markers.py` was rsynced
+   to consumers while its `scripts/local/kit_markers.py` import was not, breaking
+   consumer `pytest`/`pytest-fast` at collection. The marker design was sound but
+   the *delivery* of its test was not — a blind spot pure-LLM self-review missed.
+2. **Five fix rounds for a "4–8 hour" task** — each push surfaced exactly one new
+   edge case (orphan sweep → CRLF → merge atomicity → arg guard). All were
+   legitimate; the cadence was "fix, push, bot finds the next layer." The fail-fast
+   I added on CodeRabbit's advice is what made the *atomicity* bug reachable, which
+   BugBot then caught — a fix exposing the next finding.
+3. **flake8 E501 noise vs. actual gate** — bare `flake8` flagged 79-char overflows,
+   but the repo's CI and pre-commit both use `--select=E9,F63,F7,F82` (no E501) with
+   `--max-line-length=88`. Several minutes spent reconciling before reading
+   `.github/workflows/test.yml` showed line length isn't even checked.
+4. **The coverage gate, not a test, was the first CI failure** — adding 100%-tested
+   library functions still dropped total coverage to 78% because the *CLI* layer
+   (`_cmd_*`, `main`) was uncovered. Easy to forget the gate is on the whole file.
+
+### What Should Change
+
+1. **Add a "does this test ship downstream?" check to self-review** — any new test
+   that imports from `scripts/local/` (not synced to consumers) must be excluded
+   from the consumer `tests/` rsync. This was the highest-severity miss and is a
+   recurring structural hazard for the kit's dual ASK-dev / consumer audience.
+2. **Bootstrap mutations should be temp-then-commit by default** — the atomicity
+   bug (per-item `mv` inside a `set -e` loop) is a general bash pattern worth
+   codifying: stage all outputs to temp files, then move them only after every
+   step succeeds. Worth a note in a bootstrap/scripting guideline.
+3. **Run the evaluator AND a quick `git grep` for "what gets synced" before first
+   push** — the consumer-import bug was discoverable by asking "the test file lands
+   in consumers; does its import?" A pre-push checklist item for files that cross
+   the ASK→consumer boundary would have saved 2 bot rounds.
+4. **Document the Gate-2 SHA-matching quirk in preflight** — CodeRabbit APPROVED
+   and its check-run is green, but `preflight-check.sh` Gate 2 still FAILs because
+   no `coderabbitai[bot]` review event is tied to the exact head SHA after a docs-
+   only or trivial push. The gate should accept "check-run passed + latest review
+   APPROVED + zero unresolved threads" as equivalent.
+
+### Permission Prompts Hit
+
+1. **`cd … && chmod … && rm -rf … && bash …`** (chained, with `rm -rf`) — denied
+   immediately at the first scratch-dir setup. Worked around by splitting into
+   separate calls and using `mktemp -d` instead of `rm -rf` on a fixed path.
+2. **`rm -rf /tmp/kit-consumer-test; mkdir …; echo`** — denied (the `rm -rf`).
+   Switched to `mktemp -d` for all scratch consumers thereafter.
+
+Both are general sandbox guards (destructive `rm -rf` + command chaining), not
+project allowlist entries — no `.claude/settings.json` change warranted. Lesson:
+reach for `mktemp -d` from the start for throwaway dirs.
+
+### Process Actions Taken
+
+- [ ] Add self-review checklist item: tests importing `scripts/local/` must be
+      excluded from the consumer `tests/` sync in `bootstrap-consumer.sh`
+- [ ] Codify the temp-then-commit (two-pass) pattern for multi-file bootstrap
+      mutations in a scripting guideline
+- [ ] Relax `preflight-check.sh` Gate 2 to accept check-run-pass + latest review
+      APPROVED + zero unresolved threads (avoid SHA-exact false negatives)
+- [ ] Consider shipping `kit_markers.py` test coverage expectations as part of the
+      consumer manifest contract (so the dual-audience boundary is explicit)

--- a/.kit/context/reviews/KIT-0033-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0033-evaluator-review.md
@@ -1,0 +1,47 @@
+#  Code Reviewer Fast
+
+**Source**: .adversarial/inputs/KIT-0033-code-review-input.md
+**Evaluator**: code-reviewer-fast
+**Model**: gemini/gemini-2.5-flash
+**Generated**: 2026-06-27 00:52 UTC
+
+---
+
+### Findings
+
+**[CORRECTNESS]: Duplicate KIT-LOCAL region names are not handled correctly**
+- **Location**: `scripts/local/kit_markers.py:merge`
+- **Edge case**: An agent markdown file contains multiple `KIT-LOCAL` regions with the *same* name (e.g., two `project-context` blocks).
+- **What happens**: `find_regions` will return the duplicate names. When `merge` iterates through these and calls `replace_region` for each, `replace_region` (due to `count=1`) will consistently modify *only the first* instance of that named region. Subsequent regions with the same name will be ignored during the merge process, silently failing to apply consumer content or placeholders to them. This violates the implicit expectation that if a region is defined, it should be processed.
+- **Tested?**: No
+
+**[CORRECTNESS]: `bootstrap-consumer.sh` modifies its own source repository if target is `PROJECT_ROOT`**
+- **Location**: `scripts/local/bootstrap-consumer.sh`
+- **Edge case**: The target directory (`$TARGET`) for bootstrapping is accidentally set to the `agentive-starter-kit`'s own `PROJECT_ROOT`.
+- **What happens**: The `rm -f` commands intended to sweep retired agent variants from the *consumer* project (`"$TARGET/.claude/agents/planner2.md"`, etc.) would execute on the *source* `agentive-starter-kit` repository itself. This would delete the historical `planner2.md`, `planner3.md`, `feature-developer-v3.md`, `feature-developer-v6.md`, and `feature-developer-v7.md` files from the kit's own `.claude/agents` directory. While these are "retired", their deletion from the canonical source repo as a side effect of a consumer bootstrap operation is highly undesirable and likely unintended.
+- **Tested?**: No
+
+**[ROBUSTNESS]: `kit_markers.py` does not explicitly validate well-formed marker pairs**
+- **Location**: `scripts/local/kit_markers.py:find_regions`
+- **Edge case**: An agent markdown file contains a `BEGIN` marker for a region but is missing the corresponding `END` marker (e.g., `<!-- BEGIN KIT-LOCAL: my-region -->\nSome content\n`).
+- **What happens**: `find_regions` would still detect and return the region name. However, `extract_region` and `replace_region` would fail to find a match for `_region_pattern` because the pattern requires both `BEGIN\nBODY\nEND`. This would lead `extract_region` to return `None`, and `replace_region` to raise `KeyError` (if called directly for that region) or fallback to placeholder/upstream content in `merge`. While `merge` handles the fallback, it could silently mask a malformed agent file.
+- **Tested?**: No
+
+**[ROBUSTNESS]: `default_placeholders` produces empty title for specific `project_name` inputs**
+- **Location**: `scripts/local/kit_markers.py:default_placeholders`
+- **Edge case**: The `project_name` is an empty string, or consists only of characters that are replaced by spaces (`-`, `_`). For example, `project_name="---"` or `project_name=""`.
+- **What happens**: `project_name.replace("-", " ").replace("_", " ").title()` will result in an empty string or a string of spaces. The placeholder content would then include "This is the **''** project." or "This is the **   ** project.". While not a functional failure, it's a cosmetic issue that makes the generated placeholder less user-friendly. `basename` in `bootstrap-consumer.sh` makes truly empty unlikely, but all-whitespace/punctuation is possible.
+- **Tested?**: Yes (TestDefaultPlaceholders covers empty and `widget-factory_2`, but doesn't explicitly check for all-whitespace/punctuation names).
+
+### Test Gap Summary
+| Edge Case | Function | Tested? | Risk |
+|---|---|---|---|
+| Duplicate KIT-LOCAL region names | `kit_markers.py:merge` | No | High (logic error, silent failure to apply updates) |
+| Target is `PROJECT_ROOT` (self-bootstrap) | `bootstrap-consumer.sh` | No | High (modifies source control of the kit itself) |
+| Missing `END` marker for a region | `kit_markers.py:find_regions` | No | Medium (silently masks malformed agent file) |
+| Empty content within markers | `kit_markers.py:extract_region`, `kit_markers.py:replace_region` | No | Low (implied by other tests, likely works) |
+| Entire `bootstrap-consumer.sh` script | `bootstrap-consumer.sh` (all functions) | No | High (orchestration logic, file system operations) |
+
+### Verdict
+
+**FAIL**: Correctness bugs found. The `rm -f` in `bootstrap-consumer.sh` operating on the source kit is a critical issue that could lead to data loss or corruption of the kit's own history. The silent failure to handle duplicate region names in `kit_markers.py` is also a correctness bug for unexpected but plausible inputs. These must be fixed.

--- a/.kit/tasks/3-in-progress/KIT-0033-portable-agents-downstream.md
+++ b/.kit/tasks/3-in-progress/KIT-0033-portable-agents-downstream.md
@@ -1,6 +1,6 @@
 # KIT-0033: Make planner + feature-developer truly portable downstream
 
-**Status**: Backlog
+**Status**: In Progress
 **Priority**: medium
 **Assigned To**: unassigned
 **Estimated Effort**: 4-8 hours

--- a/.kit/tasks/4-in-review/KIT-0033-portable-agents-downstream.md
+++ b/.kit/tasks/4-in-review/KIT-0033-portable-agents-downstream.md
@@ -1,6 +1,6 @@
 # KIT-0033: Make planner + feature-developer truly portable downstream
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: medium
 **Assigned To**: unassigned
 **Estimated Effort**: 4-8 hours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Portable downstream agents via KIT-LOCAL markers** (KIT-0033) — resolves
+  the four PR #57 bot threads on under-scaffolded consumer bootstrap.
+  - `planner.md` and `feature-developer.md` wrap their consumer-customizable
+    sections (Project Context, and Stack Notes for feature-developer) in
+    stable `<!-- BEGIN/END KIT-LOCAL: <region> -->` markers. ASK's own filled
+    content is unchanged — only the markers and a short mechanism note are
+    added.
+  - New `scripts/local/kit_markers.py` (stdlib-only) merges marker regions:
+    fresh bootstrap seeds them with consumer-neutral placeholders (no kit
+    identity); re-bootstrap preserves the consumer's filled regions
+    byte-for-byte while refreshing agent structure *outside* the markers.
+    Without markers the only safe rsync mode is `--ignore-existing`, which
+    leaves consumers stuck on whatever agent version they first bootstrapped.
+  - `bootstrap-consumer.sh` provisions a working `.kit/` skeleton
+    (`tasks/1-backlog … 7-blocked`, `context/`,
+    `templates/TASK-STARTER-TEMPLATE.md`) so the shipped V2 planner +
+    feature-developer workflows run on day one, and marker-merges the two
+    agents instead of rsyncing them blindly.
+  - New `--no-kit` opt-out flag: skips the `.kit/` scaffold and drops
+    `planner.md` / `feature-developer.md`, with a one-line summary of what
+    was skipped.
+  - `tests/test_kit_markers.py` covers the merge logic, including the
+    re-bootstrap byte-preservation guarantee.
+
 ### Changed
 
 - **Planner and feature-developer agents consolidated** (PR #57) — versioned

--- a/scripts/local/bootstrap-consumer.sh
+++ b/scripts/local/bootstrap-consumer.sh
@@ -56,6 +56,12 @@ if [ ! -d "$TARGET" ]; then
     exit 1
 fi
 TARGET="$(cd "$TARGET" && pwd)"
+if [ "$TARGET" = "$PROJECT_ROOT" ]; then
+    echo "Error: target is the kit source repo ($PROJECT_ROOT)."
+    echo "   bootstrap-consumer.sh provisions a *consumer* checkout; running it"
+    echo "   against the kit itself would rsync/sweep its own files. Aborting."
+    exit 1
+fi
 PROJECT_NAME="$(basename "$TARGET")"
 
 if [ "$KIT_ENABLED" -eq 1 ]; then

--- a/scripts/local/bootstrap-consumer.sh
+++ b/scripts/local/bootstrap-consumer.sh
@@ -41,6 +41,11 @@ for arg in "$@"; do
             exit 1
             ;;
         *)
+            if [ -n "$TARGET" ]; then
+                echo "Error: multiple target directories given ('$TARGET' and '$arg')"
+                echo "Usage: $0 [--no-kit] <target-directory>"
+                exit 1
+            fi
             TARGET="$arg"
             ;;
     esac
@@ -202,20 +207,33 @@ if [ "$KIT_ENABLED" -eq 1 ]; then
     # passed so that an existing-but-markerless agent (a consumer stuck on
     # a pre-consolidation copy) gets clean placeholders rather than the
     # kit's own Project Context / Stack Notes content.
-    for agent in planner.md feature-developer.md; do
+    #
+    # Two-pass for atomicity: merge BOTH agents to temp files first, so a
+    # failure on the second (e.g. malformed consumer markers → ValueError
+    # under `set -e`) aborts before any destination is overwritten — never
+    # leaving a consumer with one agent updated and the other stale. Only
+    # once every merge succeeds are the temp files moved into place.
+    KIT_AGENTS=(planner.md feature-developer.md)
+    # Clear any stale temp file left by a previously aborted merge pass.
+    rm -f "$TARGET/.claude/agents/"*.kit-merge.tmp
+    for agent in "${KIT_AGENTS[@]}"; do
         up="$PROJECT_ROOT/.claude/agents/$agent"
         dst="$TARGET/.claude/agents/$agent"
-        tmp="$dst.kit-merge.tmp"
-        merge_args=(merge --upstream "$up" --project-name "$PROJECT_NAME" --out "$tmp")
+        merge_args=(merge --upstream "$up" --project-name "$PROJECT_NAME" \
+                    --out "$dst.kit-merge.tmp")
         if [ -f "$dst" ]; then
             merge_args+=(--consumer "$dst")
-            python3 "$KIT_MARKERS" "${merge_args[@]}"
+        fi
+        python3 "$KIT_MARKERS" "${merge_args[@]}"
+    done
+    for agent in "${KIT_AGENTS[@]}"; do
+        dst="$TARGET/.claude/agents/$agent"
+        if [ -f "$dst" ]; then
             echo "  refreshed $agent (preserved filled KIT-LOCAL regions)"
         else
-            python3 "$KIT_MARKERS" "${merge_args[@]}"
             echo "  installed $agent (KIT-LOCAL regions seeded with placeholders)"
         fi
-        mv "$tmp" "$dst"
+        mv "$dst.kit-merge.tmp" "$dst"
     done
 
     # .kit/ skeleton — task status folders, coordination dir, task-starter

--- a/scripts/local/bootstrap-consumer.sh
+++ b/scripts/local/bootstrap-consumer.sh
@@ -125,7 +125,10 @@ mkdir -p "$TARGET/scripts/optional"
 # tests/ — test infrastructure. Exclude test_kit_markers.py: it imports
 # scripts/local/kit_markers.py, an ASK-only bootstrap tool that is never
 # synced to consumers, so shipping the test would break consumer pytest
-# (and the pytest-fast pre-commit hook) at collection time.
+# (and the pytest-fast pre-commit hook) at collection time. The rm -f
+# sweep removes a stale copy from a pre-fix bootstrap — --ignore-existing
+# would otherwise leave the orphaned test behind in existing consumers.
+rm -f "$TARGET/tests/test_kit_markers.py"
 "${RSYNC_BASE[@]}" --exclude='test_kit_markers.py' \
     "$PROJECT_ROOT/tests/" "$TARGET/tests/"
 

--- a/scripts/local/bootstrap-consumer.sh
+++ b/scripts/local/bootstrap-consumer.sh
@@ -2,10 +2,18 @@
 # Bootstrap a consumer project from the agentive starter kit.
 #
 # Consumer projects get implementation tools (agents, scripts, commands)
-# but NOT the builder layer (.kit/ — planning, evaluation, coordination).
+# plus a minimal .kit/ workflow skeleton (task folders, context, task-starter
+# template) that the shipped V2 planner + feature-developer agents need.
+# They do NOT get the full builder layer (evaluators, ADRs, kit planning docs).
 #
 # Usage:
 #   ~/Github/agentive-starter-kit/scripts/local/bootstrap-consumer.sh ~/Github/my-app
+#   ~/Github/agentive-starter-kit/scripts/local/bootstrap-consumer.sh --no-kit ~/Github/my-app
+#
+# Flags:
+#   --no-kit   Opt out of the kit workflow entirely: no .kit/ scaffold and
+#              no planner.md / feature-developer.md shipped. Useful for a
+#              consumer that only wants the lighter implementation tooling.
 #
 # Prerequisites:
 #   - Target directory exists
@@ -14,12 +22,34 @@
 set -e
 
 # ─────────────────────────────────────────
-# Resolve paths
+# Resolve paths + parse args
 # ─────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+KIT_MARKERS="$PROJECT_ROOT/scripts/local/kit_markers.py"
 
-TARGET="${1:?Usage: $0 <target-directory>}"
+KIT_ENABLED=1
+TARGET=""
+for arg in "$@"; do
+    case "$arg" in
+        --no-kit)
+            KIT_ENABLED=0
+            ;;
+        --*)
+            echo "Error: unknown flag: $arg"
+            echo "Usage: $0 [--no-kit] <target-directory>"
+            exit 1
+            ;;
+        *)
+            TARGET="$arg"
+            ;;
+    esac
+done
+
+if [ -z "$TARGET" ]; then
+    echo "Usage: $0 [--no-kit] <target-directory>"
+    exit 1
+fi
 if [ ! -d "$TARGET" ]; then
     echo "Error: Target directory does not exist: $TARGET"
     echo "   Create it first and put your project files in it."
@@ -28,24 +58,36 @@ fi
 TARGET="$(cd "$TARGET" && pwd)"
 PROJECT_NAME="$(basename "$TARGET")"
 
+if [ "$KIT_ENABLED" -eq 1 ]; then
+    KIT_LABEL="Consumer + .kit/ workflow skeleton"
+else
+    KIT_LABEL="Consumer (--no-kit: no workflow skeleton, no planner/feature-developer)"
+fi
+
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Bootstrapping consumer project: $PROJECT_NAME"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Source:  $PROJECT_ROOT"
 echo "  Target:  $TARGET"
-echo "  Type:    Consumer (no builder layer)"
+echo "  Type:    $KIT_LABEL"
 echo
 
 # ─────────────────────────────────────────
 # Step 1: Copy implementation scaffolding
 # ─────────────────────────────────────────
-echo "1/3 Copying implementation scaffolding..."
+echo "1/4 Copying implementation scaffolding..."
 
 RSYNC_BASE=(rsync -a --ignore-existing --exclude='.git/' --exclude='.venv/' --exclude='__pycache__/' --exclude='.DS_Store')
 
-# .claude/ — implementation agents, commands, skills, settings
-# planner.md ships downstream (V2 is portable with EXTENSION POINTs).
-# Reviewer agents stay builder-only.
+# .claude/ — implementation agents, commands, skills, settings.
+# Reviewer agents stay builder-only. The two consumer-customizable V2
+# agents (planner.md, feature-developer.md) are excluded here and handled
+# by the marker-merge step below — rsync's --ignore-existing can neither
+# fill their KIT-LOCAL regions for a fresh consumer nor refresh structure
+# for an existing one. With --no-kit they are dropped entirely.
+AGENT_EXCLUDES=(--exclude='code-reviewer.md' --exclude='document-reviewer.md' --exclude='security-reviewer.md' \
+                --exclude='planner.md' --exclude='feature-developer.md')
+
 # Sweep retired agent variants from a prior bootstrap before rsync; --ignore-existing
 # would otherwise leave legacy planner2/3 + feature-developer-v3/v6/v7 alongside the
 # canonical V2 agents in an existing checkout.
@@ -54,8 +96,7 @@ rm -f "$TARGET/.claude/agents/planner2.md" \
       "$TARGET/.claude/agents/feature-developer-v3.md" \
       "$TARGET/.claude/agents/feature-developer-v6.md" \
       "$TARGET/.claude/agents/feature-developer-v7.md"
-"${RSYNC_BASE[@]}" \
-    --exclude='code-reviewer.md' --exclude='document-reviewer.md' --exclude='security-reviewer.md' \
+"${RSYNC_BASE[@]}" "${AGENT_EXCLUDES[@]}" \
     "$PROJECT_ROOT/.claude/" "$TARGET/.claude/"
 
 # .serena/ — setup script and template
@@ -130,13 +171,65 @@ if [ ! -f "$TARGET/scripts/.core-manifest.json" ]; then
 MANIFEST
 fi
 
-echo "Done (no .kit/ builder layer — consumer project)"
+echo "Done"
 echo
 
 # ─────────────────────────────────────────
-# Step 2: Initialize git (if needed)
+# Step 2: Kit workflow agents + skeleton
 # ─────────────────────────────────────────
-echo "2/3 Checking git..."
+echo "2/4 Provisioning kit workflow..."
+
+if [ "$KIT_ENABLED" -eq 1 ]; then
+    mkdir -p "$TARGET/.claude/agents"
+
+    # Marker-merge the two consumer-customizable V2 agents. A fresh
+    # consumer gets KIT-LOCAL regions filled with project placeholders;
+    # an existing consumer keeps its filled-in regions while picking up
+    # upstream structure outside the markers. --project-name is always
+    # passed so that an existing-but-markerless agent (a consumer stuck on
+    # a pre-consolidation copy) gets clean placeholders rather than the
+    # kit's own Project Context / Stack Notes content.
+    for agent in planner.md feature-developer.md; do
+        up="$PROJECT_ROOT/.claude/agents/$agent"
+        dst="$TARGET/.claude/agents/$agent"
+        tmp="$dst.kit-merge.tmp"
+        merge_args=(merge --upstream "$up" --project-name "$PROJECT_NAME" --out "$tmp")
+        if [ -f "$dst" ]; then
+            merge_args+=(--consumer "$dst")
+            python3 "$KIT_MARKERS" "${merge_args[@]}"
+            echo "  refreshed $agent (preserved filled KIT-LOCAL regions)"
+        else
+            python3 "$KIT_MARKERS" "${merge_args[@]}"
+            echo "  installed $agent (KIT-LOCAL regions seeded with placeholders)"
+        fi
+        mv "$tmp" "$dst"
+    done
+
+    # .kit/ skeleton — task status folders, coordination dir, task-starter
+    # template. The project script hardcodes .kit/tasks/<status>/, so these
+    # directories must exist for the lifecycle commands to work.
+    for d in 1-backlog 2-todo 3-in-progress 4-in-review 5-done 6-canceled 7-blocked; do
+        mkdir -p "$TARGET/.kit/tasks/$d"
+        [ -e "$TARGET/.kit/tasks/$d/.gitkeep" ] || touch "$TARGET/.kit/tasks/$d/.gitkeep"
+    done
+    mkdir -p "$TARGET/.kit/context"
+    [ -e "$TARGET/.kit/context/.gitkeep" ] || touch "$TARGET/.kit/context/.gitkeep"
+    mkdir -p "$TARGET/.kit/templates"
+    if [ ! -f "$TARGET/.kit/templates/TASK-STARTER-TEMPLATE.md" ]; then
+        cp "$PROJECT_ROOT/.kit/templates/TASK-STARTER-TEMPLATE.md" \
+           "$TARGET/.kit/templates/TASK-STARTER-TEMPLATE.md"
+    fi
+
+    echo "  .kit/ skeleton ready (tasks/, context/, templates/)"
+else
+    echo "  Skipped (--no-kit): no .kit/ scaffold, no planner.md / feature-developer.md"
+fi
+echo
+
+# ─────────────────────────────────────────
+# Step 3: Initialize git (if needed)
+# ─────────────────────────────────────────
+echo "3/4 Checking git..."
 
 cd "$TARGET"
 
@@ -151,9 +244,9 @@ fi
 echo
 
 # ─────────────────────────────────────────
-# Step 3: Next steps
+# Step 4: Next steps
 # ─────────────────────────────────────────
-echo "3/3 Next steps"
+echo "4/4 Next steps"
 echo
 echo "Your consumer project is scaffolded. To complete setup:"
 echo
@@ -162,8 +255,17 @@ echo "  ./scripts/core/project setup        # Python venv + deps"
 echo "  source .venv/bin/activate            # Activate venv"
 echo "  cp .env.template .env               # Add your API keys"
 echo
-echo "Launch agents with:"
-echo "  claude --agent .claude/agents/feature-developer.md"
+if [ "$KIT_ENABLED" -eq 1 ]; then
+    echo "Fill in the KIT-LOCAL regions (Project Context / Stack Notes) in:"
+    echo "  .claude/agents/feature-developer.md"
+    echo "  .claude/agents/planner.md"
+    echo
+    echo "Launch agents with:"
+    echo "  claude --agent .claude/agents/feature-developer.md"
+else
+    echo "Launch an agent with, e.g.:"
+    echo "  claude --agent .claude/agents/ci-checker.md"
+fi
 echo
 echo "To pull upstream updates later:"
 echo "  git remote add upstream https://github.com/movito/agentive-starter-kit.git"

--- a/scripts/local/bootstrap-consumer.sh
+++ b/scripts/local/bootstrap-consumer.sh
@@ -122,8 +122,12 @@ mkdir -p "$TARGET/scripts/optional"
     --exclude='sync-core-scripts.yml' --exclude='sync-to-linear.yml' \
     "$PROJECT_ROOT/.github/" "$TARGET/.github/"
 
-# tests/ — test infrastructure
-"${RSYNC_BASE[@]}" "$PROJECT_ROOT/tests/" "$TARGET/tests/"
+# tests/ — test infrastructure. Exclude test_kit_markers.py: it imports
+# scripts/local/kit_markers.py, an ASK-only bootstrap tool that is never
+# synced to consumers, so shipping the test would break consumer pytest
+# (and the pytest-fast pre-commit hook) at collection time.
+"${RSYNC_BASE[@]}" --exclude='test_kit_markers.py' \
+    "$PROJECT_ROOT/tests/" "$TARGET/tests/"
 
 # Top-level files (only if they don't exist in target)
 for f in pyproject.toml .gitignore .pre-commit-config.yaml .env.template .coderabbitignore conftest.py; do

--- a/scripts/local/kit_markers.py
+++ b/scripts/local/kit_markers.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""kit_markers — overwrite/preserve KIT-LOCAL marker regions in agent files.
+
+The canonical agents (`planner.md`, `feature-developer.md`) wrap their
+consumer-customizable sections (Project Context, Stack Notes) in stable
+markers:
+
+    <!-- BEGIN KIT-LOCAL: project-context -->
+    ...consumer-owned content...
+    <!-- END KIT-LOCAL: project-context -->
+
+`bootstrap-consumer.sh` uses this helper so that:
+
+- **Fresh bootstrap** — the upstream agent is copied, then each marker
+  region is replaced with consumer-derived placeholder content (so a
+  consumer never inherits the kit's own Project Context / Stack Notes).
+- **Re-bootstrap** — the upstream agent is copied to pick up structural
+  improvements *outside* the markers, while the consumer's existing
+  content *inside* every marker region is preserved verbatim
+  (byte-for-byte).
+
+Stdlib only — consumers run this with the bare `python3` the `project`
+script already requires; no venv needed.
+
+CLI:
+    kit_markers.py merge --upstream U --out O [--consumer C] [--project-name N]
+    kit_markers.py extract <file> <region>
+    kit_markers.py replace <file> <region> (--content-file F | --stdin)
+    kit_markers.py regions <file>
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+BEGIN_RE = re.compile(r"<!-- BEGIN KIT-LOCAL: (?P<name>\S+) -->")
+
+
+def _region_pattern(name: str) -> re.Pattern[str]:
+    """Compile a DOTALL pattern capturing the inner content of one region.
+
+    Group 'body' is everything between the newline after BEGIN and the
+    newline before END — never the marker lines themselves — so an
+    extract/replace round-trip is byte-identical.
+    """
+    esc = re.escape(name)
+    return re.compile(
+        r"(?P<begin><!-- BEGIN KIT-LOCAL: " + esc + r" -->\n)"
+        r"(?P<body>.*?)"
+        r"(?P<end>\n<!-- END KIT-LOCAL: " + esc + r" -->)",
+        re.DOTALL,
+    )
+
+
+def find_regions(text: str) -> list[str]:
+    """Return the region names present in *text*, in document order."""
+    return BEGIN_RE.findall(text)
+
+
+def extract_region(text: str, name: str) -> str | None:
+    """Return the inner content of region *name*, or None if absent."""
+    match = _region_pattern(name).search(text)
+    if match is None:
+        return None
+    return match.group("body")
+
+
+def replace_region(text: str, name: str, new_content: str) -> str:
+    """Return *text* with region *name*'s inner content replaced.
+
+    The marker lines are preserved. Raises KeyError if the region is
+    absent so callers fail loudly rather than silently no-op.
+    """
+    pattern = _region_pattern(name)
+    if pattern.search(text) is None:
+        raise KeyError(f"region not found: {name}")
+
+    def _sub(match: re.Match[str]) -> str:
+        return match.group("begin") + new_content + match.group("end")
+
+    return pattern.sub(_sub, text, count=1)
+
+
+def merge(
+    upstream: str,
+    consumer: str | None = None,
+    placeholders: dict[str, str] | None = None,
+) -> str:
+    """Merge marker regions into the *upstream* agent text.
+
+    For each region defined upstream:
+    - if *consumer* contains the same region, keep the consumer's content
+      (re-bootstrap preservation);
+    - else if a *placeholder* is supplied for it, use that (fresh
+      bootstrap);
+    - else leave the upstream content untouched.
+    """
+    placeholders = placeholders or {}
+    result = upstream
+    for name in find_regions(upstream):
+        if consumer is not None:
+            preserved = extract_region(consumer, name)
+            if preserved is not None:
+                result = replace_region(result, name, preserved)
+                continue
+        if name in placeholders:
+            result = replace_region(result, name, placeholders[name])
+    return result
+
+
+def default_placeholders(project_name: str) -> dict[str, str]:
+    """Generate safe, consumer-neutral placeholder content per region.
+
+    Derives a human title from the project directory name; the rest is
+    explicit TODOs the consumer fills in. Contains no kit identity.
+    """
+    title = project_name.replace("-", " ").replace("_", " ").title()
+    project_context = (
+        f"This is the **{title}** project.\n"
+        "\n"
+        "- **Tech Stack**: TODO — languages, frameworks, runtimes\n"
+        "- **Layout**: TODO — repo / workspace structure\n"
+        "- **Task Prefix**: TODO — e.g. PROJ-NNNN\n"
+        "- **Language**: TODO — content + code/comment language\n"
+        "- **Topology**: single-repo\n"
+        "\n"
+        "**Rules:**\n"
+        "\n"
+        "- TODO — fill in the project-specific rules this agent must follow"
+    )
+    stack_notes = (
+        "- **Test/lint loop**: TODO — local test, lint, and format commands\n"
+        "- **Build/run**: TODO — how to build and run the project locally\n"
+        "- **Pre-commit**: TODO — describe the pre-commit hooks, if any\n"
+        "- **Gotchas**: TODO — what an implementer coming in cold gets wrong\n"
+        "- **Task lifecycle**: `./scripts/core/project start|move|complete <ID>`"
+    )
+    return {"project-context": project_context, "stack-notes": stack_notes}
+
+
+# ─────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────
+def _cmd_merge(args: argparse.Namespace) -> int:
+    upstream = Path(args.upstream).read_text(encoding="utf-8")
+
+    consumer = None
+    if args.consumer is not None and Path(args.consumer).is_file():
+        consumer = Path(args.consumer).read_text(encoding="utf-8")
+
+    placeholders = None
+    if args.project_name is not None:
+        placeholders = default_placeholders(args.project_name)
+
+    merged = merge(upstream, consumer=consumer, placeholders=placeholders)
+    Path(args.out).write_text(merged, encoding="utf-8")
+    return 0
+
+
+def _cmd_extract(args: argparse.Namespace) -> int:
+    text = Path(args.file).read_text(encoding="utf-8")
+    body = extract_region(text, args.region)
+    if body is None:
+        print(f"region not found: {args.region}", file=sys.stderr)
+        return 1
+    sys.stdout.write(body)
+    return 0
+
+
+def _cmd_replace(args: argparse.Namespace) -> int:
+    text = Path(args.file).read_text(encoding="utf-8")
+    if args.stdin:
+        new_content = sys.stdin.read()
+    else:
+        new_content = Path(args.content_file).read_text(encoding="utf-8")
+    try:
+        updated = replace_region(text, args.region, new_content)
+    except KeyError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    Path(args.file).write_text(updated, encoding="utf-8")
+    return 0
+
+
+def _cmd_regions(args: argparse.Namespace) -> int:
+    text = Path(args.file).read_text(encoding="utf-8")
+    for name in find_regions(text):
+        print(name)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_merge = sub.add_parser("merge", help="merge marker regions into an agent")
+    p_merge.add_argument("--upstream", required=True)
+    p_merge.add_argument("--out", required=True)
+    p_merge.add_argument("--consumer", default=None)
+    p_merge.add_argument("--project-name", default=None)
+    p_merge.set_defaults(func=_cmd_merge)
+
+    p_extract = sub.add_parser("extract", help="print a region's inner content")
+    p_extract.add_argument("file")
+    p_extract.add_argument("region")
+    p_extract.set_defaults(func=_cmd_extract)
+
+    p_replace = sub.add_parser("replace", help="replace a region's inner content")
+    p_replace.add_argument("file")
+    p_replace.add_argument("region")
+    group = p_replace.add_mutually_exclusive_group(required=True)
+    group.add_argument("--content-file")
+    group.add_argument("--stdin", action="store_true")
+    p_replace.set_defaults(func=_cmd_replace)
+
+    p_regions = sub.add_parser("regions", help="list region names in a file")
+    p_regions.add_argument("file")
+    p_regions.set_defaults(func=_cmd_regions)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/local/kit_markers.py
+++ b/scripts/local/kit_markers.py
@@ -114,6 +114,15 @@ def merge(
     for name in find_regions(upstream):
         if consumer is not None:
             preserved = extract_region(consumer, name)
+            if preserved is None and f"<!-- BEGIN KIT-LOCAL: {name} -->" in consumer:
+                # Marker opened but not parseable (e.g. END edited away).
+                # Fail fast rather than silently clobber the consumer's
+                # trapped content with a placeholder on re-bootstrap.
+                raise ValueError(
+                    f"malformed KIT-LOCAL region in consumer file: {name} "
+                    "(BEGIN marker present but region not parseable — "
+                    "missing or mismatched END marker?)"
+                )
             if preserved is not None:
                 result = replace_region(result, name, preserved)
                 continue

--- a/scripts/local/kit_markers.py
+++ b/scripts/local/kit_markers.py
@@ -47,10 +47,13 @@ def _region_pattern(name: str) -> re.Pattern[str]:
     extract/replace round-trip is byte-identical.
     """
     esc = re.escape(name)
+    # \r?\n so files with CRLF line endings (Windows / git autocrlf) parse
+    # too. The newline is captured inside begin/end and re-emitted verbatim,
+    # and the body group is preserved byte-for-byte regardless of ending.
     return re.compile(
-        r"(?P<begin><!-- BEGIN KIT-LOCAL: " + esc + r" -->\n)"
+        r"(?P<begin><!-- BEGIN KIT-LOCAL: " + esc + r" -->\r?\n)"
         r"(?P<body>.*?)"
-        r"(?P<end>\n<!-- END KIT-LOCAL: " + esc + r" -->)",
+        r"(?P<end>\r?\n<!-- END KIT-LOCAL: " + esc + r" -->)",
         re.DOTALL,
     )
 

--- a/scripts/local/kit_markers.py
+++ b/scripts/local/kit_markers.py
@@ -56,8 +56,17 @@ def _region_pattern(name: str) -> re.Pattern[str]:
 
 
 def find_regions(text: str) -> list[str]:
-    """Return the region names present in *text*, in document order."""
-    return BEGIN_RE.findall(text)
+    """Return the unique region names in *text*, in first-seen order.
+
+    Region names are expected to be unique within a file; duplicates are
+    de-duplicated here so callers iterate each name once (replace_region
+    rewrites every occurrence of a name regardless).
+    """
+    seen: list[str] = []
+    for name in BEGIN_RE.findall(text):
+        if name not in seen:
+            seen.append(name)
+    return seen
 
 
 def extract_region(text: str, name: str) -> str | None:
@@ -71,8 +80,10 @@ def extract_region(text: str, name: str) -> str | None:
 def replace_region(text: str, name: str, new_content: str) -> str:
     """Return *text* with region *name*'s inner content replaced.
 
-    The marker lines are preserved. Raises KeyError if the region is
-    absent so callers fail loudly rather than silently no-op.
+    The marker lines are preserved. Every occurrence of the named region
+    is rewritten (a well-formed agent has exactly one, but duplicates must
+    not be silently skipped). Raises KeyError if the region is absent so
+    callers fail loudly rather than silently no-op.
     """
     pattern = _region_pattern(name)
     if pattern.search(text) is None:
@@ -81,7 +92,7 @@ def replace_region(text: str, name: str, new_content: str) -> str:
     def _sub(match: re.Match[str]) -> str:
         return match.group("begin") + new_content + match.group("end")
 
-    return pattern.sub(_sub, text, count=1)
+    return pattern.sub(_sub, text)
 
 
 def merge(
@@ -117,7 +128,9 @@ def default_placeholders(project_name: str) -> dict[str, str]:
     Derives a human title from the project directory name; the rest is
     explicit TODOs the consumer fills in. Contains no kit identity.
     """
-    title = project_name.replace("-", " ").replace("_", " ").title()
+    title = project_name.replace("-", " ").replace("_", " ").title().strip()
+    if not title:
+        title = "Your Project"
     project_context = (
         f"This is the **{title}** project.\n"
         "\n"

--- a/tests/test_kit_markers.py
+++ b/tests/test_kit_markers.py
@@ -78,6 +78,17 @@ class TestReplaceRegion:
         with pytest.raises(KeyError):
             km.replace_region(SAMPLE, "nope", "x")
 
+    def test_replaces_every_occurrence_of_a_name(self):
+        # A malformed file with two same-named regions: both must update,
+        # not just the first (no silent skip).
+        dupe = (
+            "<!-- BEGIN KIT-LOCAL: r -->\nold-1\n<!-- END KIT-LOCAL: r -->\n"
+            "<!-- BEGIN KIT-LOCAL: r -->\nold-2\n<!-- END KIT-LOCAL: r -->\n"
+        )
+        out = km.replace_region(dupe, "r", "NEW")
+        assert out.count("NEW") == 2
+        assert "old-1" not in out and "old-2" not in out
+
 
 class TestMerge:
     def test_fresh_fills_placeholders(self):
@@ -142,6 +153,12 @@ class TestDefaultPlaceholders:
         for needle in ("agentive-starter-kit", "KIT-NNNN", "pytest-fast", "DK rules"):
             assert needle not in blob
 
+    @pytest.mark.parametrize("name", ["", "---", "___", "  "])
+    def test_blank_name_falls_back_to_readable_title(self, name):
+        ph = km.default_placeholders(name)
+        assert "**Your Project**" in ph["project-context"]
+        assert "****" not in ph["project-context"]
+
 
 class TestRealAgentFiles:
     """The shipped agents must expose the expected regions and round-trip."""
@@ -167,3 +184,99 @@ class TestRealAgentFiles:
         for name in km.find_regions(text):
             out = km.replace_region(out, name, km.extract_region(text, name))
         assert out == text
+
+
+class TestCLI:
+    """Exercise the argparse CLI surface (main + _cmd_* handlers)."""
+
+    def _write(self, path, text):
+        path.write_text(text, encoding="utf-8")
+        return str(path)
+
+    def test_merge_fresh_with_project_name(self, tmp_path):
+        up = self._write(tmp_path / "up.md", SAMPLE)
+        out = str(tmp_path / "out.md")
+        rc = km.main(
+            ["merge", "--upstream", up, "--out", out, "--project-name", "demo"]
+        )
+        assert rc == 0
+        merged = (tmp_path / "out.md").read_text(encoding="utf-8")
+        assert "**Demo**" in km.extract_region(merged, "project-context")
+
+    def test_merge_rebootstrap_preserves_consumer(self, tmp_path):
+        up = self._write(tmp_path / "up.md", SAMPLE)
+        consumer_text = km.replace_region(SAMPLE, "project-context", "KEEP")
+        cons = self._write(tmp_path / "cons.md", consumer_text)
+        out = str(tmp_path / "out.md")
+        rc = km.main(
+            [
+                "merge",
+                "--upstream",
+                up,
+                "--out",
+                out,
+                "--consumer",
+                cons,
+                "--project-name",
+                "demo",
+            ]
+        )
+        assert rc == 0
+        merged = (tmp_path / "out.md").read_text(encoding="utf-8")
+        assert km.extract_region(merged, "project-context") == "KEEP"
+
+    def test_merge_missing_consumer_path_is_ignored(self, tmp_path):
+        up = self._write(tmp_path / "up.md", SAMPLE)
+        out = str(tmp_path / "out.md")
+        rc = km.main(
+            [
+                "merge",
+                "--upstream",
+                up,
+                "--out",
+                out,
+                "--consumer",
+                str(tmp_path / "nope.md"),
+                "--project-name",
+                "demo",
+            ]
+        )
+        assert rc == 0  # absent consumer file falls back to placeholders
+
+    def test_extract_prints_body(self, tmp_path, capsys):
+        f = self._write(tmp_path / "a.md", SAMPLE)
+        rc = km.main(["extract", f, "project-context"])
+        assert rc == 0
+        assert capsys.readouterr().out == "ASK content here\n- a bullet"
+
+    def test_extract_missing_region_returns_1(self, tmp_path):
+        f = self._write(tmp_path / "a.md", SAMPLE)
+        assert km.main(["extract", f, "nope"]) == 1
+
+    def test_replace_from_content_file(self, tmp_path):
+        f = self._write(tmp_path / "a.md", SAMPLE)
+        cf = self._write(tmp_path / "c.txt", "REPLACED")
+        rc = km.main(["replace", f, "stack-notes", "--content-file", cf])
+        assert rc == 0
+        text = (tmp_path / "a.md").read_text(encoding="utf-8")
+        assert km.extract_region(text, "stack-notes") == "REPLACED"
+
+    def test_replace_from_stdin(self, tmp_path, monkeypatch):
+        import io
+
+        f = self._write(tmp_path / "a.md", SAMPLE)
+        monkeypatch.setattr("sys.stdin", io.StringIO("VIA-STDIN"))
+        rc = km.main(["replace", f, "stack-notes", "--stdin"])
+        assert rc == 0
+        text = (tmp_path / "a.md").read_text(encoding="utf-8")
+        assert km.extract_region(text, "stack-notes") == "VIA-STDIN"
+
+    def test_replace_missing_region_returns_1(self, tmp_path):
+        f = self._write(tmp_path / "a.md", SAMPLE)
+        assert km.main(["replace", f, "nope", "--content-file", f]) == 1
+
+    def test_regions_lists_names(self, tmp_path, capsys):
+        f = self._write(tmp_path / "a.md", SAMPLE)
+        rc = km.main(["regions", f])
+        assert rc == 0
+        assert capsys.readouterr().out.split() == ["project-context", "stack-notes"]

--- a/tests/test_kit_markers.py
+++ b/tests/test_kit_markers.py
@@ -1,0 +1,169 @@
+"""Tests for scripts/local/kit_markers.py — KIT-LOCAL marker merge logic.
+
+These guard the heart of KIT-0033: a re-bootstrap must refresh agent
+structure *outside* the markers while preserving consumer content
+*inside* them byte-for-byte (requirements F4 + N2).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_MODULE_PATH = REPO_ROOT / "scripts" / "local" / "kit_markers.py"
+
+_spec = importlib.util.spec_from_file_location("kit_markers", _MODULE_PATH)
+km = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(km)
+
+
+SAMPLE = """# Agent
+
+## Project Context
+
+> instructions stay outside
+
+<!-- BEGIN KIT-LOCAL: project-context -->
+ASK content here
+- a bullet
+<!-- END KIT-LOCAL: project-context -->
+
+## Stack Notes
+
+<!-- BEGIN KIT-LOCAL: stack-notes -->
+- pytest + DK rules
+<!-- END KIT-LOCAL: stack-notes -->
+
+## Phase 4
+done
+"""
+
+
+class TestFindRegions:
+    def test_returns_names_in_order(self):
+        assert km.find_regions(SAMPLE) == ["project-context", "stack-notes"]
+
+    def test_empty_when_no_markers(self):
+        assert km.find_regions("# plain doc\n") == []
+
+
+class TestExtractRegion:
+    def test_extracts_inner_content(self):
+        assert km.extract_region(SAMPLE, "project-context") == (
+            "ASK content here\n- a bullet"
+        )
+
+    def test_missing_region_returns_none(self):
+        assert km.extract_region(SAMPLE, "nope") is None
+
+
+class TestReplaceRegion:
+    def test_replaces_inner_preserving_markers(self):
+        out = km.replace_region(SAMPLE, "stack-notes", "- cargo test")
+        assert "<!-- BEGIN KIT-LOCAL: stack-notes -->\n- cargo test\n" in out
+        assert "<!-- END KIT-LOCAL: stack-notes -->" in out
+        # other region untouched
+        assert (
+            km.extract_region(out, "project-context") == "ASK content here\n- a bullet"
+        )
+
+    def test_round_trip_is_byte_identical(self):
+        body = km.extract_region(SAMPLE, "project-context")
+        assert km.replace_region(SAMPLE, "project-context", body) == SAMPLE
+
+    def test_missing_region_raises(self):
+        with pytest.raises(KeyError):
+            km.replace_region(SAMPLE, "nope", "x")
+
+
+class TestMerge:
+    def test_fresh_fills_placeholders(self):
+        placeholders = {"project-context": "PH-PC", "stack-notes": "PH-SN"}
+        out = km.merge(SAMPLE, consumer=None, placeholders=placeholders)
+        assert km.extract_region(out, "project-context") == "PH-PC"
+        assert km.extract_region(out, "stack-notes") == "PH-SN"
+
+    def test_rebootstrap_preserves_consumer_content(self):
+        # Consumer customized both regions.
+        consumer = km.replace_region(SAMPLE, "project-context", "WIDGET FACTORY")
+        consumer = km.replace_region(consumer, "stack-notes", "cargo only")
+        # Upstream changed OUTSIDE the markers.
+        upstream = SAMPLE.replace("## Phase 4", "## Phase 4: Self-Review (GATE)")
+        out = km.merge(upstream, consumer=consumer, placeholders=None)
+        # Inside-marker content preserved byte-identical...
+        assert km.extract_region(out, "project-context") == "WIDGET FACTORY"
+        assert km.extract_region(out, "stack-notes") == "cargo only"
+        # ...and the upstream structural change outside markers is picked up.
+        assert "## Phase 4: Self-Review (GATE)" in out
+
+    def test_consumer_takes_priority_over_placeholder(self):
+        consumer = km.replace_region(SAMPLE, "project-context", "KEEP ME")
+        out = km.merge(
+            SAMPLE,
+            consumer=consumer,
+            placeholders={"project-context": "SHOULD-NOT-WIN"},
+        )
+        assert km.extract_region(out, "project-context") == "KEEP ME"
+
+    def test_no_consumer_no_placeholder_keeps_upstream(self):
+        out = km.merge(SAMPLE, consumer=None, placeholders=None)
+        assert out == SAMPLE
+
+    def test_markerless_consumer_falls_back_to_placeholder(self):
+        # A consumer stuck on a pre-consolidation agent has no markers;
+        # the region must seed from the placeholder, NOT inherit the
+        # upstream (kit) content — otherwise kit identity leaks.
+        markerless = "# old agent\n\nno markers here at all\n"
+        out = km.merge(
+            SAMPLE,
+            consumer=markerless,
+            placeholders={"project-context": "PH-PC", "stack-notes": "PH-SN"},
+        )
+        assert km.extract_region(out, "project-context") == "PH-PC"
+        assert km.extract_region(out, "stack-notes") == "PH-SN"
+        assert "ASK content here" not in out
+
+
+class TestDefaultPlaceholders:
+    def test_has_both_regions(self):
+        ph = km.default_placeholders("my-app")
+        assert set(ph) == {"project-context", "stack-notes"}
+
+    def test_title_cased_from_project_name(self):
+        ph = km.default_placeholders("widget-factory_2")
+        assert "Widget Factory 2" in ph["project-context"]
+
+    def test_no_kit_identity_leaks(self):
+        ph = km.default_placeholders("my-app")
+        blob = ph["project-context"] + ph["stack-notes"]
+        for needle in ("agentive-starter-kit", "KIT-NNNN", "pytest-fast", "DK rules"):
+            assert needle not in blob
+
+
+class TestRealAgentFiles:
+    """The shipped agents must expose the expected regions and round-trip."""
+
+    @pytest.mark.parametrize(
+        "rel,expected",
+        [
+            (".claude/agents/feature-developer.md", ["project-context", "stack-notes"]),
+            (".claude/agents/planner.md", ["project-context"]),
+        ],
+    )
+    def test_regions_present(self, rel, expected):
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert km.find_regions(text) == expected
+
+    @pytest.mark.parametrize(
+        "rel",
+        [".claude/agents/feature-developer.md", ".claude/agents/planner.md"],
+    )
+    def test_round_trip_identity(self, rel):
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        out = text
+        for name in km.find_regions(text):
+            out = km.replace_region(out, name, km.extract_region(text, name))
+        assert out == text

--- a/tests/test_kit_markers.py
+++ b/tests/test_kit_markers.py
@@ -140,6 +140,16 @@ class TestMerge:
         with pytest.raises(ValueError, match="malformed KIT-LOCAL region"):
             km.merge(SAMPLE, consumer=malformed, placeholders={"project-context": "X"})
 
+    def test_crlf_consumer_is_parsed_and_preserved(self):
+        # A consumer agent with CRLF line endings must still parse, so
+        # re-bootstrap preserves its content instead of aborting as malformed.
+        consumer = km.replace_region(SAMPLE, "project-context", "CRLF KEEP")
+        crlf = consumer.replace("\n", "\r\n")
+        assert km.find_regions(crlf) == ["project-context", "stack-notes"]
+        assert km.extract_region(crlf, "project-context") == "CRLF KEEP"
+        out = km.merge(SAMPLE, consumer=crlf, placeholders=None)
+        assert km.extract_region(out, "project-context") == "CRLF KEEP"
+
     def test_markerless_consumer_falls_back_to_placeholder(self):
         # A consumer stuck on a pre-consolidation agent has no markers;
         # the region must seed from the placeholder, NOT inherit the

--- a/tests/test_kit_markers.py
+++ b/tests/test_kit_markers.py
@@ -15,6 +15,13 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 _MODULE_PATH = REPO_ROOT / "scripts" / "local" / "kit_markers.py"
 
+# kit_markers.py is an ASK-only bootstrap tool (scripts/local is not synced
+# downstream). The consumer sync also excludes this test, but guard the load
+# so a stray copy in a consumer checkout skips cleanly instead of erroring at
+# collection.
+if not _MODULE_PATH.exists():
+    pytest.skip("kit_markers.py present only in the kit repo", allow_module_level=True)
+
 _spec = importlib.util.spec_from_file_location("kit_markers", _MODULE_PATH)
 km = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(km)
@@ -122,6 +129,16 @@ class TestMerge:
     def test_no_consumer_no_placeholder_keeps_upstream(self):
         out = km.merge(SAMPLE, consumer=None, placeholders=None)
         assert out == SAMPLE
+
+    def test_malformed_consumer_marker_raises(self):
+        # Consumer file opened a region but the END marker was edited away;
+        # merge must fail fast rather than clobber the trapped content.
+        malformed = (
+            "<!-- BEGIN KIT-LOCAL: project-context -->\n"
+            "consumer content with no closing marker\n"
+        )
+        with pytest.raises(ValueError, match="malformed KIT-LOCAL region"):
+            km.merge(SAMPLE, consumer=malformed, placeholders={"project-context": "X"})
 
     def test_markerless_consumer_falls_back_to_placeholder(self):
         # A consumer stuck on a pre-consolidation agent has no markers;


### PR DESCRIPTION
## Summary

Makes the consolidated **planner** + **feature-developer** V2 agents truly portable to consumer projects bootstrapped via `bootstrap-consumer.sh`. Resolves the four PR #57 bot threads on under-scaffolded downstream bootstrap (ASK identity shipped downstream, planner shipped without its `.kit/` infrastructure, re-bootstrap leaving stale agents).

### Mechanism (N2 — markers, necessary not preferred)

- The two agents wrap their consumer-customizable sections — **Project Context** (both) and **Stack Notes** (feature-developer) — in stable `<!-- BEGIN/END KIT-LOCAL: <region> -->` markers. ASK's own filled content is **byte-unchanged**; only the markers and a short mechanism note are added.
- New stdlib-only `scripts/local/kit_markers.py` merges marker regions:
  - **Fresh bootstrap** → regions seeded with consumer-neutral placeholders (no kit identity).
  - **Re-bootstrap** → consumer's filled regions preserved **byte-for-byte**, while structure *outside* the markers is refreshed from upstream. Without markers, `--ignore-existing` is the only safe rsync mode and consumers get stuck on whatever agent version they first bootstrapped.
  - **Markerless pre-consolidation agent** → seeds from placeholders, never inheriting kit identity (closes the gap #1 × gap #3 interaction).

### Scaffolding (F1) + opt-out (F3)

- `bootstrap-consumer.sh` provisions a working `.kit/` skeleton: `tasks/1-backlog … 7-blocked`, `context/`, `templates/TASK-STARTER-TEMPLATE.md`. The shipped `./scripts/core/project` makes the lifecycle work on day one.
- New `--no-kit` flag: no `.kit/` scaffold, no `planner.md` / `feature-developer.md`, with a one-line skip summary.

## Test plan

- [x] `tests/test_kit_markers.py` — 19 tests over merge logic incl. re-bootstrap byte-preservation + markerless fallback
- [x] Full suite green (274 passed, 12 skipped); pattern-lint, black, isort, flake8 clean
- [x] **Fresh bootstrap** against scratch consumer: `.kit/` skeleton created, agents seeded with placeholders, zero KIT-NNNN / kit-path leaks
- [x] **Lifecycle**: `project start` then `project complete` move a stub task `2-todo → 3-in-progress → 5-done` and update `**Status**`
- [x] **Re-bootstrap**: customized regions preserved byte-identical; stale outside-marker heading refreshed from upstream
- [x] **Opt-out**: `--no-kit` yields no `.kit/`, no planner/feature-developer, clean summary; other agents still ship
- [x] **N1**: ASK's filled agent content unchanged (diff is purely additive markers)

Task spec: `.kit/tasks/3-in-progress/KIT-0033-portable-agents-downstream.md`

Closes the four PR #57 threads: r3484524391, r3484524395, r3484592020, r3484585878.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consumer bootstrap orchestration and agent delivery paths; mistakes could leak kit identity or break consumer pytest, though guards (self-target, test exclusion, fail-fast merge) and broad tests mitigate this.
> 
> **Overview**
> Makes **planner** and **feature-developer** safe to ship through `bootstrap-consumer.sh`: customizable sections are wrapped in `KIT-LOCAL` markers, and a new stdlib `kit_markers.py` merges upstream agent structure with consumer-neutral placeholders (fresh bootstrap) or byte-preserved consumer edits (re-bootstrap).
> 
> **`bootstrap-consumer.sh`** now provisions a minimal `.kit/` skeleton (task folders, `context/`, task-starter template), marker-merges the two agents instead of blind rsync, adds **`--no-kit`** to skip workflow scaffolding and those agents, blocks bootstrapping the kit source repo, and excludes `test_kit_markers.py` from consumer test sync so pytest does not import ASK-only `scripts/local/`.
> 
> Agent markdown changes are **additive** (markers + docs); kit-filled Project Context / Stack Notes in ASK are unchanged. **`tests/test_kit_markers.py`** covers merge, CRLF, malformed markers, and CLI. CHANGELOG and KIT-0033 task/context docs updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2d8645e26b419a6b55a236869cd039427d69d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->