### PR TITLE
fix(KIT-0040): KIT-0034 retro follow-ups — kit_markers fixes, preflight test harness, move-metadata sync

### DIFF
--- a/.kit/context/KIT-0040-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0040-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0040 Handoff — feature-developer
 
-**Task**: `.kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0040-kit-0034-retro-followups.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-05 (planner-f5)
 **Estimated effort**: 3–5 hours

--- a/.kit/context/KIT-0040-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0040-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0040 Handoff — feature-developer
 
-**Task**: `.kit/tasks/2-todo/KIT-0040-kit-0034-retro-followups.md`
+**Task**: `.kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-05 (planner-f5)
 **Estimated effort**: 3–5 hours

--- a/.kit/context/KIT-0040-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0040-REVIEW-STARTER.md
@@ -1,0 +1,67 @@
+# KIT-0040 Review Starter — KIT-0034 Retro Follow-ups
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/70
+**Branch**: `feature/KIT-0040-kit-0034-retro-followups`
+**Task**: `.kit/tasks/4-in-review/KIT-0040-kit-0034-retro-followups.md`
+**Handoff**: `.kit/context/KIT-0040-HANDOFF-feature-developer.md`
+**Date**: 2026-07-05
+
+## What shipped
+
+Three retro follow-ups from KIT-0034, F3 first per the planner's
+sequencing decision (all three landed in one PR — nothing dragged):
+
+- **F3 — `kit_markers.py` fixes** (`scripts/local/kit_markers.py`): the
+  two BugBot findings open on merged PR #58 since KIT-0033. Prose
+  mentions of a BEGIN marker no longer abort re-bootstrap (line-anchored
+  malformed check); whitespace-drifted markers now parse and preserve
+  customized consumer content instead of silently clobbering it with
+  placeholders; drift beyond tolerance fails fast. Byte-preserving
+  round-trip retained. Both PR #58 threads replied to and resolved with
+  pointers to PR #70.
+- **F1 — stub-`gh` preflight harness** (`tests/test_preflight_check.py`):
+  the real `preflight-check.sh` runs against canned `gh` payloads across
+  the KIT-0034 8-state matrix + baseline all-pass (10 tests, ~1.8 s,
+  hermetic temp dirs, mutation-verified). Ships to consumers (targets
+  `scripts/core/` only).
+- **F2 — decision: tooling fix** (stated choice; the COMMIT-PROTOCOL.md
+  documentation fallback was not needed): `project move|start|complete|
+  block` rewrites the moved task's numbered-folder path in
+  `agent-handoffs.json` + `HANDOFF-*.md` files. Conservative (exact file
+  name, numbered folders only), warn-never-block, re-run = repair.
+
+## Review trail
+
+- **Bots**: CodeRabbit round 1 → 1 finding (UnicodeDecodeError not
+  caught by `except OSError`) — fixed in `5addbdf` with regression test;
+  latest CodeRabbit review APPROVED. BugBot → 1 finding (`\b` prefix
+  collision in the malformed-marker detector) — fixed in `dca46c8`;
+  thread auto-resolved, reply added. 3 threads total on PR #70 (2 + the
+  courtesy reply), 0 unresolved.
+- **Evaluators** (`.kit/context/reviews/KIT-0040-evaluator-review.md`):
+  fast-v2 CONCERNS (1 real → fixed in `dca46c8`; 3 declined with
+  reasoning), o3 CONCERNS (2 claims verified false empirically, 1
+  documented fail-fast trade-off), claude-code APPROVED.
+- **CI**: green on every push (Lint + Tests + BugBot + CodeRabbit).
+
+## Suggested review focus
+
+1. `scripts/local/kit_markers.py` — the three regexes (`BEGIN_RE`,
+   `_region_pattern`, `_begin_marker_line_re`) and the consistency
+   argument: everything parseable is preserved byte-for-byte; everything
+   marker-shaped but unparseable fails fast; nothing falls between.
+2. `scripts/core/project::_sync_coordination_metadata` — conservative
+   rewrite scope (is `[0-9]+-[a-z-]+` + exact file name the right
+   boundary?).
+3. Known accepted limitation: a literal BEGIN-marker line inside a
+   fenced code sample (region otherwise absent) still fail-fast aborts —
+   deliberate (loud abort beats silent clobber), same behavior as before
+   the fix, noted by both evaluators and declined.
+
+## Verification commands
+
+```bash
+pytest tests/test_kit_markers.py tests/test_preflight_check.py tests/test_project_script.py -q
+./scripts/core/ci-check.sh
+./scripts/core/preflight-check.sh --pr 70
+```

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0040",
     "task_started": null,
     "brief_note": "KIT-0040 promoted to todo (high, user pulled it forward to fix the kit_markers bugs), evaluated (RESTRUCTURE_NEEDED declined, F3-first sequencing accepted — disposition in spec), handoff ready. Then: KIT-0037/38/39 bundle, KIT-0035, ADR-0025 slim. Awaiting human verdicts: KIT-0032 (PR #56 merged), ASK-0048 (PR #45).",
-    "details_link": ".kit/tasks/2-todo/KIT-0040-kit-0034-retro-followups.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md",
     "handoff_file": ".kit/context/KIT-0040-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0040",
     "task_started": null,
     "brief_note": "KIT-0040 (kit_markers bug fixes FIRST, then preflight stub-gh harness + project-move metadata pairing) ready for assignment.",
-    "details_link": ".kit/tasks/2-todo/KIT-0040-kit-0034-retro-followups.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md",
     "handoff_file": ".kit/context/KIT-0040-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0040",
     "task_started": null,
     "brief_note": "KIT-0040 promoted to todo (high, user pulled it forward to fix the kit_markers bugs), evaluated (RESTRUCTURE_NEEDED declined, F3-first sequencing accepted — disposition in spec), handoff ready. Then: KIT-0037/38/39 bundle, KIT-0035, ADR-0025 slim. Awaiting human verdicts: KIT-0032 (PR #56 merged), ASK-0048 (PR #45).",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0040-kit-0034-retro-followups.md",
     "handoff_file": ".kit/context/KIT-0040-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0040",
     "task_started": null,
     "brief_note": "KIT-0040 (kit_markers bug fixes FIRST, then preflight stub-gh harness + project-move metadata pairing) ready for assignment.",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0040-kit-0034-retro-followups.md",
     "handoff_file": ".kit/context/KIT-0040-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/reviews/KIT-0040-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0040-evaluator-review.md
