### PR TITLE
fix(KIT-0035): harden upgrade-guide detection greps + re-sync upgrader (PR 2 of 2)

### DIFF
--- a/.claude/agents/upgrader.md
+++ b/.claude/agents/upgrader.md
@@ -89,9 +89,11 @@ surfaced once, at the end, as a post-upgrade hint to run
 ### 0a. Marketplace-source guard (guide § Prerequisites / Gotchas)
 
 ```bash
-# Accept any GitHub-form source line — paren form "GitHub (movito/agentive-skills)"
-# or URL form "https://github.com/movito/agentive-skills", either case:
-claude plugin marketplace list | grep -Ei 'github.*movito/agentive-skills'
+# Accept a GitHub-form Source line — paren form "GitHub (movito/agentive-skills)"
+# or URL form "https://github.com/movito/agentive-skills", either case. The
+# pattern is anchored to the Source field so a local checkout at a path like
+# "Directory (/Users/alice/github/movito/agentive-skills)" cannot slip past:
+claude plugin marketplace list | grep -Ei '^[[:space:]]*source: *(github \(|https://github\.com/)movito/agentive-skills'
 ```
 
 - If the grep matches → the source is GitHub-form → proceed.
@@ -108,9 +110,9 @@ claude plugin marketplace list | grep -Ei 'github.*movito/agentive-skills'
 ### 0b. Already-consuming guard (refuse initial migration)
 
 ```bash
-# Match on the plugin name alone — the row format may render the source
-# as '@agentive-skills' or '(agentive-skills)' across CLI versions:
-claude plugin list | grep -A3 'agentive-workflow'   # must show: enabled
+# Tolerate row-format drift ('@agentive-skills' vs '(agentive-skills)')
+# while excluding similarly-named siblings (e.g. agentive-workflow-beta):
+claude plugin list | grep -A3 -E 'agentive-workflow([@ (]|$)'   # must show: enabled
 ```
 
 - If `agentive-workflow@agentive-skills` is present **and** its status reads
@@ -133,7 +135,7 @@ claude plugin list | grep -A3 'agentive-workflow'   # must show: enabled
 # Scope to the whole Provenance section (a fixed -A window breaks if the
 # pin sits lower in the section; sed stops at the next '## ' header):
 sed -n '/^## Provenance/,/^## /p' CLAUDE.md | grep agentive-workflow   # may be absent
-claude plugin list | grep -A3 'agentive-workflow'
+claude plugin list | grep -A3 -E 'agentive-workflow([@ (]|$)'
 ```
 
 - The authoritative current version is what `claude plugin list` reports.
@@ -289,7 +291,7 @@ Then, if the pre-update gate passes:
 
 ```bash
 claude plugin update agentive-workflow@agentive-skills
-claude plugin list | grep -A3 'agentive-workflow'  # confirm the version advanced to <target>
+claude plugin list | grep -A3 -E 'agentive-workflow([@ (]|$)'  # confirm the version advanced to <target>
 ```
 
 > If the upstream `version` was not bumped, `/plugin update` reports "already at
@@ -361,7 +363,7 @@ rather than creating one — do not introduce CLAUDE.md structure on your own.
 ## PHASE 6 — Verify (guide step 6)
 
 ```bash
-claude plugin list | grep -A3 'agentive-workflow'   # new version, enabled
+claude plugin list | grep -A3 -E 'agentive-workflow([@ (]|$)'   # new version, enabled
 ```
 
 Optional headless probe that namespaced artifacts resolve at the new version,

--- a/.claude/agents/upgrader.md
+++ b/.claude/agents/upgrader.md
@@ -2,9 +2,9 @@
 name: upgrader
 description: Raises a project from one agentive-workflow plugin version to a newer one, and refreshes local agent model: pins on a model rollout. Automates docs/PLUGIN-UPGRADE-GUIDE.md. Ongoing upgrades only — refuses initial migration, script/manifest upgrades, and CLAUDE.md identity edits.
 model: claude-sonnet-5
-version: 1.0.0
+version: 1.1.0
 origin: agentive-starter-kit
-last-updated: 2026-07-03
+last-updated: 2026-07-06
 created-by: "@movito"
 tools:
   - Bash
@@ -89,12 +89,14 @@ surfaced once, at the end, as a post-upgrade hint to run
 ### 0a. Marketplace-source guard (guide § Prerequisites / Gotchas)
 
 ```bash
