### PR TITLE
docs: distribution architecture overview (v1.0.0)

### DIFF
--- a/docs/DISTRIBUTION-ARCHITECTURE.md
+++ b/docs/DISTRIBUTION-ARCHITECTURE.md
@@ -1,0 +1,260 @@
+# Distribution Architecture
+
+> How `agentive-starter-kit` distributes agents, commands, and shared
+> tooling to downstream projects — and how to keep everything updated.
+
+**Version**: 1.0.0
+**Last updated**: 2026-07-03
+**Status**: Current
+**Related**: `docs/MANIFEST-UPGRADE-GUIDE.md`, `docs/PLUGIN-UPGRADE-GUIDE.md`,
+`docs/CROSS-REPO-PATTERN.md`, ADR-0008, KIT-ADR-0022, KIT-ADR-0024, KIT-ADR-0025
+
+---
+
+## TL;DR
+
+- **One upstream source of truth**: this repo.
+- **Two distribution channels**: a **plugin** (install-based) and a
+  **manifest sync** GitHub Action (vendored-file-based).
+- **Commands & scripts propagate automatically** on merge to `main`
+  (the sync Action opens PRs downstream).
+- **Agents do not auto-propagate** via the sync Action today — they ship
+  through the plugin or a bootstrap merge. Closing that asymmetry is
+  tracked as KIT-0026.
+- **Everything is semver-pinned**: agents in frontmatter (`version`),
+  the sync unit via `core_version` in the manifest.
+
+---
+
+## 1. One upstream source of truth
+
+`agentive-starter-kit` (`movito/agentive-starter-kit`) is the canonical
+origin for all shared tooling — agents, commands, skills, scripts,
+templates, ADRs. Everything downstream is a copy or an install of what
+lives here. Nothing is authored in a consumer repo and pushed back up.
+
+## 2. Two distribution channels
+
+Rendered view (GitHub renders Mermaid natively):
+
+```mermaid
+flowchart TD
+    SRC["agentive-starter-kit (main)<br/><i>canonical source of truth</i>"]
+
+    subgraph A["Channel A — Plugin (install-based)"]
+        PLUGIN["agentive-workflow plugin<br/>served via movito/agentive-skills marketplace<br/><br/>carries: agents · commands · skills<br/>(namespaced installs)"]
+        CONSA["consumer repo<br/>agentive-workflow:&lt;name&gt;<br/>installed, version-pinned"]
+        PLUGIN -->|"claude plugin update<br/>/ upgrader agent"| CONSA
+    end
+
+    subgraph B["Channel B — Manifest sync (vendored files)"]
+        ACT["sync-core-scripts.yml Action<br/>driven by scripts/.core-manifest.json<br/><br/>carries: scripts/core · .claude/commands · .kit/**"]
+        CONSB["consumer repo<br/>vendored files + PR to review<br/>opted_in tiers preserved"]
+        ACT -->|"auto PR on push to main<br/>(CROSS_REPO_TOKEN)"| CONSB
+    end
+
+    SRC -->|"publish / re-publish"| PLUGIN
+    SRC -->|"push to watched paths"| ACT
+
+    AGENTS{{"Agents: NOT watched by the Action<br/>ship via plugin (a) or bootstrap merge (b)<br/>— KIT-ADR-0025 / KIT-0033"}}
+    SRC -.->|"special case"| AGENTS
+    AGENTS -.-> PLUGIN
+
+    classDef src fill:#1f2937,color:#fff,stroke:#111;
+    classDef note fill:#fef3c7,color:#78350f,stroke:#d97706;
+    class SRC src;
+    class AGENTS note;
+```
+
+Plain-text view (terminals, diffs, non-Mermaid viewers):
+
+```
+                 ┌───────────────────────────────────────────┐
+                 │        agentive-starter-kit (main)         │
+                 │           canonical source of truth        │
+                 └───────────────┬───────────────┬───────────┘
+                                 │               │
+         Channel A: PLUGIN       │               │   Channel B: MANIFEST SYNC
+         (install-based)         │               │   (vendored file copies)
+                                 ▼               ▼
+      ┌──────────────────────────────┐   ┌──────────────────────────────────┐
+      │ agentive-workflow plugin      │   │ sync-core-scripts.yml (Action)    │
+      │ served via                    │   │ driven by                         │
+      │ movito/agentive-skills        │   │ scripts/.core-manifest.json       │
+      │ marketplace                   │   │                                   │
+      │                               │   │ on push to watched paths on main: │
+      │ carries:                      │   │  • matrix over downstream repos   │
+      │  • agents  (namespaced)       │   │  • copy files per manifest tiers  │
+      │  • commands (namespaced)      │   │  • open a PR (CROSS_REPO_TOKEN)   │
+      │  • skills   (namespaced)      │   │                                   │
+      │                               │   │ carries:                          │
+      │ consumer updates via:         │   │  • scripts/core/**                │
+      │  claude plugin update         │   │  • .claude/commands/**            │
+      │  (or the `upgrader` agent)    │   │  • .kit/** templates/skills/ADRs  │
+      └───────────────┬──────────────┘   └────────────────┬─────────────────┘
+                      │                                    │
+                      ▼                                    ▼
+      ┌──────────────────────────────┐   ┌──────────────────────────────────┐
+      │ consumer repo                 │   │ consumer repo                     │
+      │  agentive-workflow:<name>     │   │  vendored files + PR to review    │
+      │  installed, version-pinned    │   │  opted_in tiers preserved         │
+      └──────────────────────────────┘   └──────────────────────────────────┘
+```
+
+Why two channels: the plugin gives consumers *installable, version-pinned*
+artifacts they don't maintain; the manifest sync is for files that must
+physically live in the consumer's tree (scripts they run, commands,
+kit-builder scaffolding).
+
+| | **Channel A — Plugin** | **Channel B — Manifest sync** |
+|---|---|---|
+| **What** | `agentive-workflow` plugin, from the `movito/agentive-skills` marketplace | `sync-core-scripts.yml` Action + `scripts/.core-manifest.json` |
+| **Carries** | Agents, commands, skills as **namespaced installs** (`agentive-workflow:feature-developer-v7`, `agentive-workflow:check-ci`) | **Vendored file copies**: `scripts/core/`, `.claude/commands/`, `.kit/` templates/skills/ADRs/workflows |
+| **Consumer update path** | `claude plugin update` / `upgrader` agent | Automated PR into the consumer repo |
+| **Governed by** | KIT-ADR-0024 §3, KIT-ADR-0025 | ADR-0008, KIT-ADR-0022, `docs/MANIFEST-UPGRADE-GUIDE.md` |
+
+## 3. The tiered manifest (Channel B's brain)
+
+`scripts/.core-manifest.json` — `core_version` is the semver of the sync
+unit (currently `2.1.0`). Files are grouped into **tiers**, and tier
+membership decides who receives what:
+
+| Tier | Count | Sync rule |
+|------|-------|-----------|
+| `scripts_core` | 17 | Always sync to every downstream |
+| `commands_core` | 6 | Always sync to every downstream |
+| `commands_optional` | 5 | Sync **only if** consumer opted in |
+| `kit_builder` | 14 | Sync **only to** kit-family repos (`is_kit: true`) |
+
+`commands_core` is the "most essential commands" set:
+`check-ci`, `check-bots`, `wait-for-bots`, `start-task`,
+`commit-push-pr`, `preflight`.
+
+A consumer's `opted_in` array is **preserved across syncs** — the Action
+reads the downstream manifest and never clobbers the consumer's tier
+choices.
+
+## 4. The sync Action mechanics
+
+`.github/workflows/sync-core-scripts.yml` fires on push to `main` when any
+watched path changes (`scripts/core/**`, `.claude/commands/**`,
+`.kit/templates/**`, the manifest itself, and more). It:
+
+1. runs a **matrix** over downstream repos (today: `dispatch-kit`,
+   `adversarial-workflow`, `adversarial-evaluator-library`),
+2. checks out source + target, walks the manifest tier-by-tier honoring
+   the opt-in / kit-only rules,
+3. copies files and opens a **PR** into each consumer using the
+   `CROSS_REPO_TOKEN` secret.
+
+Consumers review and merge on their own schedule — nothing is force-pushed.
+
+## 5. Agents are the special case
+
+The sync Action **does not watch `.claude/agents/**`**, and there is no
+`agents` tier in the manifest. Agents are deliberately **not** file-synced.
+Two mechanisms cover them instead.
+
+### (a) Plugin body + runtime-read localization — KIT-ADR-0025
+
+A shared agent file fuses two things with different lifecycles:
+
+1. **Workflow body** — phases, gates, the CI/review loop, shell rules.
+   Plugin-owned; the point of distribution is that consumers *receive
+   upgrades* to this.
+2. **Project specifics** — tech stack, task-ID prefix, repo topology,
+   local test/lint commands, which Serena project to activate.
+   Project-owned; these *must survive* an upgrade.
+
+Resolution: **the distributed body carries zero project specifics.** Agents
+read their specifics at **runtime** from files the project already owns:
+
+| Information | Home | How the agent gets it |
+|---|---|---|
+| Topology, target repo, project rules, identity | `CLAUDE.md` | auto-injected every session |
+| Tech stack, task-ID prefix, local test loop, stack footguns | `CLAUDE.md` + task spec | read at runtime (early action) |
+| Defensive-coding patterns | `.kit/context/patterns.yml` | read at runtime |
+
+A hardcoded Serena project or origin check in a distributed agent is a
+**distribution bug**, not a feature to parameterize.
+
+### (b) KIT-LOCAL marker vendoring — KIT-0033
+
+For agents that *are* copied into a consumer (`feature-developer.md`,
+`planner.md`, `feature-developer-f5.md`), the project-owned sections are
+wrapped in markers:
+
+```markdown
+<!-- BEGIN KIT-LOCAL: project-context -->
+...consumer-owned content...
+<!-- END KIT-LOCAL: project-context -->
+
+<!-- BEGIN KIT-LOCAL: stack-notes -->
+...consumer-owned content...
+<!-- END KIT-LOCAL: stack-notes -->
+```
+
+`bootstrap-consumer.sh` fills these on first bootstrap and **preserves them
+byte-for-byte across re-bootstraps** (via `scripts/local/kit_markers.py`),
+while upstream refreshes everything *outside* the markers. This is the
+contract that lets a consumer take a workflow-body upgrade without losing
+its localization.
+
+### In transition
+
+KIT-0026 (backlog) proposes adding `agents_core` / `skills_core` tiers so
+agents *also* flow through Channel B. Until that ships, agent updates reach
+consumers via the plugin (a) or a bootstrap/re-bootstrap merge (b) — **not**
+the sync Action.
+
+> **The asymmetry to remember:** editing a *command* on `main` opens
+> downstream PRs automatically; editing an *agent* does not.
+
+## 6. Versioning discipline
+
+Per KIT-0029, every canonical agent pins in frontmatter: `model`,
+`version` (semver), `last-updated`, `origin`, `created-by`. Rules from
+`docs/MANIFEST-UPGRADE-GUIDE.md`:
+
+- **Model-pin-only bump → semver patch**, and update `last-updated`.
+- The manifest's `core_version` is the semver of the sync unit as a whole.
+
+Documents (like this one) are semver-stamped too — see the header.
+
+## 7. Two upgrade surfaces, one agent
+
+- `docs/MANIFEST-UPGRADE-GUIDE.md` — the **scripts/manifest** surface
+  (Channel B).
+- `docs/PLUGIN-UPGRADE-GUIDE.md` — the **plugin** surface (Channel A).
+- The **`upgrader` agent** automates the plugin runbook: raises a consumer
+  from one plugin version to the next *and* refreshes local agent model
+  pins on a rollout, using a two-phase `PREVIEW → operator ACK → APPLY`
+  gate (idempotent — a no-op if already current).
+
+---
+
+## The "keeping everything updated" loop
+
+1. Edit the canonical agent/command in `agentive-starter-kit`, bump its
+   `version` + `last-updated`, commit to a branch → PR → merge to `main`.
+2. **Commands & scripts**: merging to `main` auto-fires
+   `sync-core-scripts.yml`, which opens update PRs in each downstream.
+   Consumers merge on their schedule; `opted_in` tiers are respected.
+3. **Agents**: re-publish the plugin (consumers run `claude plugin update`
+   or the `upgrader` agent), or the consumer picks up body changes on its
+   next bootstrap merge — KIT-LOCAL regions preserved.
+4. Consumers verify with the synced `commands_core` gates (`preflight`,
+   `check-ci`, `check-bots`).
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Upstream / kit** | `agentive-starter-kit` — the canonical source repo |
+| **Consumer / downstream** | A project that installs the plugin and/or receives manifest syncs |
+| **Kit-family repo** | A downstream that is itself part of the tooling (receives `kit_builder`); `is_kit: true` in the sync matrix |
+| **Tier** | A named group of files in the manifest with a shared sync rule |
+| **Opt-in** | A consumer's recorded choice to receive a non-core tier (`opted_in` array) |
+| **KIT-LOCAL region** | A marker-delimited, consumer-owned section of a vendored agent file |