@@ -1,0 +1,68 @@
+# KIT-0040 — Adversarial Evaluator Review
+
+**Date**: 2026-07-05
+**PR**: #70 (`feature/KIT-0040-kit-0034-retro-followups`)
+**Input**: `.adversarial/inputs/KIT-0040-code-review-input.md`
+(full diff + file contents vs `main`, regenerated after the round-1 fixes)
+
+| Evaluator | Model | Verdict | Log |
+|-----------|-------|---------|-----|
+| `code-reviewer-fast-v2` | gemini-3-flash-preview | CONCERNS | `.adversarial/logs/KIT-0040-code-review-input--code-reviewer-fast-v2.md` |
+| `code-reviewer` | o3 | CONCERNS | `.adversarial/logs/KIT-0040-code-review-input--code-reviewer.md` |
+| `claude-code` | claude-sonnet-4-6 | **APPROVED** | `.adversarial/logs/KIT-0040-code-review-input--claude-code.md` |
+
+## Triage (verify-before-believing applied to every finding)
+
+### code-reviewer-fast-v2 (4 findings)
+
+1. **File-name collision in `_sync_coordination_metadata`** — *non-issue*.
+   The evaluator's own trace concludes the full-file-name constraint makes
+   the substitution correct; rewriting every mention of the moved task's
+   exact path is the intended sync behavior
+   (`test_move_leaves_other_tasks_untouched` covers the collision case).
+2. **Non-numbered custom folder names not rewritten** — *declined, by
+   design*. The conservative `[0-9]+-[a-z-]+` scope was an explicit
+   handoff requirement; `project move` can only write numbered folders
+   from `STATUS_FOLDER_MAP`, so tooling-written paths always match.
+3. **`\b` prefix collision on hyphenated marker names** — **REAL BUG,
+   FIXED** in `dca46c8`. `_begin_marker_line_re("project-context")`
+   matched a well-formed `project-context-extra` BEGIN line (word
+   boundary at the `t→-` transition), falsely aborting merge as
+   malformed. Name terminator changed from `\b` to `(?!-?\w)`; regression
+   test `test_prefix_named_region_does_not_trip_malformed_check`.
+4. **Line-anchored marker examples in docs still abort** — *declined,
+   documented trade-off*. See o3 finding 1 below.
+
+### code-reviewer / o3 (3 findings)
+
+1. **Fenced code-block marker line → "malformed" abort** — *declined,
+   deliberate fail-fast trade-off*. Mechanically true: a literal BEGIN
+   marker line inside a fenced code sample, with no parseable region for
+   that name, raises ValueError. This is the explicitly chosen behavior
+   (loud abort with a clear message beats silently clobbering consumer
+   content — the exact bug F3 fixes), the same input aborted before this
+   PR too (raw substring check), and parsing Markdown fences is out of
+   scope for a stdlib helper. Documented in `_begin_marker_line_re`'s
+   docstring.
+2. **EOF without trailing newline breaks region parsing** — **VERIFIED
+   FALSE**. Empirical check: a file ending exactly at
+   `<!-- END KIT-LOCAL: foo -->` (no final newline) parses and extracts
+   correctly. The `\r?\n` in `_region_pattern` is the body/END-marker
+   separator, not a trailing-newline requirement.
+3. **Metadata regex clobbers non-path prose** — **VERIFIED FALSE as
+   stated**. The pattern requires the full `.kit/tasks/<folder>/` prefix;
+   the evaluator's own example (bare `KIT-1234-sample-task.md` in a note)
+   does not match. Full-path mentions being rewritten to the new folder
+   is the intended behavior (path references should track the move).
+
+### claude-code (security)
+
+APPROVED, no findings to triage.
+
+## Outcome
+
+One real finding across all three evaluators (fast-v2 #3), fixed with a
+regression test before this review was persisted. o3 produced two
+factually wrong claims (consistent with the KIT-0034 retro's
+verify-before-believing observation). Final code: 408 tests green,
+`ci-check.sh` green.

--- a/.kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md
+++ b/.kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md
@@ -1,6 +1,6 @@
 # KIT-0040: KIT-0034 retro follow-ups — preflight test harness, move-metadata pairing, kit_markers fixes
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 3-5 hours

--- a/.kit/tasks/4-in-review/KIT-0040-kit-0034-retro-followups.md
+++ b/.kit/tasks/4-in-review/KIT-0040-kit-0034-retro-followups.md
@@ -1,6 +1,6 @@
 # KIT-0040: KIT-0034 retro follow-ups — preflight test harness, move-metadata pairing, kit_markers fixes
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 3-5 hours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kit_markers.py` marker-merge robustness** (KIT-0040 F3, resolves the
+  two BugBot findings open on PR #58 since the KIT-0033 merge):
+  - A prose mention of a region's BEGIN marker inside another (preserved)
+    region no longer aborts re-bootstrap as "malformed" — the malformed
+    check is now line-anchored instead of a raw substring test.
+  - Benign whitespace drift inside a marker line (extra spaces/tabs) no
+    longer makes the region unparseable — previously a drifted marker
+    silently replaced customized consumer content with placeholder TODO
+    text on re-bootstrap. Drift beyond the whitespace tolerance is now
+    *detected* by a deliberately looser line-anchored check and fails
+    fast instead of clobbering. Well-formed and drifted regions still
+    round-trip byte-for-byte.
+
 ### Added
+
+- **Stub-`gh` regression harness for `preflight-check.sh`**
+  (`tests/test_preflight_check.py`, KIT-0040 F1) — runs the real script
+  against canned `gh` payloads via a fake `gh` on PATH, covering the
+  KIT-0034 8-state verification matrix (Gate 2 status/check-run fallback,
+  fail-closed paths, Gate 1 PENDING vs FAIL precedence) in CI. The script
+  itself stays shell + gh; the stub pattern is reusable for other
+  shell+gh scripts.
+- **Task moves now sync coordination metadata** (KIT-0040 F2) —
+  `./scripts/core/project move|start|complete|block` rewrites the moved
+  task's numbered-folder path in `.kit/context/agent-handoffs.json` and
+  the task's `HANDOFF-*.md` files, so status moves no longer strand stale
+  paths for CodeRabbit to flag. Re-running a move for a task already in
+  place doubles as a metadata repair.
 
 - **Pull-based consumer sync — one engine, two callers** (KIT-0036,
   KIT-ADR-0026). Core scripts sync (Channel B) gains a consumer-initiated

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -136,7 +136,9 @@ def _sync_coordination_metadata(
                 meta_file.write_text(updated, encoding="utf-8")
                 rel = meta_file.relative_to(project_dir)
                 print(f"🔗 Updated task path in {rel}")
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
+            # UnicodeDecodeError is a ValueError, not an OSError — a
+            # non-UTF-8 coordination file must warn, not break the move.
             print(f"⚠️  Could not update {meta_file.name}: {e}")
 
 

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -104,6 +104,42 @@ def update_status_in_file(file_path: Path, new_status: str) -> bool:
         return False
 
 
+def _sync_coordination_metadata(
+    task_id: str, file_name: str, target_folder: str, project_dir: Path
+) -> None:
+    """Rewrite the moved task's path in coordination metadata (KIT-0040 F2).
+
+    A status move changes the task file's numbered folder, stranding stale
+    paths in .kit/context/agent-handoffs.json (details_link/handoff_file
+    values) and the task's HANDOFF-*.md files; CodeRabbit flags the drift
+    on every move. Only strings matching
+    .kit/tasks/<status-folder>/<this task's file name> are rewritten —
+    nothing else is touched. Failures warn and never block the already
+    completed move (CLI-layer error strategy).
+    """
+    context_dir = project_dir / ".kit" / "context"
+    if not context_dir.is_dir():
+        return
+
+    pattern = re.compile(r"\.kit/tasks/[0-9]+-[a-z-]+/" + re.escape(file_name))
+    new_path = f".kit/tasks/{target_folder}/{file_name}"
+
+    targets = [context_dir / "agent-handoffs.json"]
+    targets.extend(sorted(context_dir.glob(f"{task_id.upper()}-HANDOFF-*.md")))
+    for meta_file in targets:
+        if not meta_file.is_file():
+            continue
+        try:
+            content = meta_file.read_text(encoding="utf-8")
+            updated = pattern.sub(new_path, content)
+            if updated != content:
+                meta_file.write_text(updated, encoding="utf-8")
+                rel = meta_file.relative_to(project_dir)
+                print(f"🔗 Updated task path in {rel}")
+        except OSError as e:
+            print(f"⚠️  Could not update {meta_file.name}: {e}")
+
+
 def move_task(task_id: str, target_status: str, project_dir: Path) -> bool:
     """Move a task to a new folder and update its Status field."""
     # Normalize target status
@@ -130,6 +166,9 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> bool:
         print(f"ℹ️  Task already in {target_folder}")
         # Still update status field if needed
         update_status_in_file(task_file, linear_status)
+        # Re-running a move doubles as a repair action for metadata that
+        # drifted out of sync with the task's folder.
+        _sync_coordination_metadata(task_id, task_file.name, target_folder, project_dir)
         return True
 
     # Move file
@@ -146,6 +185,8 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> bool:
     # Update status field
     if update_status_in_file(target_path, linear_status):
         print(f"✏️  Updated: **Status**: {linear_status}")
+
+    _sync_coordination_metadata(task_id, target_path.name, target_folder, project_dir)
 
     print(f"✅ Task {task_id} is now {linear_status}")
     return True

--- a/scripts/local/kit_markers.py
+++ b/scripts/local/kit_markers.py
@@ -77,10 +77,15 @@ def _begin_marker_line_re(name: str) -> re.Pattern[str]:
     parsing tolerates is still *detected* and merge fails fast instead of
     silently clobbering the region's content with a placeholder. Line-
     anchored so a prose sentence mentioning a marker never matches.
+
+    The name must end after *esc*: (?!-?\\w) rejects a continuation like
+    "-extra" or "2" (a \\b alone would match at the t→- boundary of a
+    hyphenated name, tripping the check for prefix-named sibling regions)
+    while still allowing whitespace, "-->", or end-of-line after the name.
     """
     esc = re.escape(name)
     return re.compile(
-        r"^[ \t]*<!--[ \t]*BEGIN[ \t]+KIT-LOCAL\b[ \t]*:?[ \t]*" + esc + r"\b",
+        r"^[ \t]*<!--[ \t]*BEGIN[ \t]+KIT-LOCAL\b[ \t]*:?[ \t]*" + esc + r"(?!-?\w)",
         re.MULTILINE | re.IGNORECASE,
     )
 

--- a/scripts/local/kit_markers.py
+++ b/scripts/local/kit_markers.py
@@ -36,7 +36,15 @@ import re
 import sys
 from pathlib import Path
 
-BEGIN_RE = re.compile(r"<!-- BEGIN KIT-LOCAL: (?P<name>\S+) -->")
+# Markers are matched as whole lines, tolerating benign whitespace drift
+# inside the comment ([ \t] only — never \s, so tolerance can't cross a
+# line break). A consumer whose marker gained an extra space must still
+# parse: treating its region as absent would silently replace customized
+# content with placeholders on re-bootstrap.
+BEGIN_RE = re.compile(
+    r"^[ \t]*<!--[ \t]*BEGIN[ \t]+KIT-LOCAL:[ \t]*(?P<name>\S+?)[ \t]*-->[ \t]*\r?$",
+    re.MULTILINE,
+)
 
 
 def _region_pattern(name: str) -> re.Pattern[str]:
@@ -44,17 +52,36 @@ def _region_pattern(name: str) -> re.Pattern[str]:
 
     Group 'body' is everything between the newline after BEGIN and the
     newline before END — never the marker lines themselves — so an
-    extract/replace round-trip is byte-identical.
+    extract/replace round-trip is byte-identical. Drifted marker lines are
+    captured and re-emitted verbatim, never normalized.
     """
     esc = re.escape(name)
     # \r?\n so files with CRLF line endings (Windows / git autocrlf) parse
     # too. The newline is captured inside begin/end and re-emitted verbatim,
     # and the body group is preserved byte-for-byte regardless of ending.
     return re.compile(
-        r"(?P<begin><!-- BEGIN KIT-LOCAL: " + esc + r" -->\r?\n)"
+        r"(?P<begin>^[ \t]*<!--[ \t]*BEGIN[ \t]+KIT-LOCAL:[ \t]*"
+        + esc
+        + r"[ \t]*-->[ \t]*\r?\n)"
         r"(?P<body>.*?)"
-        r"(?P<end>\r?\n<!-- END KIT-LOCAL: " + esc + r" -->)",
-        re.DOTALL,
+        r"(?P<end>\r?\n[ \t]*<!--[ \t]*END[ \t]+KIT-LOCAL:[ \t]*" + esc + r"[ \t]*-->)",
+        re.DOTALL | re.MULTILINE,
+    )
+
+
+def _begin_marker_line_re(name: str) -> re.Pattern[str]:
+    """Loose, line-anchored detector for a BEGIN marker of region *name*.
+
+    Deliberately looser than the parse patterns (case-insensitive, colon
+    optional, no closing --> required) so a marker damaged beyond what
+    parsing tolerates is still *detected* and merge fails fast instead of
+    silently clobbering the region's content with a placeholder. Line-
+    anchored so a prose sentence mentioning a marker never matches.
+    """
+    esc = re.escape(name)
+    return re.compile(
+        r"^[ \t]*<!--[ \t]*BEGIN[ \t]+KIT-LOCAL\b[ \t]*:?[ \t]*" + esc + r"\b",
+        re.MULTILINE | re.IGNORECASE,
     )
 
 
@@ -117,14 +144,17 @@ def merge(
     for name in find_regions(upstream):
         if consumer is not None:
             preserved = extract_region(consumer, name)
-            if preserved is None and f"<!-- BEGIN KIT-LOCAL: {name} -->" in consumer:
-                # Marker opened but not parseable (e.g. END edited away).
-                # Fail fast rather than silently clobber the consumer's
-                # trapped content with a placeholder on re-bootstrap.
+            if preserved is None and _begin_marker_line_re(name).search(consumer):
+                # A line looks like this region's BEGIN marker but the
+                # region is not parseable (END edited away, marker damaged
+                # beyond whitespace tolerance). Fail fast rather than
+                # silently clobber the consumer's trapped content with a
+                # placeholder on re-bootstrap. Line-anchored, so a prose
+                # mention of a marker inside another region never trips it.
                 raise ValueError(
                     f"malformed KIT-LOCAL region in consumer file: {name} "
-                    "(BEGIN marker present but region not parseable — "
-                    "missing or mismatched END marker?)"
+                    "(BEGIN marker line present but region not parseable — "
+                    "missing/mismatched END marker or damaged BEGIN marker?)"
                 )
             if preserved is not None:
                 result = replace_region(result, name, preserved)

--- a/tests/test_kit_markers.py
+++ b/tests/test_kit_markers.py
@@ -85,6 +85,19 @@ class TestReplaceRegion:
         with pytest.raises(KeyError):
             km.replace_region(SAMPLE, "nope", "x")
 
+    def test_drifted_marker_round_trip_is_byte_identical(self):
+        # Whitespace-drifted markers are tolerated (KIT-0040) but must
+        # still round-trip byte-for-byte — the drifted marker lines are
+        # captured and re-emitted verbatim, never normalized.
+        drifted = (
+            "<!--  BEGIN  KIT-LOCAL: r -->\n"
+            "body line\n"
+            "  <!-- END KIT-LOCAL: r  -->\n"
+        )
+        body = km.extract_region(drifted, "r")
+        assert body == "body line"
+        assert km.replace_region(drifted, "r", body) == drifted
+
     def test_replaces_every_occurrence_of_a_name(self):
         # A malformed file with two same-named regions: both must update,
         # not just the first (no silent skip).
@@ -149,6 +162,84 @@ class TestMerge:
         assert km.extract_region(crlf, "project-context") == "CRLF KEEP"
         out = km.merge(SAMPLE, consumer=crlf, placeholders=None)
         assert km.extract_region(out, "project-context") == "CRLF KEEP"
+
+    def test_prose_mention_of_begin_marker_does_not_abort(self):
+        # KIT-0040 regression (BugBot on PR #58, finding 1): a consumer whose
+        # preserved region merely *mentions* another region's BEGIN marker in
+        # prose must not trip the malformed check for that other region —
+        # the absent region seeds from its placeholder instead of aborting
+        # bootstrap-consumer.sh.
+        consumer = (
+            "# consumer agent\n"
+            "\n"
+            "<!-- BEGIN KIT-LOCAL: project-context -->\n"
+            "Docs note: keep the `<!-- BEGIN KIT-LOCAL: stack-notes -->` "
+            "marker intact when editing.\n"
+            "<!-- END KIT-LOCAL: project-context -->\n"
+        )
+        out = km.merge(
+            SAMPLE,
+            consumer=consumer,
+            placeholders={"project-context": "PH-PC", "stack-notes": "PH-SN"},
+        )
+        # project-context preserved from the consumer, stack-notes seeded.
+        assert "marker intact when editing." in km.extract_region(
+            out, "project-context"
+        )
+        assert km.extract_region(out, "stack-notes") == "PH-SN"
+
+    def test_whitespace_drifted_marker_still_preserves_content(self):
+        # KIT-0040 regression (BugBot on PR #58, finding 2): benign
+        # whitespace drift inside a marker line must not make the region
+        # unparseable — that silently replaced customized content with
+        # placeholder TODO text on re-bootstrap.
+        consumer = (
+            "<!--  BEGIN  KIT-LOCAL:  project-context  -->\n"
+            "CUSTOMIZED CONSUMER CONTENT\n"
+            "<!-- END KIT-LOCAL:\tproject-context -->\n"
+        )
+        assert km.extract_region(consumer, "project-context") == (
+            "CUSTOMIZED CONSUMER CONTENT"
+        )
+        out = km.merge(
+            SAMPLE,
+            consumer=consumer,
+            placeholders={"project-context": "PH-PC", "stack-notes": "PH-SN"},
+        )
+        assert km.extract_region(out, "project-context") == (
+            "CUSTOMIZED CONSUMER CONTENT"
+        )
+
+    def test_marker_drift_beyond_tolerance_fails_fast(self):
+        # Drift the whitespace tolerance can't absorb (here: lowercased
+        # keywords) must raise, never silently seed a placeholder over the
+        # consumer's customized content.
+        consumer = (
+            "<!-- begin kit-local: project-context -->\n"
+            "CUSTOMIZED CONSUMER CONTENT\n"
+            "<!-- end kit-local: project-context -->\n"
+        )
+        with pytest.raises(ValueError, match="malformed KIT-LOCAL region"):
+            km.merge(
+                SAMPLE,
+                consumer=consumer,
+                placeholders={"project-context": "PH-PC"},
+            )
+
+    def test_missing_colon_marker_fails_fast(self):
+        # A marker edited past parseability (colon dropped) is detected by
+        # the loose malformed check and fails fast.
+        consumer = (
+            "<!-- BEGIN KIT-LOCAL project-context -->\n"
+            "CUSTOMIZED CONSUMER CONTENT\n"
+            "<!-- END KIT-LOCAL project-context -->\n"
+        )
+        with pytest.raises(ValueError, match="malformed KIT-LOCAL region"):
+            km.merge(
+                SAMPLE,
+                consumer=consumer,
+                placeholders={"project-context": "PH-PC"},
+            )
 
     def test_markerless_consumer_falls_back_to_placeholder(self):
         # A consumer stuck on a pre-consolidation agent has no markers;

--- a/tests/test_kit_markers.py
+++ b/tests/test_kit_markers.py
@@ -188,6 +188,25 @@ class TestMerge:
         )
         assert km.extract_region(out, "stack-notes") == "PH-SN"
 
+    def test_prefix_named_region_does_not_trip_malformed_check(self):
+        # KIT-0040 evaluator finding: a well-formed consumer region whose
+        # name merely *extends* an upstream region's name (project-context
+        # vs project-context-extra) must not trip the malformed check for
+        # the shorter name — \b after a hyphenated name matches at the
+        # t→- boundary, so the detector needs a stricter name terminator.
+        consumer = (
+            "<!-- BEGIN KIT-LOCAL: project-context-extra -->\n"
+            "extension region content\n"
+            "<!-- END KIT-LOCAL: project-context-extra -->\n"
+        )
+        out = km.merge(
+            SAMPLE,
+            consumer=consumer,
+            placeholders={"project-context": "PH-PC", "stack-notes": "PH-SN"},
+        )
+        assert km.extract_region(out, "project-context") == "PH-PC"
+        assert km.extract_region(out, "stack-notes") == "PH-SN"
+
     def test_whitespace_drifted_marker_still_preserves_content(self):
         # KIT-0040 regression (BugBot on PR #58, finding 2): benign
         # whitespace drift inside a marker line must not make the region

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -1,0 +1,417 @@
+"""Stub-`gh` regression harness for scripts/core/preflight-check.sh (KIT-0040 F1).
+
+Runs the REAL preflight script against canned `gh` payloads: a fake `gh`
+executable on PATH dispatches on argv and serves per-scenario files, while
+a throwaway git repo provides real branch/SHA state. This turns the
+KIT-0034 manual stub-`gh` verification matrix (8 states) into CI
+regression coverage. The script itself stays shell + gh (KIT-0034 N2) —
+only the harness is Python.
+
+API-shape facts the canned payloads model (verified in KIT-0034):
+- CodeRabbit reports via the legacy commit-status API (Gate 2 fallback
+  primary source); check-runs are its secondary source.
+- BugBot (cursor) reports via check-runs when it has no findings.
+
+The stub-`gh` pattern is reusable for other shell+gh scripts: write
+canned payload files, point the stub's data dir at them, run the real
+script with the stub bin dir prepended to PATH.
+
+Everything runs against temp dirs with a cleaned git environment (N1) —
+see the GIT_DIR gotcha in .kit/context/workflows/TESTING-WORKFLOW.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = REPO_ROOT / "scripts" / "core" / "preflight-check.sh"
+_TARGET_REPO_LIB = REPO_ROOT / "scripts" / "core" / "lib" / "target_repo.sh"
+
+if not _SCRIPT.exists():
+    pytest.skip(
+        "preflight-check.sh not present in this checkout", allow_module_level=True
+    )
+
+for tool in ("bash", "git", "jq"):
+    if shutil.which(tool) is None:
+        pytest.skip(f"{tool} not available on PATH", allow_module_level=True)
+
+
+HEAD_TASK = "KIT-9999"
+OLD_SHA = "deadbeef" * 5  # a SHA no canned run/review maps to HEAD
+
+# The stub serves canned payloads from $PREFLIGHT_GH_STUB_DIR, keyed by
+# the shape of the gh call. "<key>.out present" -> cat it, exit with
+# <key>.rc (default 0). "<key>.out absent" -> exit 1 (models a gh error;
+# the script wraps these calls in `|| true` / $? checks).
+STUB_GH = textwrap.dedent("""\
+    #!/bin/bash
+    emit() {
+        dir="$PREFLIGHT_GH_STUB_DIR"
+        if [ -f "$dir/$1.out" ]; then
+            cat "$dir/$1.out"
+            rc=0
+            [ -f "$dir/$1.rc" ] && rc=$(cat "$dir/$1.rc")
+            exit "$rc"
+        fi
+        exit 1
+    }
+
+    all_args="$*"
+    case "$1 $2" in
+        "auth status") exit 0 ;;
+        "repo view") echo "stub-owner/stub-repo"; exit 0 ;;
+        "pr view")
+            case "$all_args" in
+                *headRefOid*) emit pr_view_head ;;
+                *) emit pr_view_number ;;
+            esac ;;
+        "run list") emit run_list ;;
+        "api graphql") emit graphql ;;
+        api\\ *)
+            case "$2" in
+                */status) emit commit_status ;;
+                */check-runs)
+                    case "$all_args" in
+                        *coderabbit*) emit check_runs_coderabbit ;;
+                        *cursor*) emit check_runs_cursor ;;
+                    esac ;;
+            esac
+            exit 1 ;;
+    esac
+    echo "stub gh: unhandled call: $all_args" >&2
+    exit 1
+    """)
+
+# `sleep` is stubbed so the CI poll loop's retry delays are instant;
+# `dispatch` is stubbed so the fire-and-forget progress event can never
+# reach a real event log from a test run (N1).
+STUB_NOOP = "#!/bin/bash\nexit 0\n"
+
+
+def _clean_env(extra: dict[str, str]) -> dict[str, str]:
+    """Subprocess env with inherited GIT_* location vars stripped (N1).
+
+    Ambient GIT_DIR / GIT_WORK_TREE (set e.g. by pre-commit) would point
+    git at the real repo instead of the temp one. Global/system git
+    config is disabled so host config can't alter behavior.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    env.update(extra)
+    return env
+
+
+class PreflightProject:
+    """Temp project skeleton around the real preflight-check.sh."""
+
+    def __init__(self, root: Path, stub_data: Path, env: dict[str, str], head: str):
+        self.root = root
+        self.stub_data = stub_data
+        self.env = env
+        self.head = head
+
+    def run(self, files: dict[str, str]) -> subprocess.CompletedProcess:
+        # The project fixture is module-scoped (the git repo and .kit
+        # artifacts are read-only during a run); the canned payloads are
+        # per-scenario, so wipe leftovers from the previous test first.
+        for stale in self.stub_data.iterdir():
+            stale.unlink()
+        for key, content in files.items():
+            (self.stub_data / f"{key}.out").write_text(content, encoding="utf-8")
+        return subprocess.run(
+            [
+                "bash",
+                str(self.root / "scripts" / "core" / "preflight-check.sh"),
+                "--pr",
+                "42",
+            ],
+            cwd=self.root,
+            env=self.env,
+            capture_output=True,
+            text=True,
+        )
+
+
+def _gates(output: str) -> dict[int, tuple[str, str]]:
+    """Parse GATE:<n>:<name>:<verdict>:<detail> lines into {n: (verdict, detail)}."""
+    parsed: dict[int, tuple[str, str]] = {}
+    for line in output.splitlines():
+        m = re.match(r"^GATE:(\d+):[^:]*:(PASS|FAIL|PENDING):(.*)$", line)
+        if m:
+            parsed[int(m.group(1))] = (m.group(2), m.group(3))
+    return parsed
+
+
+@pytest.fixture(scope="module")
+def proj(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("preflight")
+    root = tmp_path / "proj"
+    core = root / "scripts" / "core"
+    (core / "lib").mkdir(parents=True)
+    shutil.copy(_SCRIPT, core / "preflight-check.sh")
+    shutil.copy(_TARGET_REPO_LIB, core / "lib" / "target_repo.sh")
+
+    # Gate 5/6/7 artifacts — green by default so gate-1-to-4 scenarios
+    # can assert overall exit codes.
+    (root / ".kit" / "context" / "reviews").mkdir(parents=True)
+    (root / ".kit" / "tasks" / "3-in-progress").mkdir(parents=True)
+    (root / ".kit" / "tasks" / "4-in-review").mkdir(parents=True)
+    reviews = root / ".kit" / "context" / "reviews"
+    (reviews / f"{HEAD_TASK}-code-review.md").write_text("review\n", encoding="utf-8")
+    starter = root / ".kit" / "context" / f"{HEAD_TASK}-REVIEW-STARTER.md"
+    starter.write_text("starter\n", encoding="utf-8")
+    task = root / ".kit" / "tasks" / "3-in-progress" / f"{HEAD_TASK}-stub-task.md"
+    task.write_text("task\n", encoding="utf-8")
+
+    env = _clean_env({})
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", *args], cwd=root, env=env, check=True, capture_output=True
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@t")
+    git("config", "user.name", "t")
+    (root / "README.md").write_text("seed\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "seed")
+    git("update-ref", "refs/remotes/origin/main", "main")
+    git("checkout", "-q", "-b", f"feature/{HEAD_TASK}-stub")
+    (root / "code.py").write_text("x = 1\n", encoding="utf-8")
+    git("add", "code.py")
+    git("commit", "-qm", "feat: code change")
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    bin_dir = tmp_path / "stub-bin"
+    bin_dir.mkdir()
+    for name, body in (("gh", STUB_GH), ("sleep", STUB_NOOP), ("dispatch", STUB_NOOP)):
+        stub = bin_dir / name
+        stub.write_text(body, encoding="utf-8")
+        stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    stub_data = tmp_path / "stub-data"
+    stub_data.mkdir()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["PREFLIGHT_GH_STUB_DIR"] = str(stub_data)
+
+    return PreflightProject(root, stub_data, env, head)
+
+
+# ── Canned payload builders ──────────────────────────────────────────────
+def _review(login: str, state: str, oid: str) -> dict:
+    return {"author": {"login": login}, "state": state, "commit": {"oid": oid}}
+
+
+def _graphql(reviews: list[dict], unresolved: int = 0, resolved: int = 0) -> str:
+    threads = [{"isResolved": True}] * resolved + [{"isResolved": False}] * unresolved
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviews": {"nodes": reviews},
+                        "reviewThreads": {"nodes": threads},
+                    }
+                }
+            }
+        }
+    )
+
+
+def _run_entry(
+    head: str,
+    status: str = "completed",
+    conclusion: str = "success",
+    name: str = "Tests",
+) -> dict:
+    return {
+        "status": status,
+        "conclusion": conclusion,
+        "workflowName": name,
+        "event": "push",
+        "headSha": head,
+    }
+
+
+def _baseline(head: str) -> dict[str, str]:
+    """Everything green via the primary paths: CI success on HEAD,
+    CodeRabbit review event on HEAD, BugBot review event on HEAD."""
+    return {
+        "pr_view_head": head + "\n",
+        "run_list": json.dumps([_run_entry(head)]),
+        "graphql": _graphql(
+            [
+                _review("coderabbitai[bot]", "APPROVED", head),
+                _review("cursor[bot]", "COMMENTED", head),
+            ],
+            resolved=2,
+        ),
+    }
+
+
+# ── Baseline ─────────────────────────────────────────────────────────────
+class TestBaseline:
+    def test_all_gates_pass_exit_0(self, proj):
+        result = proj.run(_baseline(proj.head))
+        gates = _gates(result.stdout)
+        assert {n: v for n, (v, _) in gates.items()} == {
+            n: "PASS" for n in range(1, 8)
+        }, (result.stdout + result.stderr)
+        assert result.returncode == 0
+
+
+# ── Gate 1: CI ───────────────────────────────────────────────────────────
+class TestGate1CI:
+    def test_completed_failure_beats_running_sibling(self, proj):
+        # KIT-0034 N3 precedence: a completed non-success run FAILs the
+        # gate even while a sibling workflow is still executing.
+        files = _baseline(proj.head)
+        files["run_list"] = json.dumps(
+            [
+                _run_entry(proj.head, status="in_progress", conclusion="", name="Slow"),
+                _run_entry(proj.head, conclusion="failure", name="Lint"),
+            ]
+        )
+        result = proj.run(files)
+        verdict, detail = _gates(result.stdout)[1]
+        assert verdict == "FAIL", result.stdout
+        assert "failure" in detail
+        assert result.returncode == 1
+
+    def test_gh_error_fails_not_pending(self, proj):
+        # `gh run list` erroring on every attempt is a connectivity/auth
+        # problem — fail closed, don't report PENDING.
+        files = _baseline(proj.head)
+        del files["run_list"]  # absent canned file -> stub gh exits 1
+        result = proj.run(files)
+        verdict, detail = _gates(result.stdout)[1]
+        assert verdict == "FAIL", result.stdout
+        assert "Could not fetch CI runs" in detail
+        assert result.returncode == 1
+
+    def test_empty_run_list_is_pending_exit_2(self, proj):
+        # Runs not registered yet for the head SHA: PENDING (not FAIL),
+        # and with every other gate green the script exits 2.
+        files = _baseline(proj.head)
+        files["run_list"] = "[]"
+        result = proj.run(files)
+        verdict, detail = _gates(result.stdout)[1]
+        assert verdict == "PENDING", result.stdout
+        assert "No CI runs registered" in detail
+        assert result.returncode == 2
+
+
+# ── Gate 2: CodeRabbit (fallback matrix) ─────────────────────────────────
+class TestGate2CodeRabbit:
+    def _no_head_review(self, head: str, cr_state: str = "APPROVED") -> dict[str, str]:
+        # CodeRabbit review event exists only on an OLD sha, so the
+        # primary SHA match misses and the fallback logic decides.
+        files = _baseline(head)
+        files["graphql"] = _graphql(
+            [
+                _review("coderabbitai[bot]", cr_state, OLD_SHA),
+                _review("cursor[bot]", "COMMENTED", head),
+            ]
+        )
+        return files
+
+    def test_fallback_pass_on_commit_status(self, proj):
+        # KIT-0034 F1: commit status green + latest review APPROVED +
+        # 0 unresolved threads = reviewed, even with no review event on
+        # the head SHA. CodeRabbit's primary signal is the commit-status
+        # API, not check-runs.
+        files = self._no_head_review(proj.head)
+        files["commit_status"] = "success\n"
+        result = proj.run(files)
+        verdict, detail = _gates(result.stdout)[2]
+        assert verdict == "PASS", result.stdout
+        assert "fallback" in detail
+        assert result.returncode == 0
+
+    def test_fallback_pass_on_check_run_source(self, proj):
+        # Secondary source: empty commit status but a green CodeRabbit
+        # check-run still satisfies the fallback.
+        files = self._no_head_review(proj.head)
+        files["commit_status"] = ""  # gh succeeds, no matching contexts
+        files["check_runs_coderabbit"] = "success\n"
+        result = proj.run(files)
+        verdict, detail = _gates(result.stdout)[2]
+        assert verdict == "PASS", result.stdout
+        assert "fallback" in detail
+
+    def test_no_review_fails(self, proj):
+        # No CodeRabbit review event anywhere and no signal on the head
+        # SHA: the gate fails closed.
+        files = _baseline(proj.head)
+        files["graphql"] = _graphql([_review("cursor[bot]", "COMMENTED", proj.head)])
+        result = proj.run(files)
+        verdict, detail = _gates(result.stdout)[2]
+        assert verdict == "FAIL", result.stdout
+        assert "No review from coderabbitai[bot]" in detail
+        assert result.returncode == 1
+
+    def test_unresolved_thread_blocks_fallback(self, proj):
+        # N1 fail-closed: signal green + APPROVED, but one unresolved
+        # thread blocks the fallback (and Gate 4 agrees — same snapshot).
+        files = _baseline(proj.head)
+        files["graphql"] = _graphql(
+            [
+                _review("coderabbitai[bot]", "APPROVED", OLD_SHA),
+                _review("cursor[bot]", "COMMENTED", proj.head),
+            ],
+            unresolved=1,
+        )
+        files["commit_status"] = "success\n"
+        result = proj.run(files)
+        gates = _gates(result.stdout)
+        assert gates[2][0] == "FAIL", result.stdout
+        assert gates[4][0] == "FAIL"
+        assert result.returncode == 1
+
+    def test_changes_requested_blocks_fallback(self, proj):
+        # N1 fail-closed: a CHANGES_REQUESTED latest verdict blocks the
+        # fallback even with a green signal and zero unresolved threads.
+        files = self._no_head_review(proj.head, cr_state="CHANGES_REQUESTED")
+        files["commit_status"] = "success\n"
+        result = proj.run(files)
+        verdict, detail = _gates(result.stdout)[2]
+        assert verdict == "FAIL", result.stdout
+        assert "CHANGES_REQUESTED" in detail
+        assert result.returncode == 1
+
+
+# ── Gate 3: BugBot ───────────────────────────────────────────────────────
+class TestGate3BugBot:
+    def test_check_run_pass_when_no_review_event(self, proj):
+        # BugBot's no-findings case: no review event, a green cursor
+        # check-run on the code SHA satisfies the gate.
+        files = _baseline(proj.head)
+        files["graphql"] = _graphql(
+            [_review("coderabbitai[bot]", "APPROVED", proj.head)]
+        )
+        files["check_runs_cursor"] = "completed:success\n"
+        result = proj.run(files)
+        verdict, detail = _gates(result.stdout)[3]
+        assert verdict == "PASS", result.stdout
+        assert "check-run" in detail
+        assert result.returncode == 0

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -991,3 +991,20 @@ class TestMoveTaskMetadataSync:
         assert data["planner"]["details_link"] == (
             f".kit/tasks/5-done/{self.TASK_FILE}"
         )
+
+    def test_non_utf8_metadata_warns_but_move_succeeds(self, tmp_path, capsys):
+        # A corrupted (non-UTF-8) coordination file must warn, never
+        # break the already completed move (UnicodeDecodeError is a
+        # ValueError, not an OSError).
+        context = self._setup_project(tmp_path)
+        (context / "agent-handoffs.json").write_bytes(b"\xff\xfe broken")
+
+        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
+
+        out = capsys.readouterr().out
+        assert "Could not update agent-handoffs.json" in out
+        # The parseable handoff file was still rewritten.
+        handoff_md = (context / "KIT-1234-HANDOFF-feature-developer.md").read_text(
+            encoding="utf-8"
+        )
+        assert f".kit/tasks/3-in-progress/{self.TASK_FILE}" in handoff_md

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -5,6 +5,7 @@ Focus: install-evaluators command with mocked subprocess calls.
 """
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -888,3 +889,105 @@ class TestVerifyIdentityLeaks:
         verify = _project_module._verify_identity_leaks
         count = verify(tmp_path)
         assert count == 0
+
+
+class TestMoveTaskMetadataSync:
+    """KIT-0040 F2: task moves rewrite the task's path in coordination
+    metadata (agent-handoffs.json + HANDOFF files) instead of stranding
+    stale numbered-folder paths."""
+
+    TASK_FILE = "KIT-1234-sample-task.md"
+
+    def _setup_project(self, tmp_path):
+        tasks = tmp_path / ".kit" / "tasks"
+        for folder in ("2-todo", "3-in-progress", "5-done"):
+            (tasks / folder).mkdir(parents=True)
+        task = tasks / "2-todo" / self.TASK_FILE
+        task.write_text("# Task\n\n**Status**: Todo\n", encoding="utf-8")
+
+        context = tmp_path / ".kit" / "context"
+        context.mkdir(parents=True)
+        handoffs = {
+            "planner": {
+                "status": "handoff_ready",
+                "current_task": "KIT-1234",
+                "details_link": f".kit/tasks/2-todo/{self.TASK_FILE}",
+                "handoff_file": ".kit/context/KIT-1234-HANDOFF-feature-developer.md",
+            },
+            "other-agent": {
+                "status": "idle",
+                "current_task": None,
+                "details_link": ".kit/tasks/2-todo/KIT-0002-unrelated-task.md",
+            },
+        }
+        (context / "agent-handoffs.json").write_text(
+            json.dumps(handoffs, indent=2) + "\n", encoding="utf-8"
+        )
+        (context / "KIT-1234-HANDOFF-feature-developer.md").write_text(
+            f"# Handoff\n\n**Task**: `.kit/tasks/2-todo/{self.TASK_FILE}`\n",
+            encoding="utf-8",
+        )
+        return context
+
+    def test_move_rewrites_handoffs_json_and_handoff_file(self, tmp_path):
+        context = self._setup_project(tmp_path)
+
+        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        assert data["planner"]["details_link"] == (
+            f".kit/tasks/3-in-progress/{self.TASK_FILE}"
+        )
+        handoff_md = (context / "KIT-1234-HANDOFF-feature-developer.md").read_text(
+            encoding="utf-8"
+        )
+        assert f".kit/tasks/3-in-progress/{self.TASK_FILE}" in handoff_md
+        assert "2-todo" not in handoff_md
+
+    def test_move_leaves_other_tasks_untouched(self, tmp_path):
+        context = self._setup_project(tmp_path)
+
+        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        # The unrelated task's (stale-looking) path must be preserved.
+        assert data["other-agent"]["details_link"] == (
+            ".kit/tasks/2-todo/KIT-0002-unrelated-task.md"
+        )
+
+    def test_move_without_context_dir_still_succeeds(self, tmp_path):
+        tasks = tmp_path / ".kit" / "tasks"
+        for folder in ("2-todo", "3-in-progress"):
+            (tasks / folder).mkdir(parents=True)
+        (tasks / "2-todo" / self.TASK_FILE).write_text(
+            "**Status**: Todo\n", encoding="utf-8"
+        )
+
+        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
+        assert (tasks / "3-in-progress" / self.TASK_FILE).exists()
+
+    def test_rerun_in_same_folder_repairs_stale_metadata(self, tmp_path):
+        # Metadata drifted while the task is already in place: re-running
+        # the move acts as a repair and rewrites the stale path.
+        context = self._setup_project(tmp_path)
+        task = tmp_path / ".kit" / "tasks" / "2-todo" / self.TASK_FILE
+        moved = tmp_path / ".kit" / "tasks" / "3-in-progress" / self.TASK_FILE
+        task.rename(moved)
+
+        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        assert data["planner"]["details_link"] == (
+            f".kit/tasks/3-in-progress/{self.TASK_FILE}"
+        )
+
+    def test_second_move_rewrites_again(self, tmp_path):
+        context = self._setup_project(tmp_path)
+
+        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
+        assert _project_module.move_task("KIT-1234", "done", tmp_path)
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        assert data["planner"]["details_link"] == (
+            f".kit/tasks/5-done/{self.TASK_FILE}"
+        )


### PR DESCRIPTION
## Summary

Clears the KIT-0034 retro debt (task: `.kit/tasks/3-in-progress/KIT-0040-kit-0034-retro-followups.md`), F3 first per the planner's sequencing decision.

- **F3 — `kit_markers.py` bug fixes** (the two BugBot findings open on PR #58 since the KIT-0033 merge):
  - Prose mentions of a BEGIN marker inside another preserved region no longer abort re-bootstrap — the malformed check is line-anchored, not a raw substring test.
  - Whitespace-drifted marker lines now parse (within-line `[ \t]` tolerance only), so customized consumer content is preserved instead of silently replaced with placeholder TODO text. Drift beyond the tolerance is detected by a deliberately looser line-anchored check and **fails fast** — nothing falls between the two detection paths. Byte-preserving round-trip retained, drifted markers re-emitted verbatim.
- **F1 — stub-`gh` pytest harness** (`tests/test_preflight_check.py`): runs the *real* `preflight-check.sh` against canned `gh` payloads across the KIT-0034 8-state matrix (plus a baseline all-pass). Script unchanged (N2); temp dirs + cleaned git env, stubbed `sleep`/`dispatch` (N1); targets `scripts/core/` only so it ships to consumers (N3). Harness verified by mutation testing.
- **F2 — decision: tooling fix** (not the COMMIT-PROTOCOL.md documentation fallback): `project move|start|complete|block` now rewrites the moved task's `.kit/tasks/<folder>/<file>` path in `agent-handoffs.json` and the task's `HANDOFF-*.md` files. Conservative string rewrite scoped to the moved task's file name; warns-and-continues on I/O errors. Re-running a move repairs drifted metadata (used on KIT-0040's own paths in this PR).

## Test plan

- [x] 5 new kit_markers regression tests written first, reproducing both BugBot scenarios (44 pass)
- [x] 10 preflight harness scenarios; mutation test confirms the harness catches a broken gate
- [x] 5 new project-move metadata tests (55 pass in test_project_script.py)
- [x] Full suite green (407 tests), `ci-check.sh` all green
- [x] N3: new kit_markers tests live in the already-excluded `test_kit_markers.py`; `test_preflight_check.py` intentionally ships to consumers

After merge: reply to + resolve the two PR #58 threads with a pointer here (tracked acceptance criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSFuMyFFafwqSxzarfy6o8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consumer re-bootstrap merge logic and automatic metadata rewrites on task moves; scope is conservative and heavily tested, but mistakes could still clobber consumer agent content or rewrite wrong path strings.
> 
> **Overview**
> KIT-0040 closes three KIT-0034 retro items in one PR.
> 
> **`kit_markers.py` (F3)** — Marker parsing and merge behavior are tightened so re-bootstrap is safer. `BEGIN_RE` / `_region_pattern` are **line-anchored** and tolerate benign `[ \t]` drift inside marker lines while still **byte-preserving** drifted markers on round-trip. The malformed-region check no longer uses a raw BEGIN substring (fixes prose mentions aborting bootstrap); it uses `_begin_marker_line_re` with a stricter name terminator `(?!-?\w)` instead of `\b` (fixes false positives on prefix-named regions like `project-context` vs `project-context-extra`). Unparseable but marker-shaped lines still **fail fast** instead of silently applying placeholders.
> 
> **`tests/test_preflight_check.py` (F1)** — New stub-`gh` pytest harness runs the real `preflight-check.sh` in temp repos with canned `gh` payloads, covering the KIT-0034 gate matrix (CI precedence, CodeRabbit fallback, BugBot check-runs, fail-closed paths).
> 
> **`scripts/core/project` (F2)** — `move_task` (and same-folder re-run) calls `_sync_coordination_metadata` to rewrite `.kit/tasks/<numbered-folder>/<task file>` in `agent-handoffs.json` and matching `HANDOFF-*.md` files; I/O/UTF-8 issues warn and do not block the move.
> 
> Regression tests added in `test_kit_markers.py` and `test_project_script.py`; **CHANGELOG** and KIT-0040 review/task metadata updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5adde5e297ea250c74f758edc6d49bb4d815f8d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->