-claude plugin marketplace list        # Source for agentive-skills must read: GitHub (movito/agentive-skills)
+# Accept any GitHub-form source line — paren form "GitHub (movito/agentive-skills)"
+# or URL form "https://github.com/movito/agentive-skills", either case:
+claude plugin marketplace list | grep -Ei 'github.*movito/agentive-skills'
 ```
 
-- If the `agentive-skills` source reads `GitHub (movito/agentive-skills)` →
-  proceed.
-- If it reads `Directory (...)` → **HALT.** A local directory source serves
+- If the grep matches → the source is GitHub-form → proceed.
+- If it does not match, inspect the full `claude plugin marketplace list`
+  output. If the `agentive-skills` source reads `Directory (...)` → **HALT.** A local directory source serves
   whatever is on disk and defeats version pins. Print the re-point commands for
   **the operator to run** (you cannot edit `settings.json`):
 
@@ -106,7 +108,9 @@ claude plugin marketplace list        # Source for agentive-skills must read: Gi
 ### 0b. Already-consuming guard (refuse initial migration)
 
 ```bash
-claude plugin list | grep -A3 'agentive-workflow@agentive-skills'   # must show: enabled
+# Match on the plugin name alone — the row format may render the source
+# as '@agentive-skills' or '(agentive-skills)' across CLI versions:
+claude plugin list | grep -A3 'agentive-workflow'   # must show: enabled
 ```
 
 - If `agentive-workflow@agentive-skills` is present **and** its status reads
@@ -126,8 +130,10 @@ claude plugin list | grep -A3 'agentive-workflow@agentive-skills'   # must show:
 
 ```bash
 # Current pin — two sources that should agree:
-grep -A8 '## Provenance' CLAUDE.md | grep agentive-workflow      # may be absent
-claude plugin list | grep -A3 'agentive-workflow@agentive-skills'
+# Scope to the whole Provenance section (a fixed -A window breaks if the
+# pin sits lower in the section; sed stops at the next '## ' header):
+sed -n '/^## Provenance/,/^## /p' CLAUDE.md | grep agentive-workflow   # may be absent
+claude plugin list | grep -A3 'agentive-workflow'
 ```
 
 - The authoritative current version is what `claude plugin list` reports.
@@ -212,7 +218,9 @@ Also confirm no **flat** references regressed (they would not resolve now that
 artifacts come from the plugin):
 
 ```bash
-grep -rnoE '(^|[^:A-Za-z/.-])/(preflight|retro|triage-threads|check-ci|check-bots|wrap-up|babysit-pr|wait-for-bots|commit-push-pr|start-task|check-spec|status)([^.A-Za-z]|$)' \
+# -i: catch case-drifted slash-references in prose too (a capitalized
+# command name after a slash would evade a case-sensitive grep)
+grep -rinoE '(^|[^:A-Za-z/.-])/(preflight|retro|triage-threads|check-ci|check-bots|wrap-up|babysit-pr|wait-for-bots|commit-push-pr|start-task|check-spec|status)([^.A-Za-z]|$)' \
   .claude .kit/templates .kit/context/workflows CLAUDE.md
 # expect no output
 ```
@@ -259,7 +267,8 @@ claude plugin marketplace update agentive-skills                   # pull latest
 
 **Pre-update gate: prevent target overshoot.** `claude plugin update` is
 **unpinned** — it installs whatever marketplace-latest is at the moment of the
-call (see L146-149: the Phase 3 update is a fixed string by design). If the
+call (see Phase 1's no-guess rule: the Phase 3 update is a fixed string by
+design). If the
 operator named a target in Phase 1 that differs from marketplace-latest
 (intentional pinning, or a race where latest moved between Phase 1 and now), an
 unpinned update would land on latest rather than the ACK'd target. Re-read
@@ -280,7 +289,7 @@ Then, if the pre-update gate passes:
 
 ```bash
 claude plugin update agentive-workflow@agentive-skills
-claude plugin list | grep -A3 'agentive-workflow@agentive-skills'  # confirm the version advanced to <target>
+claude plugin list | grep -A3 'agentive-workflow'  # confirm the version advanced to <target>
 ```
 
 > If the upstream `version` was not bumped, `/plugin update` reports "already at
@@ -352,7 +361,7 @@ rather than creating one — do not introduce CLAUDE.md structure on your own.
 ## PHASE 6 — Verify (guide step 6)
 
 ```bash