--- a/docs/DISTRIBUTION-ARCHITECTURE.md
+++ b/docs/DISTRIBUTION-ARCHITECTURE.md
@@ -68,7 +68,7 @@ flowchart TD
 
 Plain-text view (terminals, diffs, non-Mermaid viewers):
 
-```
+```text
                  ┌───────────────────────────────────────────┐
                  │        agentive-starter-kit (main)         │
                  │           canonical source of truth        │


### PR DESCRIPTION
## Summary

Adds `docs/DISTRIBUTION-ARCHITECTURE.md` (v1.0.0) — a team-facing overview of
how the kit distributes agents and commands downstream, and how to keep
everything updated.

Covers:
- **Two channels**: the `agentive-workflow` plugin (install-based) vs the
  `sync-core-scripts.yml` manifest-sync Action (vendored files)
- **The tiered manifest** (`scripts/.core-manifest.json`) and its sync rules
  (core / opt-in / kit-only)
- **The agent special-case**: why agents aren't file-synced — KIT-ADR-0025
  runtime localization + KIT-0033 KIT-LOCAL markers — and the KIT-0026
  in-transition note
- **Semver discipline** and the two upgrade runbooks + the `upgrader` agent
- A **Mermaid diagram** (renders on GitHub) plus an ASCII fallback
- The end-to-end "keeping everything updated" loop and a glossary

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or deployment behavior modified.
> 
> **Overview**
> Adds **`docs/DISTRIBUTION-ARCHITECTURE.md` (v1.0.0)** as a team-facing guide for how the kit ships shared tooling downstream and how consumers stay current.
> 
> It documents the **two distribution channels** — the install-based **`agentive-workflow` plugin** vs the **`sync-core-scripts.yml` + `scripts/.core-manifest.json` manifest sync** — including Mermaid and ASCII diagrams, a comparison table, and how **manifest tiers** (`scripts_core`, `commands_core`, optional opt-in, kit-only `kit_builder`) and preserved **`opted_in`** choices drive what gets copied via automated downstream PRs.
> 
> It also spells out the **agent asymmetry** (not file-synced today): **KIT-ADR-0025** runtime localization from `CLAUDE.md` / task specs / `.kit/context/patterns.yml`, **KIT-0033** `KIT-LOCAL` marker preservation on bootstrap, the **KIT-0026** transition note, **semver** rules, pointers to the manifest vs plugin upgrade guides, the **`upgrader` agent** loop, and an end-to-end “keeping everything updated” checklist plus glossary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7311be79ee5e9b2f6197e52bc732aabd318cd16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->