### PR TITLE
feat(KIT-0034): harden preflight gates and bootstrap machinery

### DIFF
--- a/.claude/agents/feature-developer-f5.md
+++ b/.claude/agents/feature-developer-f5.md
@@ -229,6 +229,11 @@ For each change:
   `.adversarial/evaluators/` (NOT `.kit/adversarial/`)
 - **Task lifecycle**: `./scripts/core/project start|move|complete
   <KIT-NNNN>` moves task files between status folders
+- **Consumer test boundary**: any new test importing or reading
+  `scripts/local/` must be excluded from the consumer `tests/` rsync in
+  `bootstrap-consumer.sh` (both `--exclude` and the `rm -f` sweep) and
+  must module-skip when its dependency is absent (pattern:
+  `tests/test_kit_markers.py`)
 <!-- END KIT-LOCAL: stack-notes -->
 
 ## Phase 4: Self-Review (GATE)

--- a/.claude/agents/feature-developer.md
+++ b/.claude/agents/feature-developer.md
@@ -224,6 +224,11 @@ For each change:
   `.adversarial/evaluators/` (NOT `.kit/adversarial/`)
 - **Task lifecycle**: `./scripts/core/project start|move|complete
   <KIT-NNNN>` moves task files between status folders
+- **Consumer test boundary**: any new test importing or reading
+  `scripts/local/` must be excluded from the consumer `tests/` rsync in
+  `bootstrap-consumer.sh` (both `--exclude` and the `rm -f` sweep) and
+  must module-skip when its dependency is absent (pattern:
+  `tests/test_kit_markers.py`)
 <!-- END KIT-LOCAL: stack-notes -->
 
 ## Phase 4: Self-Review (GATE)

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,10 +1,10 @@
 ---
 description: Check all 7 completion gates before requesting human review
 argument-hint: "[optional --pr PR_NUMBER --task TASK_ID --repo owner/name]"
-version: 1.1.0
+version: 1.2.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-04-20
+last-updated: 2026-07-04
 created-by: "@movito with planner2"
 ---
 