-claude plugin list | grep -A3 'agentive-workflow@agentive-skills'   # new version, enabled
+claude plugin list | grep -A3 'agentive-workflow'   # new version, enabled
 ```
 
 Optional headless probe that namespaced artifacts resolve at the new version,

--- a/.claude/agents/upgrader.md
+++ b/.claude/agents/upgrader.md
@@ -92,8 +92,10 @@ surfaced once, at the end, as a post-upgrade hint to run
 # Accept a GitHub-form Source line — paren form "GitHub (movito/agentive-skills)"
 # or URL form "https://github.com/movito/agentive-skills", either case. The
 # pattern is anchored to the Source field so a local checkout at a path like
-# "Directory (/Users/alice/github/movito/agentive-skills)" cannot slip past:
-claude plugin marketplace list | grep -Ei '^[[:space:]]*source: *(github \(|https://github\.com/)movito/agentive-skills'
+# "Directory (/Users/alice/github/movito/agentive-skills)" cannot slip past,
+# and end-anchored so a similarly named repo (movito/agentive-skills-beta)
+# cannot either:
+claude plugin marketplace list | grep -Ei '^[[:space:]]*source: *(github \(|https://github\.com/)movito/agentive-skills([[:space:]]*\)|$)'
 ```
 
 - If the grep matches → the source is GitHub-form → proceed.

--- a/docs/PLUGIN-UPGRADE-GUIDE.md
+++ b/docs/PLUGIN-UPGRADE-GUIDE.md
@@ -31,9 +31,11 @@ future upgrader agent, or any agent pointed at a project) or by hand.
   not a local directory. Verify:
 
   ```bash
-  # Accept any GitHub-form source line — paren form "GitHub (movito/agentive-skills)"
-  # or URL form "https://github.com/movito/agentive-skills", either case:
-  claude plugin marketplace list | grep -Ei 'github.*movito/agentive-skills'
+  # Accept a GitHub-form Source line — paren form "GitHub (movito/agentive-skills)"
+  # or URL form "https://github.com/movito/agentive-skills", either case. The
+  # pattern is anchored to the Source field so a local checkout at a path like
+  # "Directory (/Users/alice/github/movito/agentive-skills)" cannot slip past:
+  claude plugin marketplace list | grep -Ei '^[[:space:]]*source: *(github \(|https://github\.com/)movito/agentive-skills'
   # match → GitHub-sourced, proceed; no match → inspect the full output
   ```
 
@@ -57,9 +59,9 @@ future upgrader agent, or any agent pointed at a project) or by hand.
 # Scope to the whole Provenance section (a fixed -A window breaks if the
 # pin sits lower in the section; sed stops at the next '## ' header):
 sed -n '/^## Provenance/,/^## /p' CLAUDE.md | grep agentive-workflow
-# Match on the plugin name alone — the list row format may render the
-# source as '@agentive-skills' or '(agentive-skills)' across CLI versions:
-claude plugin list | grep -A3 'agentive-workflow'
+# Tolerate row-format drift ('@agentive-skills' vs '(agentive-skills)')
+# while excluding similarly-named siblings (e.g. agentive-workflow-beta):
+claude plugin list | grep -A3 -E 'agentive-workflow([@ (]|$)'
 ```
 
 Target = the version you intend to land. Either the operator names it, or read
@@ -77,7 +79,7 @@ If current == target, stop — nothing to do.
 ```bash
 claude plugin marketplace update agentive-skills      # pull latest marketplace metadata from GitHub
 claude plugin update agentive-workflow@agentive-skills
-claude plugin list | grep -A3 'agentive-workflow'     # confirm the version advanced
+claude plugin list | grep -A3 -E 'agentive-workflow([@ (]|$)'   # confirm the version advanced
 ```
 
 > The plugin's semver `version` is the cache key. If the upstream version was
@@ -137,7 +139,7 @@ Restamp `CLAUDE.md` `## Provenance`:
 ### 6. Verify
 
 ```bash
-claude plugin list | grep -A3 'agentive-workflow'   # new version, enabled
+claude plugin list | grep -A3 -E 'agentive-workflow([@ (]|$)'   # new version, enabled
 ```
 
 Optionally confirm the namespaced artifacts resolve at the new version with a

--- a/docs/PLUGIN-UPGRADE-GUIDE.md
+++ b/docs/PLUGIN-UPGRADE-GUIDE.md
@@ -34,8 +34,10 @@ future upgrader agent, or any agent pointed at a project) or by hand.
   # Accept a GitHub-form Source line — paren form "GitHub (movito/agentive-skills)"
   # or URL form "https://github.com/movito/agentive-skills", either case. The
   # pattern is anchored to the Source field so a local checkout at a path like
