### PR TITLE
chore(agents): drop && chaining from evaluator env-load snippets

### DIFF
--- a/.claude/agents/feature-developer-f5.md
+++ b/.claude/agents/feature-developer-f5.md
@@ -386,7 +386,9 @@ GIT_TARGET diff main...HEAD > .adversarial/inputs/<TASK-ID>-code-review-input.md
 ### Step 2 — Run the evaluator trio
 
 ```bash
-set -a && source .env && set +a
+set -a
+source .env
+set +a
 
 adversarial code-reviewer-fast .adversarial/inputs/<TASK-ID>-code-review-input.md
 adversarial code-reviewer .adversarial/inputs/<TASK-ID>-code-review-input.md

--- a/.claude/agents/feature-developer.md
+++ b/.claude/agents/feature-developer.md
@@ -381,7 +381,9 @@ GIT_TARGET diff main...HEAD > .adversarial/inputs/<TASK-ID>-code-review-input.md
 ### Step 2 — Run the evaluator trio
 
 ```bash
-set -a && source .env && set +a
+set -a
+source .env
+set +a
 
 adversarial code-reviewer-fast .adversarial/inputs/<TASK-ID>-code-review-input.md
 adversarial code-reviewer .adversarial/inputs/<TASK-ID>-code-review-input.md

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -167,7 +167,9 @@ producing a handoff. Always `source .env` first — evaluators need API
 keys.
 
 ```bash
-set -a && source .env && set +a
+set -a
+source .env
+set +a
 
 # Fast/cheap (Gemini):
 adversarial arch-review-fast .kit/tasks/2-todo/<TASK-ID>-*.md


### PR DESCRIPTION
## Summary

Follow-up to #66. CodeRabbit noted the evaluator env-load snippet used
`set -a && source .env && set +a`, which contradicts each agent's own
"No `&&` chaining" shell rule. Rewrites it as three sequential lines in the
three canonical agents that carry that rule:

- `.claude/agents/feature-developer.md`
- `.claude/agents/feature-developer-f5.md`
- `.claude/agents/planner.md`

Applied identically to `feature-developer.md` and its f5 fork so the two
bodies stay byte-identical (the f5 sync contract).

## Scope

Deliberately limited to the three agent files — they are the only ones that
carry the "no `&&` chaining" rule, so they are the only genuine
self-contradiction. The same idiom in `scripts/core/prepare-review-input.sh`
is real executable shell (where `&&` is idiomatic) and in
`docs/CROSS-REPO-PATTERN.md` there is no such rule; both left unchanged.

## Testing

- `pytest tests/test_kit_markers.py` — 37 passed (edits are outside the
  KIT-LOCAL regions; round-trip identity preserved)
- Pre-commit gauntlet green on commit (354 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only agent doc edits with no behavior or security impact.
> 
> **Overview**
> Follow-up to #66: the **Phase 7 / Phase 3** evaluator bash blocks in three canonical agents no longer use `set -a && source .env && set +a`. They now show **three separate lines** (`set -a`, `source .env`, `set +a`) so the documented workflow matches each file’s **Shell Rules** (“no `&&` chaining”).
> 
> **Touched files:** `feature-developer.md`, `feature-developer-f5.md` (same snippet as canonical for the f5 sync contract), and `planner.md`. No runtime scripts or other docs were changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63c7999c056cad51d1632d77fc34c4559a3c32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->