@@ -35,7 +35,13 @@ Override with `--repo owner/name` if needed:
 ./scripts/core/preflight-check.sh $ARGUMENTS
 ```
 
-The script outputs structured `GATE:<number>:<name>:PASS|FAIL:<detail>` lines and exits 0 (all pass) or 1 (any fail).
+The script outputs structured `GATE:<number>:<name>:PASS|FAIL|PENDING:<detail>` lines
+and exits 0 (all pass), 1 (any fail), or 2 (no failures, but at least one gate PENDING).
+
+**PENDING** (Gate 1 only, KIT-0034): CI runs are not yet registered for the head
+SHA, or are still executing — GitHub takes a few seconds to register runs after a
+push. PENDING is not a failure verdict; re-run preflight shortly (or use
+`/wait-for-bots` first) instead of treating it as a CI failure.
 
 ## Step 2: Present results
 
@@ -54,8 +60,11 @@ Parse the `GATE:` lines and format as a PASS/FAIL table:
 ### Verdict
 
 - If all 7 pass: **READY** — proceed with review handoff (move to `4-in-review`, notify user)
+- If no gate fails but one is PENDING: **NOT READY YET (pending)** — wait briefly
+  and re-run preflight; do not report a CI failure
 - If any fail: **NOT READY (N gates failing)** — list prescriptive actions for each failing gate:
   - Gate 1 fails: "Run `/check-ci` and fix failures"
+  - Gate 1 PENDING: "CI not registered/still running — re-run preflight in a minute"
   - Gate 2 fails: "Wait for CodeRabbit (1-2 min) or run `/check-bots`"
   - Gate 3 fails: "Wait for BugBot (4-6 min) or run `/check-bots`"
   - Gate 4 fails: "Run `/triage-threads` to resolve open threads" — but first

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -41,7 +41,9 @@ and exits 0 (all pass), 1 (any fail), or 2 (no failures, but at least one gate P
 **PENDING** (Gate 1 only, KIT-0034): CI runs are not yet registered for the head
 SHA, or are still executing — GitHub takes a few seconds to register runs after a
 push. PENDING is not a failure verdict; re-run preflight shortly (or use
-`/wait-for-bots` first) instead of treating it as a CI failure.
+`/wait-for-bots` first) instead of treating it as a CI failure. Note: when
+no runs are registered yet, the script re-polls briefly before reporting,
+so a preflight run may block for up to ~10 seconds.
 
 ## Step 2: Present results
 

--- a/.kit/context/KIT-0034-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0034-HANDOFF-feature-developer.md
@@ -1,0 +1,115 @@
+# KIT-0034 Handoff — feature-developer
+
+**Task**: `.kit/tasks/2-todo/KIT-0034-preflight-bootstrap-hardening.md`
+**Target Codebase**: This repo — NOT a target repo (single-repo mode)
+**Prepared**: 2026-07-04 (planner-f5)
+**Estimated effort**: 2–4 hours
+
+You are the feature-developer. Implement this task directly — do not
+delegate to another agent instance.
+
+## Mission
+
+Harden the kit's completion gates and bootstrap machinery against five
+failure modes observed across three retros (KIT-0032, KIT-0033, KIT-0036,
+session 2026-07-04). The headline is **F1**: preflight Gate 2 has
+false-negatived on three consecutive tasks.
+
+## Implementation guidance
+
+All five requirements (F1–F5) are specified in the task file. Concrete
+anchors:
+
+### F1 + F4 — `scripts/core/preflight-check.sh` (412 lines)
+
+- **Gate 1 (CI)**: lines ~224–266. `GATE:1:CI:FAIL:No CI runs found for
+  latest commit` (line 232) is the false-alarm path — no runs registered yet
+  for the head SHA must become a distinct **PENDING/UNKNOWN** state (optionally
+  after a short bounded re-poll), while a completed non-success run still
+  FAILs. Note line 263 conflates "still running" with FAIL too — same fix
+  family, keep "still running" as PENDING, not FAIL.
+- **Gate 2 (CodeRabbit)**: lines ~276–291. Currently requires a
+  `coderabbitai[bot]` review event on `$CODE_SHA` or `$LATEST_SHA` (GraphQL at
+  line 283). Add the fallback: check-run passing AND latest CodeRabbit review
+  APPROVED (or COMMENTED with no unresolved threads) AND zero unresolved
+  threads → PASS. **Gate 3 (BugBot, lines ~295–324) already implements
+  exactly this check-run fallback pattern at line 319 — mirror its
+  structure.** Gate 4 (lines ~330–349) already computes unresolved thread
+  counts; reuse that query/logic rather than duplicating it.
+- Keep the strict SHA match as the primary signal; the fallback only rescues
+  the green-everywhere case (N1: a PR with no review at all, or any
+  unresolved thread, must still FAIL).
+- **N2**: stays shell + `gh`. The arch evaluator suggested a Python rewrite;
+  planner declined (see Evaluation section in the task file). Do not migrate.
+
+### F2 — self-review checklist item
+
+- Skill lives at `.kit/skills/self-review/`. Add the item: any new test
+  importing from `scripts/local/` must be excluded from the consumer `tests/`
+  rsync in `bootstrap-consumer.sh` (and should module-skip if its dependency
+  is absent). Check whether feature-developer's Phase 4 checklist
+  (`.claude/agents/feature-developer.md` and the `-f5` fork) references the
+  same list — if so, keep them consistent (edit both or neither).
+
+### F3 — temp-then-commit guideline
+
+- Document the two-pass pattern (stage all outputs to temp, `mv` into place
+  only after every step succeeds; never per-item `mv` inside a `set -e`
+  loop) with a short before/after example. Suggested home:
+  `.kit/context/workflows/` alongside the other workflow docs. Reference the
+  KIT-0033 atomicity bug as the motivating case.
+
+### F5 — bootstrap marker-membership test
+
+- New pytest (suggested: `tests/test_bootstrap_consumer.py`) asserting every
+  `.claude/agents/*.md` containing `KIT-LOCAL` markers appears in BOTH
+  `KIT_AGENTS` (line ~206 of `scripts/local/bootstrap-consumer.sh`) and
+  `AGENT_EXCLUDES` (line ~101). Current expected membership: `planner.md`,
+  `planner-f5.md`, `feature-developer.md`, `feature-developer-f5.md`.
+  Text-parse the bash arrays — no need to execute the script.
+- **Recursive F2 trap**: this test reads `scripts/local/` content, so it must
+  itself be added to the consumer `tests/` rsync exclusion in
+  `bootstrap-consumer.sh` (same treatment as `test_kit_markers.py`), and
+  should skip cleanly if `scripts/local/bootstrap-consumer.sh` is absent.
+
+## Data-shape verification
+
+- Before touching Gate 2, capture real `gh api graphql` output for PR #58
+  (KIT-0033) — the canonical false-negative case — and for a current green
+  PR, so the fallback logic is written against observed shapes, not assumed
+  ones.
+- There is **no existing test harness** for `preflight-check.sh` or
+  `bootstrap-consumer.sh`. Gate-logic verification may be the documented
+  manual kind (per acceptance criteria); F5's test is the automatable part.
+
+## Test approach
+
+- `pytest tests/test_bootstrap_consumer.py` (new) — use `pytest` directly,
+  not `python3 -m pytest`.
+- Manual gate verification: run `./scripts/core/preflight-check.sh` against
+  KIT-0033 PR #58 (real-world Gate 2 fallback case) and a current green PR
+  (regression on all 7 gates). Record both runs in the PR description.
+- `./scripts/core/ci-check.sh` before pushing.
+
+## Evaluation summary
+
+`arch-review-fast`: REVISION_SUGGESTED — log at
+`.adversarial/logs/KIT-0034-preflight-bootstrap-hardening--arch-review-fast.md`.
+Disposition recorded in the task file's Evaluation section: Python-migration
+suggestion **declined** (N2), test-mocking emphasis **accepted**, declarative
+boundary config **noted/out-of-scope**. No outstanding blockers.
+
+## Out of scope
+
+- Rewriting preflight in Python (N2; evaluator suggestion declined)
+- The `kit_markers.py` manifest-contract idea (task Notes)
+- Any downstream-repo work — suwinex/moss migrations are deferred by
+  operator decision (2026-07-04); this task is kit-internal only
+- KIT-0035/0037/0038/0039 items — they follow in separate tasks; don't
+  absorb them even where files overlap
+
+## PR sizing
+
+F1+F4 (one script) + F2 (checklist) + F3 (doc) + F5 (test + rsync exclude)
+should fit one PR comfortably (< 500 lines). If it grows, split F3 out —
+it's the most independent.

--- a/.kit/context/KIT-0034-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0034-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0034 Handoff — feature-developer
 
-**Task**: `.kit/tasks/2-todo/KIT-0034-preflight-bootstrap-hardening.md`
+**Task**: `.kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-04 (planner-f5)
 **Estimated effort**: 2–4 hours

--- a/.kit/context/KIT-0034-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0034-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0034 Handoff — feature-developer
 
-**Task**: `.kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0034-preflight-bootstrap-hardening.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-04 (planner-f5)
 **Estimated effort**: 2–4 hours

--- a/.kit/context/KIT-0034-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0034-REVIEW-STARTER.md
@@ -1,0 +1,57 @@
+# Review Starter: KIT-0034 — Preflight & Bootstrap Hardening
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/69
+**Branch**: `feature/KIT-0034-preflight-bootstrap-hardening`
+**Task**: `.kit/tasks/4-in-review/KIT-0034-preflight-bootstrap-hardening.md`
+**Implemented by**: feature-developer-f5 (2026-07-04/05)
+
+## What this PR does
+
+Hardens the kit's completion gates and bootstrap machinery against five
+failure modes from the KIT-0032/0033/0036 retros and the 2026-07-04
+session retro:
+
+- **F1** — `preflight-check.sh` Gate 2 (CodeRabbit) gains a fail-closed
+  fallback: no review event on the head SHA still PASSes iff CodeRabbit's
+  commit status is green AND the latest review is APPROVED/COMMENTED AND
+  zero threads are unresolved. Fixes the false negative seen on three
+  consecutive tasks.
+- **F4** — Gate 1 (CI) reports **PENDING** (new state, exit code 2) for
+  "runs not registered yet" (bounded ~10 s re-poll) and "still running";
+  a completed non-success run still FAILs, even while siblings run. A
+  `gh`-level fetch error FAILs distinctly (not PENDING).
+- Gates 2/3/4 share one GraphQL snapshot (3 API calls → 1) so the
+  fallback and thread gate can never disagree.
+- **F2** — self-review skill v1.1.0 + both feature-developer forks: new
+  consumer-sync test boundary checklist item.
+- **F3** — `.kit/context/workflows/TEMP-THEN-COMMIT-PATTERN.md` (two-pass
+  atomic mutation pattern, linked from CLAUDE.md).
+- **F5** — `tests/test_bootstrap_consumer.py`: 6 tests locking KIT-LOCAL
+  marker agents into both `KIT_AGENTS` and `AGENT_EXCLUDES`, plus the
+  consumer-rsync exclusion of boundary-crossing tests (including itself).
+
+## Review focus suggestions
+
+1. **Gate 2 fallback conditions** (`scripts/core/preflight-check.sh`) —
+   is the three-way AND (green signal + APPROVED/COMMENTED latest +
+   0 unresolved) the right strictness? N1 requires fail-closed.
+2. **Exit code 2 semantics** — PENDING is nonzero by design ("all gates
+   confirmed" stays exit 0). Callers were audited (docs only).
+3. **Known evaluator blind spot**: shell-script changes have no CI test
+   harness — gate logic was verified manually (stub-`gh` matrix recorded
+   in the PR description + `.kit/context/reviews/KIT-0034-evaluator-review.md`).
+
+## Verification trail
+
+- Evaluators: code-reviewer-fast-v2 CONCERNS, code-reviewer (o3) FAIL,
+  claude-code APPROVED — full triage (accepted fixes + declined-with-
+  verification) in `.kit/context/reviews/KIT-0034-evaluator-review.md`
+- Bot rounds: CodeRabbit round 1 (4 threads) + round 2 (1 thread), all
+  fixed, replied, resolved; BugBot pass (no findings)
+- `pytest`: full suite green; pre-commit gauntlet green on every commit
+
+## Follow-ups flagged (not in this PR)
+
+- PR #58 carries 2 unresolved medium-severity BugBot threads on
+  `scripts/local/kit_markers.py` (opened at merge time, pre-date this
+  task) — planner should triage.

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -1,19 +1,19 @@
 {
   "planner": {
-    "status": "idle",
-    "current_task": null,
+    "status": "handoff_ready",
+    "current_task": "KIT-0034",
     "task_started": null,
-    "brief_note": "v0.5.0 released. Migration playbook written. Next: KIT-0026 (manifest tiers) then downstream migrations (AEL → ADV → DSP).",
-    "details_link": ".kit/docs/KIT-MIGRATION-PLAYBOOK.md",
-    "handoff_file": null
+    "brief_note": "v0.8.0 plan agreed (kit-internal hardening; downstream upgrades deferred). KIT-0034 promoted to todo (+F5), evaluated (arch-review-fast, disposition in spec), handoff ready. Next in queue: KIT-0037/38/39 bundle, KIT-0035, ADR-0025 slim. Awaiting human verdicts: KIT-0032 (PR #56 merged), ASK-0048 (PR #45).",
+    "details_link": ".kit/tasks/2-todo/KIT-0034-preflight-bootstrap-hardening.md",
+    "handoff_file": ".kit/context/KIT-0034-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
-    "status": "assigned",
-    "current_task": "KIT-0032",
+    "status": "handoff_ready",
+    "current_task": "KIT-0034",
     "task_started": null,
-    "brief_note": "KIT-0032 (build upgrader agent) assigned to feature-developer-v6 — handoff ready, spec evaluated/revised. Not yet started.",
-    "details_link": ".kit/context/KIT-0032-HANDOFF-feature-developer-v6.md",
-    "handoff_file": ".kit/context/KIT-0032-HANDOFF-feature-developer-v6.md"
+    "brief_note": "KIT-0034 (preflight Gate 2/1 + bootstrap hardening, F1-F5) ready for assignment. KIT-0032 implementation complete (PR #56 merged 2026-06-26, retro done) — task awaits human review verdict in 4-in-review.",
+    "details_link": ".kit/tasks/2-todo/KIT-0034-preflight-bootstrap-hardening.md",
+    "handoff_file": ".kit/context/KIT-0034-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {
     "status": "idle",

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0034",
     "task_started": null,
     "brief_note": "v0.8.0 plan agreed (kit-internal hardening; downstream upgrades deferred). KIT-0034 promoted to todo (+F5), evaluated (arch-review-fast, disposition in spec), handoff ready. Next in queue: KIT-0037/38/39 bundle, KIT-0035, ADR-0025 slim. Awaiting human verdicts: KIT-0032 (PR #56 merged), ASK-0048 (PR #45).",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0034-preflight-bootstrap-hardening.md",
     "handoff_file": ".kit/context/KIT-0034-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0034",
     "task_started": null,
     "brief_note": "KIT-0034 (preflight Gate 2/1 + bootstrap hardening, F1-F5) ready for assignment. KIT-0032 implementation complete (PR #56 merged 2026-06-26, retro done) — task awaits human review verdict in 4-in-review.",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0034-preflight-bootstrap-hardening.md",
     "handoff_file": ".kit/context/KIT-0034-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0034",
     "task_started": null,
     "brief_note": "v0.8.0 plan agreed (kit-internal hardening; downstream upgrades deferred). KIT-0034 promoted to todo (+F5), evaluated (arch-review-fast, disposition in spec), handoff ready. Next in queue: KIT-0037/38/39 bundle, KIT-0035, ADR-0025 slim. Awaiting human verdicts: KIT-0032 (PR #56 merged), ASK-0048 (PR #45).",
-    "details_link": ".kit/tasks/2-todo/KIT-0034-preflight-bootstrap-hardening.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md",
     "handoff_file": ".kit/context/KIT-0034-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0034",
     "task_started": null,
     "brief_note": "KIT-0034 (preflight Gate 2/1 + bootstrap hardening, F1-F5) ready for assignment. KIT-0032 implementation complete (PR #56 merged 2026-06-26, retro done) — task awaits human review verdict in 4-in-review.",
-    "details_link": ".kit/tasks/2-todo/KIT-0034-preflight-bootstrap-hardening.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md",
     "handoff_file": ".kit/context/KIT-0034-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/reviews/KIT-0034-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0034-evaluator-review.md
@@ -1,0 +1,76 @@
+# KIT-0034 — Evaluator Review Record
+
+**PR**: movito/agentive-starter-kit#69
+**Input**: `.adversarial/inputs/KIT-0034-code-review-input.md` (full-file context, 12 files)
+**Date**: 2026-07-04/05
+
+## Verdicts
+
+| Evaluator | Model | Verdict |
+|-----------|-------|---------|
+| code-reviewer-fast-v2 | gemini-3-flash-preview | CONCERNS |
+| code-reviewer | o3 | FAIL |
+| claude-code | claude-sonnet-4-6 | **APPROVED** |
+
+Logs: `.adversarial/logs/KIT-0034-code-review-input--{code-reviewer-fast-v2,code-reviewer,claude-code}.md`
+
+## Triage — accepted (fixed in follow-up commit)
+
+1. **`THREAD_UNRESOLVED` numeric guard** (o3, claude-code, fast): Gate 2
+   fallback now requires `[[ "$THREAD_UNRESOLVED" =~ ^[0-9]+$ ]]` before the
+   numeric compare — no bash "integer expression expected" noise on exotic
+   jq output.
+2. **CR commit-status multi-context determinism** (o3 #1, corrected): the
+   evaluator's mechanism was wrong — the combined-status endpoint returns
+   the *latest* status per context, so `pending`-shadows-`success` for one
+   context cannot happen. The real (smaller) gap was multiple
+   CodeRabbit-matching contexts with `tail -1` picking arbitrarily. Fixed:
+   all matching contexts must be `success` (with an explicit empty-array
+   guard — `all([])` is vacuously true); mixed results surface the first
+   non-success state in the FAIL detail. Verified against jq samples and
+   the real PR #58 head SHA.
+3. **`PR_NUMBER` numeric validation** (claude-code security MEDIUM/LOW):
+   explicit `^[0-9]+$` guard before GraphQL interpolation.
+4. **`MATCH_SHA` cosmetic bug** (claude-code LOW, pre-existing): the grep
+   for a SHA in `"author: STATE"` could never match; PASS detail now prints
+   both candidate SHAs.
+5. **Gate 4 thread-count 100-cap** (claude-code MEDIUM): PASS detail now
+   flags possible truncation when total hits the `first: 100` cap.
+6. **Poll-loop state reset + doc notes** (claude-code LOW, fast #4):
+   `LATEST_RUNS`/`RUN_COUNT` reset per attempt; TEMP-THEN-COMMIT doc gains
+   the same-directory/same-mount caveat; preflight.md documents the ~10 s
+   worst-case re-poll block.
+
+## Triage — declined (with verification)
+
+- **o3 "tail -1 picks oldest status" as stated**: combined-status endpoint
+  dedups per context (see accepted #2 for the real residue).
+- **o3 "exit code 2 breaks callers"**: repo-wide grep shows no script
+  chains `preflight-check.sh &&`; only command docs consume it, both
+  updated. PENDING must not exit 0 — "all gates confirmed" is the 0
+  contract.
+- **o3 "CRLF breaks KIT_AGENTS parse"**: `str.split()` splits on `\r` too;
+  claim incorrect.
+- **o3 "multiline array breaks regex"**: `[^)]*` matches newlines (negated
+  class ≠ `.`); claim incorrect. A `)` inside the array block would fail
+  the test loudly — desired behavior for a wiring guard.
+- **o3 "BugBot multiple check-runs"**: check-runs API defaults to
+  `filter=latest`; also pre-existing Gate 3 code, out of scope.
+- **fast "allow whitespace around `=`"**: invalid bash (assignments cannot
+  have spaces); strict regex is correct.
+- **fast "Gate 2/4 should be PENDING on API error"**: review gates are
+  fail-closed by design (N1); only CI-run absence maps to PENDING (task
+  scope). The FAIL detail surfaces `unresolved=unknown` for diagnosis.
+- **claude-code "guard missing agents dir in test"**: module-skip already
+  covers stripped checkouts (script absent ⇒ skip); in the kit repo the
+  agents dir is guaranteed, and `test_marker_agents_exist` fails loudly if
+  the convention moves.
+
+## Manual gate verification (no test harness exists for the script)
+
+- Real run vs PR #63 (2nd false-negative case): Gates 2–4 PASS, Gate 1
+  PENDING (branch context), FAIL-beats-PENDING exit precedence confirmed.
+- Stub-`gh` matrix (real script, canned output): fallback PASS (A),
+  no-review FAIL (B), unresolved-thread FAIL (C), CHANGES_REQUESTED FAIL
+  (D), check-run secondary source PASS (E), completed-failure-while-running
+  FAIL not PENDING (F). All as specified; recorded in PR #69 description.

--- a/.kit/context/workflows/TEMP-THEN-COMMIT-PATTERN.md
+++ b/.kit/context/workflows/TEMP-THEN-COMMIT-PATTERN.md
@@ -1,0 +1,84 @@
+# Temp-Then-Commit Pattern (Two-Pass File Mutation)
+
+**Purpose**: Keep multi-file mutations atomic in `set -e` shell scripts —
+either every file is updated, or none is
+**Agents**: feature-developer (bootstrap/sync script work), planner (spec review)
+**Last Updated**: 2026-07-04 (KIT-0034 F3)
+
+---
+
+## The Rule
+
+When a script step mutates **more than one file** under `set -e`, never
+write (or `mv`) into a destination inside the same loop that can still
+fail. Instead:
+
+1. **Pass 1 — stage**: produce every output to a temp file
+   (`<dest>.tmp` or similar). Any failure aborts here, before a single
+   destination has been touched.
+2. **Pass 2 — commit**: only after every staged output exists, `mv` the
+   temp files into place. This pass contains no fallible work.
+
+Also clear stale temp files from a previously aborted run before pass 1.
+
+## Why
+
+Under `set -e`, a per-item write-then-continue loop dies mid-iteration on
+the first failure — leaving some destinations updated and others stale.
+The consumer then has a **silently inconsistent** state that no error
+message describes, and a re-run may not repair (e.g. `--ignore-existing`
+sync semantics, or merges that now read the half-updated file as input).
+
+**Motivating case (KIT-0033 atomicity bug)**: the bootstrap marker-merge
+loop originally merged each agent file and moved it into place per
+iteration. A malformed KIT-LOCAL marker in the third agent aborted the
+loop after two agents were already overwritten — a consumer checkout with
+half-refreshed agents and no clean way to tell which half.
+
+## Before / After
+
+**Before — per-item mv inside the loop (broken):**
+
+```bash
+set -e
+for agent in "${KIT_AGENTS[@]}"; do
+    python3 kit_markers.py merge --upstream "$SRC/$agent" \
+        --out "$DST/$agent.tmp"
+    mv "$DST/$agent.tmp" "$DST/$agent"   # commits item N before item N+1 is known to succeed
+done
+```
+
+**After — two passes (atomic):**
+
+```bash
+set -e
+rm -f "$DST/"*.tmp                        # clear stale temps from an aborted run
+for agent in "${KIT_AGENTS[@]}"; do       # pass 1: stage everything
+    python3 kit_markers.py merge --upstream "$SRC/$agent" \
+        --out "$DST/$agent.tmp"
+done
+for agent in "${KIT_AGENTS[@]}"; do       # pass 2: commit (infallible work only)
+    mv "$DST/$agent.tmp" "$DST/$agent"
+done
+```
+
+Live implementation: the marker-merge step in
+`scripts/local/bootstrap-consumer.sh` (Step 2, kit workflow agents).
+
+## When To Apply
+
+- Bootstrap / sync / migration scripts that write N related files
+  (agent sets, manifest + files, config pairs)
+- Any `set -e` loop whose body mixes fallible work (merge, render,
+  download, validate) with destination writes
+- Not needed for single-file writes — a plain `write-to-temp && mv` (or a
+  direct write, when a torn single file is acceptable) already covers it
+
+## Boundaries
+
+- Pass 2 must stay trivial: `mv` on the same filesystem is effectively
+  atomic per file; do not add fallible logic (parsing, network, python)
+  to the commit pass.
+- If pass 2 can still fail for environmental reasons (permissions, disk
+  full), the window is at least reduced to that pass — and the staged
+  temps make recovery inspectable instead of silent.

--- a/.kit/context/workflows/TEMP-THEN-COMMIT-PATTERN.md
+++ b/.kit/context/workflows/TEMP-THEN-COMMIT-PATTERN.md
@@ -78,7 +78,9 @@ Live implementation: the marker-merge step in
 
 - Pass 2 must stay trivial: `mv` on the same filesystem is effectively
   atomic per file; do not add fallible logic (parsing, network, python)
-  to the commit pass.
+  to the commit pass. Keep temp files **next to their destinations**
+  (same directory, e.g. `<dest>.tmp`) — a temp dir on another mount
+  turns `mv` into a fallible copy+delete.
 - If pass 2 can still fail for environmental reasons (permissions, disk
   full), the window is at least reduced to that pass — and the staged
   temps make recovery inspectable instead of silent.

--- a/.kit/skills/self-review/SKILL.md
+++ b/.kit/skills/self-review/SKILL.md
@@ -1,10 +1,10 @@
 ---
 description: Self-review pass after tests pass but before committing — systematic input boundary audit that catches issues TDD misses
 user-invocable: false
-version: 1.0.0
+version: 1.1.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-02-27
+last-updated: 2026-07-04
 created-by: "@movito with planner2"
 ---
 
@@ -93,6 +93,8 @@ Read every function in the file you changed (not just the ones you wrote):
 5. **Early-return ordering**: For each early-return path, verify it doesn't block a cheaper or more important early-return that should come first. Example: validating tools (cheap, may short-circuit) should come before resolving PR (expensive subprocess call).
 
 6. **Module documentation**: If you changed a module's public API, parameters, or invariants, check if the module has a documentation file or contract (e.g., a module-level CLAUDE.md, README, or docstring). Update it if the public interface changed. When adding a breaking-change trigger that references another module, verify the inverse trigger exists in that module's documentation too.
+
+7. **Consumer-sync test boundary (kit repo)**: any new test that imports or reads from `scripts/local/` (which is NOT synced to consumers) must be excluded from the consumer `tests/` rsync in `scripts/local/bootstrap-consumer.sh` (both the `--exclude` and the stale-copy `rm -f` sweep), and must module-skip when its dependency is absent — see `tests/test_kit_markers.py` for the pattern. Shipping such a test unexcluded breaks consumer pytest at collection time (both bots caught this on KIT-0033).
 
 ## Step 4: Test assertion audit
 

--- a/.kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md
+++ b/.kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md
@@ -1,7 +1,7 @@
 # KIT-0034: Harden preflight Gate 2 + bootstrap/self-review (KIT-0033 retro)
 
-**Status**: Backlog
-**Priority**: medium
+**Status**: In Progress
+**Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 2-4 hours
 **Created**: 2026-06-27
@@ -68,6 +68,18 @@ APPROVED with a green check-run and zero open threads.
   (a run that completed with `conclusion != success`) must still FAIL. Shares the
   same false-negative theme as F1/F2 and the same file.
 
+- **F5 — Bootstrap KIT-LOCAL marker-membership test** *(from the 2026-07-04
+  session retro)*: add a test asserting that every `.claude/agents/*.md`
+  containing `KIT-LOCAL` markers is listed in BOTH `KIT_AGENTS` and
+  `AGENT_EXCLUDES` in `scripts/local/bootstrap-consumer.sh`. This mechanically
+  catches the class of bug BugBot found on PR #66 (new marker-bearing agent not
+  wired into bootstrap → kit identity leaks to fresh consumers) and the
+  `--no-kit` prune gap CodeRabbit found on PR #68. Since `KIT_AGENTS` is now
+  single-sourced and also drives the `--no-kit` prune, one membership assertion
+  covers copy-exclusion, marker-merge, and opt-out removal together. Note: this
+  test imports/reads `scripts/local/` content, so per F2 it must itself be
+  excluded from the consumer `tests/` rsync.
+
 ### Non-Functional Requirements
 
 - **N1**: F1 must not weaken the gate for genuinely un-reviewed PRs — a PR with no
@@ -93,6 +105,9 @@ APPROVED with a green check-run and zero open threads.
   head SHA, and still FAILs on a completed non-success run
 - [ ] Any preflight logic change has test coverage (mock `gh` output) if the script
   has an existing test harness; otherwise a documented manual verification
+- [ ] A test asserts every KIT-LOCAL-marker-bearing agent file is present in both
+  `KIT_AGENTS` and `AGENT_EXCLUDES` in `bootstrap-consumer.sh`, and that test is
+  excluded from the consumer `tests/` rsync
 
 ## Test Plan
 
@@ -104,11 +119,35 @@ APPROVED with a green check-run and zero open threads.
 
 ## Notes
 
-- Source: `.kit/context/retros/KIT-0033-retro.md` (F1–F3 Process Actions) and
-  `.kit/context/retros/KIT-0032-retro.md` (F4 — preflight Gate 1). F4 was added
-  here rather than in KIT-0035 so all `preflight-check.sh` changes land together.
+- Source: `.kit/context/retros/KIT-0033-retro.md` (F1–F3 Process Actions),
+  `.kit/context/retros/KIT-0032-retro.md` (F4 — preflight Gate 1), and
+  `.kit/context/retros/SESSION-2026-07-04-agent-maintenance-retro.md` (F5 —
+  bootstrap marker-membership test). F4 was added here rather than in KIT-0035
+  so all `preflight-check.sh` changes land together; F5 was added here (per that
+  retro's own pointer) so all bootstrap-hardening lands together.
 - F1 is the priority and is well-scoped/ready; F2 and F3 are doc/checklist changes
   and could be split out if the planner prefers smaller PRs.
 - A fourth, lower-value retro idea (express `kit_markers.py` test-coverage
   expectations in the consumer manifest contract) is intentionally **out of scope**
   here — revisit only if the dual-audience test boundary causes further breakage.
+
+## Evaluation (2026-07-04)
+
+`arch-review-fast` (gemini-2.5-flash): **REVISION_SUGGESTED** — log:
+`.adversarial/logs/KIT-0034-preflight-bootstrap-hardening--arch-review-fast.md`.
+Planner disposition:
+
+- **Declined — "migrate preflight to Python"**: contradicts the deliberate N2
+  constraint (shell + `gh`, no new deps). `preflight-check.sh` is 412 lines; a
+  language migration is a separate architectural decision, not a hardening fix.
+  If a future task grows preflight further, revisit via ADR.
+- **Accepted — "invest in `gh` output mocking / validate parsed output"**:
+  folded into the existing test-coverage acceptance criterion. Note there is
+  currently NO test harness for `preflight-check.sh` or
+  `bootstrap-consumer.sh`, so the documented-manual-verification fallback
+  applies to gate logic; F5's marker-membership test IS automatable (pytest,
+  reads both files as text).
+- **Noted — "declarative dual-audience boundary config"**: valid long-term
+  idea; overlaps KIT-0026/KIT-0031 territory. Out of scope here.
+- **Accepted — F3 pattern must be prominently documented**: already the F3
+  requirement; no change.

--- a/.kit/tasks/4-in-review/KIT-0034-preflight-bootstrap-hardening.md
+++ b/.kit/tasks/4-in-review/KIT-0034-preflight-bootstrap-hardening.md
@@ -1,6 +1,6 @@
 # KIT-0034: Harden preflight Gate 2 + bootstrap/self-review (KIT-0033 retro)
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 2-4 hours

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ See `.kit/templates/AGENT-TEMPLATE.md` for creating new agents.
 | Workflow freeze | `.kit/context/workflows/WORKFLOW-FREEZE-POLICY.md` |
 | Coverage | `.kit/context/workflows/COVERAGE-WORKFLOW.md` |
 | Task completion | `.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md` |
+| Atomic multi-file scripts | `.kit/context/workflows/TEMP-THEN-COMMIT-PATTERN.md` |
 
 ## Key Scripts
 

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -246,8 +246,10 @@ while [ "$CI_ATTEMPT" -le "$CI_POLL_ATTEMPTS" ]; do
     # Reset per attempt so a failed refetch can't reuse a stale filter result
     LATEST_RUNS="[]"
     RUN_COUNT=0
+    # Query by commit (not a branch window) so runs for the head SHA can't
+    # be pushed out of --limit by older reruns piling up on the branch.
     # shellcheck disable=SC2086
-    CI_RUNS=$(gh $GH_REPO_ARG run list --branch "$BRANCH" --limit 10 --json status,conclusion,workflowName,event,headSha \
+    CI_RUNS=$(gh $GH_REPO_ARG run list --commit "$LATEST_SHA" --limit 10 --json status,conclusion,workflowName,event,headSha \
         --jq '[.[] | select(.event == "push" or .event == "pull_request")]' 2>/dev/null || true)
 
     if [ -n "$CI_RUNS" ] && [ "$CI_RUNS" != "[]" ]; then
@@ -282,6 +284,10 @@ else
 
         if [ "$WF_STATUS" = "completed" ] && [ "$WF_CONCLUSION" = "success" ]; then
             CI_DETAILS="${CI_DETAILS}${WF_NAME}: pass; "
+        elif [ "$WF_STATUS" = "completed" ] && { [ "$WF_CONCLUSION" = "skipped" ] || [ "$WF_CONCLUSION" = "neutral" ]; }; then
+            # GitHub treats skipped/neutral as success for dependent checks —
+            # a path-filtered or conditionally skipped workflow is not a failure
+            CI_DETAILS="${CI_DETAILS}${WF_NAME}: ${WF_CONCLUSION}; "
         elif [ "$WF_STATUS" = "in_progress" ] || [ "$WF_STATUS" = "queued" ]; then
             CI_DETAILS="${CI_DETAILS}${WF_NAME}: running; "
             CI_ALL_PASS=false

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -3,10 +3,10 @@
 # Usage: ./scripts/preflight-check.sh [--pr PR_NUMBER] [--task TASK_ID] [--repo owner/name] [--help]
 #
 # Metadata:
-#   version: 1.1.0
+#   version: 1.2.0
 #   origin: dispatch-kit
 #   origin-version: 0.3.2
-#   last-updated: 2026-04-20
+#   last-updated: 2026-07-04
 #   created-by: "@movito with planner2"
 #
 # Cross-repo support (ID2-0014):
@@ -17,11 +17,16 @@
 #   (5, 6, 7) always read the planning repo's .kit/ directory.
 #
 # Output format (structured for machine parsing):
-#   GATE:<number>:<name>:PASS|FAIL:<detail>
+#   GATE:<number>:<name>:PASS|FAIL|PENDING:<detail>
+#
+#   PENDING (KIT-0034 F4): the gate cannot be evaluated yet — CI runs not
+#   registered for the head SHA, or runs still executing. Not a failure
+#   verdict; re-run preflight shortly.
 #
 # Exit codes:
 #   0 — All gates pass
 #   1 — One or more gates fail, or error
+#   2 — No gate failed, but at least one is PENDING (re-run shortly)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -60,6 +65,7 @@ while [[ $# -gt 0 ]]; do
             echo "Exit codes:"
             echo "  0  All gates pass"
             echo "  1  One or more gates fail"
+            echo "  2  No failures, but at least one gate PENDING (re-run shortly)"
             exit 0
             ;;
         --pr)
@@ -182,6 +188,7 @@ if [ -z "$LATEST_SHA" ]; then
 fi
 
 ANY_FAILED=false
+ANY_PENDING=false
 
 # ─── Determine latest code commit for bot review checks ───────────
 # Bots don't re-review markdown-only pushes. Find the latest commit
@@ -215,26 +222,47 @@ fi
 # ─── Gate 1: CI green ───────────────────────────────────────────────
 # Check all workflow runs for the latest commit (not just the first),
 # so a passing run from one workflow can't mask a failure in another.
+#
+# KIT-0034 F4: GitHub takes a few seconds to register workflow runs after
+# a push, so "no runs for the head SHA yet" is PENDING, not FAIL (twice a
+# false alarm on KIT-0032 PR #56). Re-poll briefly before reporting. Runs
+# still executing are also PENDING. Only a run that completed with a
+# non-success conclusion FAILs (N3) — and it FAILs even when sibling
+# workflows are still running.
 
-# shellcheck disable=SC2086
-CI_RUNS=$(gh $GH_REPO_ARG run list --branch "$BRANCH" --limit 10 --json status,conclusion,workflowName,event,headSha \
-    --jq '[.[] | select(.event == "push" or .event == "pull_request")]' 2>/dev/null || true)
+CI_POLL_ATTEMPTS=3
+CI_POLL_DELAY=5
+RUN_COUNT=0
+LATEST_RUNS="[]"
+CI_ATTEMPT=1
+while [ "$CI_ATTEMPT" -le "$CI_POLL_ATTEMPTS" ]; do
+    # shellcheck disable=SC2086
+    CI_RUNS=$(gh $GH_REPO_ARG run list --branch "$BRANCH" --limit 10 --json status,conclusion,workflowName,event,headSha \
+        --jq '[.[] | select(.event == "push" or .event == "pull_request")]' 2>/dev/null || true)
 
-if [ -z "$CI_RUNS" ] || [ "$CI_RUNS" = "[]" ]; then
-    echo "GATE:1:CI:FAIL:No CI runs found"
-    ANY_FAILED=true
+    if [ -n "$CI_RUNS" ] && [ "$CI_RUNS" != "[]" ]; then
+        # Filter runs to the PR head commit (not just the newest run's SHA)
+        LATEST_RUNS=$(echo "$CI_RUNS" | jq -c "[.[] | select(.headSha == \"$LATEST_SHA\")]" 2>/dev/null || echo "[]")
+        RUN_COUNT=$(echo "$LATEST_RUNS" | jq 'length' 2>/dev/null || echo "0")
+        RUN_COUNT="${RUN_COUNT:-0}"
+    fi
+
+    if [ "$RUN_COUNT" -gt 0 ]; then
+        break
+    fi
+    if [ "$CI_ATTEMPT" -lt "$CI_POLL_ATTEMPTS" ]; then
+        sleep "$CI_POLL_DELAY"
+    fi
+    CI_ATTEMPT=$((CI_ATTEMPT + 1))
+done
+
+if [ "$RUN_COUNT" -eq 0 ]; then
+    echo "GATE:1:CI:PENDING:No CI runs registered yet for ${LATEST_SHA:0:7} — re-run preflight shortly"
+    ANY_PENDING=true
 else
-    # Filter runs to the PR head commit (not just the newest run's SHA)
-    LATEST_RUNS=$(echo "$CI_RUNS" | jq -c "[.[] | select(.headSha == \"$LATEST_SHA\")]" 2>/dev/null || true)
-    RUN_COUNT=$(echo "$LATEST_RUNS" | jq 'length' 2>/dev/null || echo "0")
-
-    if [ "$RUN_COUNT" -eq 0 ]; then
-        echo "GATE:1:CI:FAIL:No CI runs found for latest commit"
-        ANY_FAILED=true
-    else
-
     CI_ALL_PASS=true
     CI_ANY_RUNNING=false
+    CI_ANY_FAILED_RUN=false
     CI_DETAILS=""
 
     for i in $(seq 0 $((RUN_COUNT - 1))); do
@@ -251,6 +279,7 @@ else
         else
             CI_DETAILS="${CI_DETAILS}${WF_NAME}: ${WF_CONCLUSION:-$WF_STATUS}; "
             CI_ALL_PASS=false
+            CI_ANY_FAILED_RUN=true
         fi
     done
 
@@ -259,15 +288,30 @@ else
 
     if [ "$CI_ALL_PASS" = true ]; then
         echo "GATE:1:CI:PASS:$CI_DETAILS"
-    elif [ "$CI_ANY_RUNNING" = true ]; then
-        echo "GATE:1:CI:FAIL:$CI_DETAILS (still running)"
-        ANY_FAILED=true
-    else
+    elif [ "$CI_ANY_FAILED_RUN" = true ]; then
         echo "GATE:1:CI:FAIL:$CI_DETAILS"
         ANY_FAILED=true
+    else
+        echo "GATE:1:CI:PENDING:$CI_DETAILS (still running)"
+        ANY_PENDING=true
     fi
+fi
 
-    fi # RUN_COUNT guard
+# ─── Shared PR review data (Gates 2, 3, 4) ──────────────────────────
+# One GraphQL call fetches review events and review threads. Gate 2's
+# fallback and Gate 4 must agree on the unresolved-thread count, so both
+# read from the same snapshot. Empty counts (fetch/parse failure) make
+# Gate 2's fallback fail closed and Gate 4 FAIL, as before.
+
+PR_DATA=$(gh api graphql -f query="{ repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUMBER) { reviews(last: 100) { nodes { author { login } state commit { oid } } } reviewThreads(first: 100) { nodes { isResolved } } } } }" 2>/dev/null || true)
+
+THREAD_TOTAL=""
+THREAD_RESOLVED=""
+THREAD_UNRESOLVED=""
+if [ -n "$PR_DATA" ]; then
+    THREAD_TOTAL=$(echo "$PR_DATA" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]] | length' 2>/dev/null || echo "")
+    THREAD_RESOLVED=$(echo "$PR_DATA" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == true)] | length' 2>/dev/null || echo "")
+    THREAD_UNRESOLVED=$(echo "$PR_DATA" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "")
 fi
 
 # ─── Gate 2: CodeRabbit reviewed the PR ──────────────────────────────
@@ -279,16 +323,50 @@ fi
 if [ "$NO_CODE_CHANGES" = true ]; then
     echo "GATE:2:CodeRabbit:PASS:No code changes — bot review not required"
 else
-    CR_REVIEW=$(gh api graphql -f query="{ repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUMBER) { reviews(last: 20) { nodes { author { login } state commit { oid } } } } } }" \
-        --jq ".data.repository.pullRequest.reviews.nodes[] | select(.commit.oid == \"$CODE_SHA\" or .commit.oid == \"$LATEST_SHA\") | select(.author.login | test(\"coderabbitai\")) | \"\(.author.login): \(.state)\"" 2>/dev/null | tail -1 || true)
+    CR_REVIEW=$(echo "$PR_DATA" | jq -r ".data.repository.pullRequest.reviews.nodes[] | select(.commit.oid == \"$CODE_SHA\" or .commit.oid == \"$LATEST_SHA\") | select(.author.login | test(\"coderabbitai\")) | \"\(.author.login): \(.state)\"" 2>/dev/null | tail -1 || true)
 
     if [ -n "$CR_REVIEW" ]; then
         MATCH_SHA="$CODE_SHA"
         if echo "$CR_REVIEW" | grep -q "$LATEST_SHA" 2>/dev/null; then MATCH_SHA="$LATEST_SHA"; fi
         echo "GATE:2:CodeRabbit:PASS:$CR_REVIEW (on ${MATCH_SHA:0:7})"
     else
-        echo "GATE:2:CodeRabbit:FAIL:No review from coderabbitai[bot] on ${CODE_SHA:0:7} or ${LATEST_SHA:0:7}"
-        ANY_FAILED=true
+        # Fallback (KIT-0034 F1): after a trivial/docs push CodeRabbit
+        # refreshes its commit status and keeps an APPROVED review on an
+        # earlier SHA without re-emitting a review event, so the strict
+        # SHA match above false-negatives (KIT-0033 PR #58, KIT-0036
+        # PR #63). Accept the PR as reviewed only when ALL hold (N1
+        # keeps this fail-closed — no review at all, a CHANGES_REQUESTED
+        # latest verdict, or any unresolved thread still FAILs):
+        #   1. CodeRabbit's signal on the head SHA is passing — it
+        #      reports via the legacy commit-status API (context
+        #      "CodeRabbit"); check-runs are queried as a secondary
+        #      source in case an install reports there instead;
+        #   2. the latest CodeRabbit review on the PR is APPROVED, or
+        #      COMMENTED with nothing left open;
+        #   3. zero unresolved review threads (same count as Gate 4).
+        CR_LATEST_STATE=$(echo "$PR_DATA" | jq -r "[.data.repository.pullRequest.reviews.nodes[] | select(.author.login | test(\"coderabbitai\"))] | last | .state // empty" 2>/dev/null || true)
+
+        CR_SIGNAL=$(gh api "repos/$OWNER/$NAME/commits/$LATEST_SHA/status" \
+            --jq '.statuses[] | select(.context | test("coderabbit"; "i")) | .state' 2>/dev/null | tail -1 || true)
+        if [ -z "$CR_SIGNAL" ]; then
+            CR_SIGNAL=$(gh api "repos/$OWNER/$NAME/commits/$LATEST_SHA/check-runs" \
+                --jq '.check_runs[] | select(.app.slug | test("coderabbit")) | "\(.status):\(.conclusion)"' 2>/dev/null | tail -1 || true)
+            if [ "$CR_SIGNAL" = "completed:success" ]; then CR_SIGNAL="success"; fi
+        fi
+
+        CR_FALLBACK_OK=false
+        if [ "$CR_SIGNAL" = "success" ] && [ -n "$THREAD_UNRESOLVED" ] && [ "$THREAD_UNRESOLVED" -eq 0 ]; then
+            if [ "$CR_LATEST_STATE" = "APPROVED" ] || [ "$CR_LATEST_STATE" = "COMMENTED" ]; then
+                CR_FALLBACK_OK=true
+            fi
+        fi
+
+        if [ "$CR_FALLBACK_OK" = true ]; then
+            echo "GATE:2:CodeRabbit:PASS:CodeRabbit green on ${LATEST_SHA:0:7}, latest review $CR_LATEST_STATE, 0 unresolved threads (no review event on head — fallback)"
+        else
+            echo "GATE:2:CodeRabbit:FAIL:No review from coderabbitai[bot] on ${CODE_SHA:0:7} or ${LATEST_SHA:0:7} (fallback: signal=${CR_SIGNAL:-none}, latest review=${CR_LATEST_STATE:-none}, unresolved=${THREAD_UNRESOLVED:-unknown})"
+            ANY_FAILED=true
+        fi
     fi
 fi
 
@@ -296,12 +374,13 @@ fi
 # BugBot quirk: when it finds no bugs, it reports as a check run
 # ("Cursor Bugbot") instead of posting a review. Check both.
 # Accepts review/check-run on CODE_SHA or LATEST_SHA.
+# (No Gate-2-style status fallback needed here: BugBot re-emits its
+# check-run on every push, so the head SHA always carries a signal.)
 
 if [ "$NO_CODE_CHANGES" = true ]; then
     echo "GATE:3:BugBot:PASS:No code changes — bot review not required"
 else
-    BB_REVIEW=$(gh api graphql -f query="{ repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUMBER) { reviews(last: 20) { nodes { author { login } state commit { oid } } } } } }" \
-        --jq ".data.repository.pullRequest.reviews.nodes[] | select(.commit.oid == \"$CODE_SHA\" or .commit.oid == \"$LATEST_SHA\") | select(.author.login | test(\"cursor\")) | \"\(.author.login): \(.state)\"" 2>/dev/null | tail -1 || true)
+    BB_REVIEW=$(echo "$PR_DATA" | jq -r ".data.repository.pullRequest.reviews.nodes[] | select(.commit.oid == \"$CODE_SHA\" or .commit.oid == \"$LATEST_SHA\") | select(.author.login | test(\"cursor\")) | \"\(.author.login): \(.state)\"" 2>/dev/null | tail -1 || true)
 
     if [ -n "$BB_REVIEW" ]; then
         echo "GATE:3:BugBot:PASS:$BB_REVIEW (on PR #$PR_NUMBER)"
@@ -328,21 +407,17 @@ else
 fi
 
 # ─── Gate 4: Zero unresolved threads ────────────────────────────────
+# Counts come from the shared PR_DATA snapshot above, so this gate and
+# Gate 2's fallback can never disagree about the unresolved count.
 
-THREADS_JSON=$(gh api graphql -f query="{ repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUMBER) { reviewThreads(first: 100) { nodes { isResolved } } } } }" 2>/dev/null || true)
-
-if [ -n "$THREADS_JSON" ]; then
-    TOTAL=$(echo "$THREADS_JSON" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]] | length' 2>/dev/null || echo "")
-    RESOLVED=$(echo "$THREADS_JSON" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == true)] | length' 2>/dev/null || echo "")
-    UNRESOLVED=$(echo "$THREADS_JSON" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "")
-
-    if [ -z "$TOTAL" ] || [ -z "$UNRESOLVED" ]; then
+if [ -n "$PR_DATA" ]; then
+    if [ -z "$THREAD_TOTAL" ] || [ -z "$THREAD_UNRESOLVED" ]; then
         echo "GATE:4:Threads:FAIL:Could not parse thread data"
         ANY_FAILED=true
-    elif [ "$UNRESOLVED" -eq 0 ]; then
-        echo "GATE:4:Threads:PASS:Total: $TOTAL, Resolved: $RESOLVED, Unresolved: $UNRESOLVED"
+    elif [ "$THREAD_UNRESOLVED" -eq 0 ]; then
+        echo "GATE:4:Threads:PASS:Total: $THREAD_TOTAL, Resolved: $THREAD_RESOLVED, Unresolved: $THREAD_UNRESOLVED"
     else
-        echo "GATE:4:Threads:FAIL:Total: $TOTAL, Resolved: $RESOLVED, Unresolved: $UNRESOLVED"
+        echo "GATE:4:Threads:FAIL:Total: $THREAD_TOTAL, Resolved: $THREAD_RESOLVED, Unresolved: $THREAD_UNRESOLVED"
         ANY_FAILED=true
     fi
 else
@@ -397,6 +472,8 @@ fi
 if command -v dispatch >/dev/null 2>&1; then
     if [ "$ANY_FAILED" = true ]; then
         _PF_SUMMARY="FAIL ($TASK_ID, PR #$PR_NUMBER)"
+    elif [ "$ANY_PENDING" = true ]; then
+        _PF_SUMMARY="PENDING — no failures, re-run shortly ($TASK_ID, PR #$PR_NUMBER)"
     else
         _PF_SUMMARY="PASS — All 7 gates passed ($TASK_ID, PR #$PR_NUMBER)"
     fi
@@ -407,6 +484,8 @@ fi
 
 if [ "$ANY_FAILED" = true ]; then
     exit 1
+elif [ "$ANY_PENDING" = true ]; then
+    exit 2
 else
     exit 0
 fi

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -380,9 +380,11 @@ else
         CR_SIGNAL=$(gh api "repos/$OWNER/$NAME/commits/$LATEST_SHA/status" \
             --jq '[.statuses[] | select(.context | test("coderabbit"; "i")) | .state] | if length == 0 then empty elif all(. == "success") then "success" else (map(select(. != "success")) | first) end' 2>/dev/null || true)
         if [ -z "$CR_SIGNAL" ]; then
+            # Same all-green rule as the status branch: every matching
+            # check run must be completed:success; otherwise surface the
+            # first non-green "status:conclusion" in the FAIL detail.
             CR_SIGNAL=$(gh api "repos/$OWNER/$NAME/commits/$LATEST_SHA/check-runs" \
-                --jq '.check_runs[] | select(.app.slug | test("coderabbit")) | "\(.status):\(.conclusion)"' 2>/dev/null | tail -1 || true)
-            if [ "$CR_SIGNAL" = "completed:success" ]; then CR_SIGNAL="success"; fi
+                --jq '[.check_runs[] | select(.app.slug | test("coderabbit")) | "\(.status):\(.conclusion)"] | if length == 0 then empty elif all(. == "completed:success") then "success" else (map(select(. != "completed:success")) | first) end' 2>/dev/null || true)
         fi
 
         CR_FALLBACK_OK=false

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -241,6 +241,7 @@ CI_POLL_ATTEMPTS=3
 CI_POLL_DELAY=5
 RUN_COUNT=0
 LATEST_RUNS="[]"
+CI_FETCH_OK=false
 CI_ATTEMPT=1
 while [ "$CI_ATTEMPT" -le "$CI_POLL_ATTEMPTS" ]; do
     # Reset per attempt so a failed refetch can't reuse a stale filter result
@@ -250,7 +251,12 @@ while [ "$CI_ATTEMPT" -le "$CI_POLL_ATTEMPTS" ]; do
     # be pushed out of --limit by older reruns piling up on the branch.
     # shellcheck disable=SC2086
     CI_RUNS=$(gh $GH_REPO_ARG run list --commit "$LATEST_SHA" --limit 10 --json status,conclusion,workflowName,event,headSha \
-        --jq '[.[] | select(.event == "push" or .event == "pull_request")]' 2>/dev/null || true)
+        --jq '[.[] | select(.event == "push" or .event == "pull_request")]' 2>/dev/null)
+    # Distinguish "gh succeeded with an empty list" (runs not registered
+    # yet → PENDING) from "gh itself failed" (auth/network → FAIL below)
+    if [ $? -eq 0 ]; then
+        CI_FETCH_OK=true
+    fi
 
     if [ -n "$CI_RUNS" ] && [ "$CI_RUNS" != "[]" ]; then
         # Filter runs to the PR head commit (not just the newest run's SHA)
@@ -269,8 +275,15 @@ while [ "$CI_ATTEMPT" -le "$CI_POLL_ATTEMPTS" ]; do
 done
 
 if [ "$RUN_COUNT" -eq 0 ]; then
-    echo "GATE:1:CI:PENDING:No CI runs registered yet for ${LATEST_SHA:0:7} — re-run preflight shortly"
-    ANY_PENDING=true
+    if [ "$CI_FETCH_OK" = true ]; then
+        echo "GATE:1:CI:PENDING:No CI runs registered yet for ${LATEST_SHA:0:7} — re-run preflight shortly"
+        ANY_PENDING=true
+    else
+        # Every attempt errored — a connectivity/auth problem, not "no runs
+        # yet". Fail closed like Gate 4's could-not-fetch path.
+        echo "GATE:1:CI:FAIL:Could not fetch CI runs (gh error) — check gh auth/network"
+        ANY_FAILED=true
+    fi
 else
     CI_ALL_PASS=true
     CI_ANY_RUNNING=false

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -179,6 +179,13 @@ if [ -z "$PR_NUMBER" ]; then
     fi
 fi
 
+# Defense-in-depth: PR_NUMBER is interpolated into GraphQL queries below,
+# so insist it is numeric whether it came from --pr or from gh pr view.
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: PR number must be numeric (got: $PR_NUMBER)"
+    exit 1
+fi
+
 # Get PR head SHA for review checks
 # shellcheck disable=SC2086
 LATEST_SHA=$(gh $GH_REPO_ARG pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid 2>/dev/null || true)
@@ -236,6 +243,9 @@ RUN_COUNT=0
 LATEST_RUNS="[]"
 CI_ATTEMPT=1
 while [ "$CI_ATTEMPT" -le "$CI_POLL_ATTEMPTS" ]; do
+    # Reset per attempt so a failed refetch can't reuse a stale filter result
+    LATEST_RUNS="[]"
+    RUN_COUNT=0
     # shellcheck disable=SC2086
     CI_RUNS=$(gh $GH_REPO_ARG run list --branch "$BRANCH" --limit 10 --json status,conclusion,workflowName,event,headSha \
         --jq '[.[] | select(.event == "push" or .event == "pull_request")]' 2>/dev/null || true)
@@ -326,9 +336,7 @@ else
     CR_REVIEW=$(echo "$PR_DATA" | jq -r ".data.repository.pullRequest.reviews.nodes[] | select(.commit.oid == \"$CODE_SHA\" or .commit.oid == \"$LATEST_SHA\") | select(.author.login | test(\"coderabbitai\")) | \"\(.author.login): \(.state)\"" 2>/dev/null | tail -1 || true)
 
     if [ -n "$CR_REVIEW" ]; then
-        MATCH_SHA="$CODE_SHA"
-        if echo "$CR_REVIEW" | grep -q "$LATEST_SHA" 2>/dev/null; then MATCH_SHA="$LATEST_SHA"; fi
-        echo "GATE:2:CodeRabbit:PASS:$CR_REVIEW (on ${MATCH_SHA:0:7})"
+        echo "GATE:2:CodeRabbit:PASS:$CR_REVIEW (on ${CODE_SHA:0:7} or ${LATEST_SHA:0:7})"
     else
         # Fallback (KIT-0034 F1): after a trivial/docs push CodeRabbit
         # refreshes its commit status and keeps an APPROVED review on an
@@ -346,8 +354,12 @@ else
         #   3. zero unresolved review threads (same count as Gate 4).
         CR_LATEST_STATE=$(echo "$PR_DATA" | jq -r "[.data.repository.pullRequest.reviews.nodes[] | select(.author.login | test(\"coderabbitai\"))] | last | .state // empty" 2>/dev/null || true)
 
+        # The combined-status endpoint returns the latest status per context.
+        # Require every CodeRabbit-matching context to be green (all() with an
+        # explicit empty guard — all([]) is vacuously true); on a mixed result
+        # surface the first non-success state in the FAIL detail.
         CR_SIGNAL=$(gh api "repos/$OWNER/$NAME/commits/$LATEST_SHA/status" \
-            --jq '.statuses[] | select(.context | test("coderabbit"; "i")) | .state' 2>/dev/null | tail -1 || true)
+            --jq '[.statuses[] | select(.context | test("coderabbit"; "i")) | .state] | if length == 0 then empty elif all(. == "success") then "success" else (map(select(. != "success")) | first) end' 2>/dev/null || true)
         if [ -z "$CR_SIGNAL" ]; then
             CR_SIGNAL=$(gh api "repos/$OWNER/$NAME/commits/$LATEST_SHA/check-runs" \
                 --jq '.check_runs[] | select(.app.slug | test("coderabbit")) | "\(.status):\(.conclusion)"' 2>/dev/null | tail -1 || true)
@@ -355,7 +367,7 @@ else
         fi
 
         CR_FALLBACK_OK=false
-        if [ "$CR_SIGNAL" = "success" ] && [ -n "$THREAD_UNRESOLVED" ] && [ "$THREAD_UNRESOLVED" -eq 0 ]; then
+        if [ "$CR_SIGNAL" = "success" ] && [[ "$THREAD_UNRESOLVED" =~ ^[0-9]+$ ]] && [ "$THREAD_UNRESOLVED" -eq 0 ]; then
             if [ "$CR_LATEST_STATE" = "APPROVED" ] || [ "$CR_LATEST_STATE" = "COMMENTED" ]; then
                 CR_FALLBACK_OK=true
             fi
@@ -415,7 +427,12 @@ if [ -n "$PR_DATA" ]; then
         echo "GATE:4:Threads:FAIL:Could not parse thread data"
         ANY_FAILED=true
     elif [ "$THREAD_UNRESOLVED" -eq 0 ]; then
-        echo "GATE:4:Threads:PASS:Total: $THREAD_TOTAL, Resolved: $THREAD_RESOLVED, Unresolved: $THREAD_UNRESOLVED"
+        # reviewThreads(first: 100) — flag possible truncation at the cap
+        _PF_TRUNC=""
+        if [ "$THREAD_TOTAL" -eq 100 ]; then
+            _PF_TRUNC=" (count capped at 100 — verify manually)"
+        fi
+        echo "GATE:4:Threads:PASS:Total: $THREAD_TOTAL, Resolved: $THREAD_RESOLVED, Unresolved: $THREAD_UNRESOLVED$_PF_TRUNC"
     else
         echo "GATE:4:Threads:FAIL:Total: $THREAD_TOTAL, Resolved: $THREAD_RESOLVED, Unresolved: $THREAD_UNRESOLVED"
         ANY_FAILED=true

--- a/scripts/local/bootstrap-consumer.sh
+++ b/scripts/local/bootstrap-consumer.sh
@@ -130,14 +130,17 @@ mkdir -p "$TARGET/scripts/optional"
     --exclude='sync-core-scripts.yml' --exclude='sync-to-linear.yml' \
     "$PROJECT_ROOT/.github/" "$TARGET/.github/"
 
-# tests/ — test infrastructure. Exclude test_kit_markers.py: it imports
-# scripts/local/kit_markers.py, an ASK-only bootstrap tool that is never
-# synced to consumers, so shipping the test would break consumer pytest
-# (and the pytest-fast pre-commit hook) at collection time. The rm -f
-# sweep removes a stale copy from a pre-fix bootstrap — --ignore-existing
-# would otherwise leave the orphaned test behind in existing consumers.
-rm -f "$TARGET/tests/test_kit_markers.py"
+# tests/ — test infrastructure. Exclude tests that import or read
+# scripts/local/ content (kit_markers.py, bootstrap-consumer.sh):
+# scripts/local is an ASK-only layer that is never synced to consumers,
+# so shipping these tests would break consumer pytest (and the
+# pytest-fast pre-commit hook) at collection time. The rm -f sweep
+# removes stale copies from a pre-fix bootstrap — --ignore-existing
+# would otherwise leave the orphaned tests behind in existing consumers.
+rm -f "$TARGET/tests/test_kit_markers.py" \
+      "$TARGET/tests/test_bootstrap_consumer.py"
 "${RSYNC_BASE[@]}" --exclude='test_kit_markers.py' \
+    --exclude='test_bootstrap_consumer.py' \
     "$PROJECT_ROOT/tests/" "$TARGET/tests/"
 
 # Top-level files (only if they don't exist in target)

--- a/tests/test_bootstrap_consumer.py
+++ b/tests/test_bootstrap_consumer.py
@@ -52,7 +52,11 @@ def _kit_agents() -> set[str]:
 
 
 def _agent_excludes() -> set[str]:
-    """Filenames excluded via AGENT_EXCLUDES=(--exclude='...' ...)."""
+    """Filenames excluded via AGENT_EXCLUDES=(--exclude='...' ...).
+
+    Assumes the array literal contains no nested parentheses (true of the
+    controlled internal file; a format change fails the search loudly).
+    """
     match = re.search(
         r"^AGENT_EXCLUDES=\((.*?)\)", _SCRIPT_TEXT, re.MULTILINE | re.DOTALL
     )

--- a/tests/test_bootstrap_consumer.py
+++ b/tests/test_bootstrap_consumer.py
@@ -1,0 +1,113 @@
+"""Tests for scripts/local/bootstrap-consumer.sh — KIT-LOCAL marker wiring.
+
+KIT-0034 F5: every agent file carrying KIT-LOCAL markers must be wired into
+bootstrap-consumer.sh twice — listed in KIT_AGENTS (drives the marker-merge
+step and the --no-kit prune) and rsync-excluded in AGENT_EXCLUDES (so the
+plain copy step never ships the kit's own filled-in regions to a consumer).
+A marker-bearing agent missing from either list leaks kit identity into
+fresh consumers (BugBot, PR #66) or survives a --no-kit opt-out (CodeRabbit,
+PR #68). The bash arrays are text-parsed; the script is never executed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = REPO_ROOT / "scripts" / "local" / "bootstrap-consumer.sh"
+_AGENTS_DIR = REPO_ROOT / ".claude" / "agents"
+
+# bootstrap-consumer.sh is an ASK-only bootstrap tool (scripts/local is not
+# synced downstream). The consumer sync also excludes this test, but guard
+# the load so a stray copy in a consumer checkout skips cleanly instead of
+# erroring at collection.
+if not _SCRIPT_PATH.exists():
+    pytest.skip(
+        "bootstrap-consumer.sh present only in the kit repo",
+        allow_module_level=True,
+    )
+
+_SCRIPT_TEXT = _SCRIPT_PATH.read_text(encoding="utf-8")
+
+_MARKER_BEGIN = "<!-- BEGIN KIT-LOCAL:"
+
+
+def _marker_bearing_agents() -> set[str]:
+    """Basenames of .claude/agents/*.md files containing KIT-LOCAL markers."""
+    return {
+        p.name
+        for p in _AGENTS_DIR.glob("*.md")
+        if _MARKER_BEGIN in p.read_text(encoding="utf-8")
+    }
+
+
+def _kit_agents() -> set[str]:
+    """Entries of the KIT_AGENTS=(...) bash array, text-parsed."""
+    match = re.search(r"^KIT_AGENTS=\(([^)]*)\)", _SCRIPT_TEXT, re.MULTILINE)
+    assert match is not None, "KIT_AGENTS array not found in bootstrap-consumer.sh"
+    return set(match.group(1).split())
+
+
+def _agent_excludes() -> set[str]:
+    """Filenames excluded via AGENT_EXCLUDES=(--exclude='...' ...)."""
+    match = re.search(
+        r"^AGENT_EXCLUDES=\((.*?)\)", _SCRIPT_TEXT, re.MULTILINE | re.DOTALL
+    )
+    assert match is not None, "AGENT_EXCLUDES array not found in bootstrap-consumer.sh"
+    return set(re.findall(r"--exclude='([^']+)'", match.group(1)))
+
+
+class TestMarkerAgentMembership:
+    def test_marker_agents_exist(self):
+        # Guard against a silently green run if the marker convention moves.
+        assert _marker_bearing_agents(), "no KIT-LOCAL marker-bearing agents found"
+
+    def test_every_marker_agent_in_kit_agents(self):
+        missing = _marker_bearing_agents() - _kit_agents()
+        assert not missing, (
+            f"KIT-LOCAL marker-bearing agents missing from KIT_AGENTS in "
+            f"bootstrap-consumer.sh (marker-merge + --no-kit prune skip them): "
+            f"{sorted(missing)}"
+        )
+
+    def test_every_marker_agent_in_agent_excludes(self):
+        missing = _marker_bearing_agents() - _agent_excludes()
+        assert not missing, (
+            f"KIT-LOCAL marker-bearing agents missing from AGENT_EXCLUDES in "
+            f"bootstrap-consumer.sh (plain rsync would ship kit-filled regions "
+            f"to consumers): {sorted(missing)}"
+        )
+
+    def test_no_stale_kit_agents_entries(self):
+        # An entry without markers means the agent was retired or de-markered
+        # but the bootstrap wiring was not updated.
+        stale = _kit_agents() - _marker_bearing_agents()
+        assert not stale, (
+            f"KIT_AGENTS entries with no KIT-LOCAL markers in .claude/agents/: "
+            f"{sorted(stale)}"
+        )
+
+
+class TestConsumerTestsRsyncBoundary:
+    """Tests reading scripts/local/ must not ship to consumers (F2 rule)."""
+
+    # This module reads bootstrap-consumer.sh itself, so it falls under the
+    # same exclusion rule it enforces.
+    EXCLUDED_TESTS = ("test_kit_markers.py", "test_bootstrap_consumer.py")
+
+    def test_excluded_from_consumer_rsync(self):
+        for name in self.EXCLUDED_TESTS:
+            assert f"--exclude='{name}'" in _SCRIPT_TEXT, (
+                f"{name} reads scripts/local/ content but is not rsync-excluded "
+                f"from the consumer tests/ sync in bootstrap-consumer.sh"
+            )
+
+    def test_stale_copy_swept_from_consumers(self):
+        for name in self.EXCLUDED_TESTS:
+            assert f'"$TARGET/tests/{name}"' in _SCRIPT_TEXT, (
+                f"{name} has no rm -f sweep in bootstrap-consumer.sh — a stale "
+                f"copy from an earlier bootstrap would survive --ignore-existing"
+            )


### PR DESCRIPTION
## Summary

Hardens the kit's completion gates and bootstrap machinery against five failure modes recorded across the KIT-0032/KIT-0033/KIT-0036 retros and the 2026-07-04 session retro. Task spec: `.kit/tasks/3-in-progress/KIT-0034-preflight-bootstrap-hardening.md`.

- **F1 — Gate 2 (CodeRabbit) fail-closed fallback**: when no CodeRabbit review event exists on the head SHA, the gate now PASSes only if CodeRabbit's signal on the head is green **and** the latest CodeRabbit review is APPROVED (or COMMENTED) **and** zero threads are unresolved. Data-shape note: CodeRabbit reports via the legacy commit-**status** API (context `CodeRabbit`), not check-runs — the fallback queries status first, check-runs as a secondary source. Gate 3 (BugBot) needs no equivalent: it re-emits a check-run on every push (verified on PR #58's head SHA).
- **F4 — Gate 1 (CI) PENDING state**: `no runs registered yet` and `still running` now report `GATE:1:CI:PENDING` (new exit code 2 when nothing failed) after a bounded re-poll (3 attempts × 5 s), instead of FAIL. A completed non-success run still FAILs — even while sibling workflows are running (N3).
- Gates 2/3/4 now share **one GraphQL snapshot**, so Gate 2's fallback and Gate 4 can never disagree on the unresolved-thread count (also: 3 API calls → 1).
- **F2** — self-review skill (v1.1.0) + both feature-developer forks' stack notes gain the consumer-sync test boundary item.
- **F3** — `.kit/context/workflows/TEMP-THEN-COMMIT-PATTERN.md` documents the two-pass atomic mutation pattern with the KIT-0033 bug as before/after; linked from CLAUDE.md.
- **F5** — `tests/test_bootstrap_consumer.py` (6 tests) asserts every KIT-LOCAL marker-bearing agent is in both `KIT_AGENTS` and `AGENT_EXCLUDES`, that `KIT_AGENTS` has no stale entries, and that boundary-crossing tests (including itself) are excluded from the consumer `tests/` rsync + swept.

## Test plan / verification

- [x] `pytest` — 371 passed, 12 skipped (full suite incl. new tests); pre-commit gauntlet green
- [x] **Real-world run** against KIT-0036 PR #63 (2nd recorded false-negative case): Gates 2–4 PASS, Gate 1 correctly PENDING (branch context differs), exit precedence FAIL > PENDING confirmed via Gate 7
- [x] **Stub-gh scenario matrix** (real script, canned `gh` output on PATH):
  - A: green + APPROVED-on-old-SHA + 0 unresolved, no head review → Gate 2 **PASS via fallback**
  - B: no CodeRabbit review at all → Gate 2 **FAIL** (N1)
  - C: 1 unresolved thread → Gate 2 **FAIL** + Gate 4 **FAIL** (N1)
  - D: latest review CHANGES_REQUESTED → Gate 2 **FAIL**
  - E: no commit status but green check-run → Gate 2 **PASS** (secondary source)
  - F: completed failure + sibling running → Gate 1 **FAIL**, not PENDING (N3)
- [x] `bash -n` on both scripts

## Notes

- PR #58 (the original false-negative case) currently carries **2 unresolved BugBot threads on `kit_markers.py`** (medium severity, opened at merge time) — left untouched here; flagged for planner follow-up. PR #63 was used as the clean real-world case instead.
- N2 respected: preflight stays shell + `gh`; the arch evaluator's Python-rewrite suggestion was declined by the planner (task file, Evaluation section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UmTSCAQFTPgfJDytaZX7n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shell logic that decides PR readiness (Gates 1–2) with no automated test harness for the script; incorrect fallback could pass unreviewed PRs or block green ones, though design is fail-closed and manually verified.
> 
> **Overview**
> Hardens **KIT-0034** completion gates and consumer bootstrap wiring after repeated false negatives on CodeRabbit (Gate 2) and “no CI runs yet” (Gate 1).
> 
> **`preflight-check.sh` (v1.2.0)** now emits **`PENDING`** on Gate 1 when CI runs are not registered for the head SHA (bounded re-poll) or still running, with **exit code 2** when nothing failed but a gate is pending; completed non-success runs still **FAIL**. Gate 2 adds a **fail-closed fallback** when there is no CodeRabbit review on the head SHA: green CodeRabbit signal on head, latest review APPROVED/COMMENTED, and zero unresolved threads. Gates 2–4 share **one GraphQL snapshot** so thread counts cannot disagree. Hardening includes numeric `PR_NUMBER` validation, safer CodeRabbit status/check-run aggregation, and Gate 4 truncation warning at the 100-thread cap.
> 
> **Bootstrap / process**: new **`tests/test_bootstrap_consumer.py`** locks every KIT-LOCAL marker agent into both `KIT_AGENTS` and `AGENT_EXCLUDES`, and asserts kit-only tests are rsync-excluded and swept; **`bootstrap-consumer.sh`** excludes that test from consumer sync. **Self-review** (v1.1.0) and both **feature-developer** forks document the consumer-sync test boundary. **`TEMP-THEN-COMMIT-PATTERN.md`** is added and linked from **`CLAUDE.md`**; **`/preflight`** documents PENDING semantics.
> 
> Task/handoff/review artifacts for KIT-0034 are updated (in-review status, evaluator record, review starter).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0b2dd5ac8bd12ed7b12d482be1fce00eaa3ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->