-  # "Directory (/Users/alice/github/movito/agentive-skills)" cannot slip past:
-  claude plugin marketplace list | grep -Ei '^[[:space:]]*source: *(github \(|https://github\.com/)movito/agentive-skills'
+  # "Directory (/Users/alice/github/movito/agentive-skills)" cannot slip past,
+  # and end-anchored so a similarly named repo (movito/agentive-skills-beta)
+  # cannot either:
+  claude plugin marketplace list | grep -Ei '^[[:space:]]*source: *(github \(|https://github\.com/)movito/agentive-skills([[:space:]]*\)|$)'
   # match → GitHub-sourced, proceed; no match → inspect the full output
   ```
 

--- a/docs/PLUGIN-UPGRADE-GUIDE.md
+++ b/docs/PLUGIN-UPGRADE-GUIDE.md
@@ -31,11 +31,14 @@ future upgrader agent, or any agent pointed at a project) or by hand.
   not a local directory. Verify:
 
   ```bash
-  claude plugin marketplace list        # Source should read: GitHub (movito/agentive-skills)
+  # Accept any GitHub-form source line — paren form "GitHub (movito/agentive-skills)"
+  # or URL form "https://github.com/movito/agentive-skills", either case:
+  claude plugin marketplace list | grep -Ei 'github.*movito/agentive-skills'
+  # match → GitHub-sourced, proceed; no match → inspect the full output
   ```
 
-  If it reads `Directory (...)`, it is a dev/spike artifact — re-point it
-  before upgrading:
+  If the source reads `Directory (...)`, it is a dev/spike artifact —
+  re-point it before upgrading:
 
   ```bash
   claude plugin marketplace remove agentive-skills
@@ -51,8 +54,12 @@ future upgrader agent, or any agent pointed at a project) or by hand.
 
 ```bash
 # Current pin (two sources — they should agree):
-grep -A8 '## Provenance' CLAUDE.md | grep agentive-workflow
-claude plugin list | grep -A3 'agentive-workflow@agentive-skills'
+# Scope to the whole Provenance section (a fixed -A window breaks if the
+# pin sits lower in the section; sed stops at the next '## ' header):
+sed -n '/^## Provenance/,/^## /p' CLAUDE.md | grep agentive-workflow
+# Match on the plugin name alone — the list row format may render the
+# source as '@agentive-skills' or '(agentive-skills)' across CLI versions:
+claude plugin list | grep -A3 'agentive-workflow'
 ```
 
 Target = the version you intend to land. Either the operator names it, or read
@@ -70,7 +77,7 @@ If current == target, stop — nothing to do.
 ```bash
 claude plugin marketplace update agentive-skills      # pull latest marketplace metadata from GitHub
 claude plugin update agentive-workflow@agentive-skills
-claude plugin list | grep -A3 'agentive-workflow@agentive-skills'   # confirm the version advanced
+claude plugin list | grep -A3 'agentive-workflow'     # confirm the version advanced
 ```
 
 > The plugin's semver `version` is the cache key. If the upstream version was
@@ -96,7 +103,9 @@ Compare the artifact set before/after (or read the plugin CHANGELOG):
   (they would not resolve now that artifacts come from the plugin):
 
   ```bash
-  grep -rnoE '(^|[^:A-Za-z/.-])/(preflight|retro|triage-threads|check-ci|check-bots|wrap-up|babysit-pr|wait-for-bots|commit-push-pr|start-task|check-spec|status)([^.A-Za-z]|$)' \
+  # -i: catch case-drifted slash-references in prose too (a capitalized
+  # command name after a slash would evade a case-sensitive grep)
+  grep -rinoE '(^|[^:A-Za-z/.-])/(preflight|retro|triage-threads|check-ci|check-bots|wrap-up|babysit-pr|wait-for-bots|commit-push-pr|start-task|check-spec|status)([^.A-Za-z]|$)' \
     .claude .kit/templates .kit/context/workflows CLAUDE.md
   # expect no output
   ```
@@ -128,7 +137,7 @@ Restamp `CLAUDE.md` `## Provenance`:
 ### 6. Verify
 
 ```bash
-claude plugin list | grep -A3 'agentive-workflow@agentive-skills'   # new version, enabled
+claude plugin list | grep -A3 'agentive-workflow'   # new version, enabled
 ```
 
 Optionally confirm the namespaced artifacts resolve at the new version with a
@@ -165,6 +174,11 @@ Pin back to the previous version and re-update:
   must increase for consumers to receive changes.
 - **Never hand-edit cached plugin files** (`~/.claude/plugins/cache/...`) — that
   path is ephemeral and is overwritten on the next update.
+- **ANSI colour codes can defeat the greps** — the `claude` CLI currently
+  strips colours when piped (verified 2026-07-06), but if a future version
+  colours piped output, insert a strip stage before grepping:
+  `claude plugin list | sed $'s/\x1b\\[[0-9;]*m//g' | grep ...`
+  (bash ANSI-C quoting; works with BSD/macOS sed).
 - **Plugin vs scripts vs identity** are three separate upgrade surfaces; this
   guide is only the plugin. Don't fold manifest-script or CLAUDE.md changes
   into a "plugin upgrade."


### PR DESCRIPTION
## Summary

PR 2 of 2 for KIT-0035 — F4 only. All three KIT-0032 evaluators independently flagged brittle CLI-output matching in the upgrader agent; the patterns are inherited verbatim from `docs/PLUGIN-UPGRADE-GUIDE.md`, so per N3 (guide wins) the guide is hardened and `.claude/agents/upgrader.md` mirrors it in the same commits.

- **Marketplace source guard**: anchored to the `Source:` field, accepting the GitHub paren form and the github.com URL form (either case). The initial looser pattern (`github.*movito/...`) was itself caught by this PR's evaluator round — it matched a local checkout path like `Directory (/Users/alice/github/movito/agentive-skills)`, bypassing the pin guard.
- **Provenance pin read**: `sed` section scope (`/^## Provenance/,/^## /p`) replaces the fixed `grep -A8` window — works at any section length and when Provenance is the last section.
- **Plugin-list rows**: `agentive-workflow([@ (]|$)` tolerates `@source` vs `(source)` row drift while excluding similarly-named siblings.
- **Flat-ref regression grep**: `-i` catches case-drifted slash-references.
- **New gotcha**: ANSI-strip recipe (BSD-sed-safe) should a future CLI colour piped output.
- upgrader.md 1.0.0 → 1.1.0; also replaced a hard line-number cross-reference that the insertions had shifted.

## Before/after verification (live CLI output)

| Check | Before | After |
|---|---|---|
| `Source: GitHub (movito/agentive-skills)` | eyeball only | matches |
| `Source: https://github.com/movito/agentive-skills` | no match | matches |
| `Directory (/Users/alice/github/movito/agentive-skills)` | **false pass** (looser draft) | correctly rejected |
| Pin 9 lines below `## Provenance` | missed by `-A8` | found |
| Provenance as last section (EOF) | n/a | found (sed range runs to EOF) |
| `agentive-workflow-beta` sibling row | matched | excluded |

## Test plan

- [x] All hardened patterns run against live `claude plugin marketplace list` / `claude plugin list` output
- [x] Bypass case and both legit source forms tested (table above)
- [x] Evaluator run **before** PR open (per the F3 ordering rule from PR 1): fast-v2 + o3 — the Directory-bypass finding was accepted and fixed; sed-range claims disproven empirically on BSD sed
- [x] Guide/agent lockstep verified by pattern-count (agent has one extra site: its Phase 0b guard)

## Task

`.kit/tasks/3-in-progress/KIT-0035-devenv-evaluator-workflow-hardening.md` — PR 1 is #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULQcU9dmD1fxxZNZ6fD1a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and upgrader-agent instructions only; no application runtime or auth/data paths change.
> 
> **Overview**
> **Hardens** the shell checks in `docs/PLUGIN-UPGRADE-GUIDE.md` and keeps `.claude/agents/upgrader.md` in lockstep (upgrader **1.0.0 → 1.1.0**).
> 
> The **marketplace source** guard now greps an anchored `Source:` line that accepts GitHub paren/URL forms and rejects local `Directory (...)` paths that merely contain `github/movito/agentive-skills`. **Provenance** reads use `sed` over the full `## Provenance` section instead of `grep -A8`. **`claude plugin list`** matching uses `agentive-workflow([@ (]|$)` so `@` vs `(source)` row drift works without hitting sibling plugin names. The **flat slash-command** regression grep adds **`-i`**.
> 
> The guide adds a **Gotcha** for stripping ANSI before grep if the CLI ever colors piped output; the upgrader drops a brittle line-number cross-ref in favor of naming Phase 1’s rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b3157bd8b943c5b9e5f9a467a8ba6bb5f67fc42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->