### PR TITLE
feat(KIT-0042): bundle-aware preflight Gates 5/6 (convention + F1.1)

### DIFF
--- a/.kit/context/KIT-0042-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0042-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0042 Handoff — feature-developer
 
-**Task**: `.kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0042-preflight-bundle-support.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-13 (planner-f5)
 **Estimated effort**: 1–2 hours

--- a/.kit/context/KIT-0042-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0042-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0042 Handoff — feature-developer
 
-**Task**: `.kit/tasks/2-todo/KIT-0042-preflight-bundle-support.md`
+**Task**: `.kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-13 (planner-f5)
 **Estimated effort**: 1–2 hours

--- a/.kit/context/KIT-0042-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0042-REVIEW-STARTER.md
@@ -1,0 +1,63 @@
+# Review Starter: KIT-0042
+
+**Task**: KIT-0042 — Bundle-aware preflight Gates 5/6
+**Task File**: `.kit/tasks/4-in-review/KIT-0042-preflight-bundle-support.md`
+**Branch**: feature/KIT-0042-preflight-bundle-support -> main
+**PR**: https://github.com/movito/agentive-starter-kit/pull/74
+
+## Implementation Summary
+
+- **Route (b) chosen: convention + F1.1** — gates stay strict; bundle
+  intelligence lives in process, not gate code (full code-vs-process
+  reasoning in the PR description). The bundle test proves pointer files
+  pass the exact-name find natively — zero gate-logic change needed for
+  the convention itself.
+- Gates 5/6 FAIL details now name the full repo-relative pointer path,
+  the review-handoff skill, AND the multi-PR-task case (planner's
+  2026-07-13 spec addendum, KIT-0035 evidence).
+- review-handoff skill (1.1.0): "Bundled PR? Do this FIRST" section —
+  lead-task + pointer files, KIT-0037/38/39 files cited as the reference
+  shape — plus multi-PR artifact-placement guidance.
+- Evaluator-round hardening: Gates 5/6 finds require non-empty regular
+  files (`-type f -size +0c`); prefix-boundary property pinned in tests.
+
+## Files Changed
+
+- `scripts/core/preflight-check.sh` (modified — FAIL messages + non-empty check)
+- `.kit/skills/review-handoff/SKILL.md` (modified — v1.1.0, bundle section)
+- `tests/test_preflight_check.py` (modified — 4 new tests, run() extra_args)
+- Task/handoff bookkeeping (moves, agent-handoffs.json)
+- Note: branch carries planner commit `f7a6c90` (docs-only retro
+  follow-through, includes the KIT-0042 spec addendum this PR implements)
+
+## Test Results
+
+- `pytest tests/test_preflight_check.py` — 14 passed (was 10; +4: bundle
+  PASS scenario, F1.1 message content, prefix boundary, empty-pointer)
+- `./scripts/core/ci-check.sh` green; TDD red-then-green on both the
+  F1.1 assertions and the empty-pointer case
+
+## Automated Review Summary
+
+- CodeRabbit: 1 thread (Gate 5 message lacked the directory) — fixed
+  `a30c974`, resolved
+- BugBot: pass, no findings
+- Evaluators (fast-v2 + o3): 2 accepted (empty-pointer check, boundary
+  test), 6 declined with evidence — fast-v2's headline prefix-collision
+  claim empirically false (literal separator IS the boundary; tested).
+  Full disposition: `.kit/context/reviews/KIT-0042-evaluator-review.md`
+
+## Areas for Review Focus
+
+- The declined Gate 7 prefix observation (`${TASK_ID}*`, no separator) is
+  real in principle but out of scope and nil with fixed-width IDs —
+  confirm you agree it stays a non-issue
+- Message wording: FAIL lines are long (one line each, GATE prefix
+  intact) — check they render acceptably in your terminal
+
+## Related ADRs
+
+- None directly; lineage is KIT-0034/KIT-0040 preflight hardening
+
+---
+**Ready for human review**

--- a/.kit/context/REVIEW-INSIGHTS.md
+++ b/.kit/context/REVIEW-INSIGHTS.md
@@ -124,6 +124,14 @@ Distilled knowledge from code reviews. Updated by planner during task completion
 - **A script cannot export into its caller's shell**: `prepare-review-input.sh` surfaces the `ADVERSARIAL_UNATTENDED=1` export line in its next-steps output rather than pretending to set it — surface, don't fake-set. (KIT-0035)
 - **`adversarial list-evaluators` exists** for evaluator discovery (with `ls .adversarial/evaluators/*/` as fallback; prefer `-v2` variants). (KIT-0035)
 - **isort's pin is a floor (`>=`), not exact** — version-drift warnings comparing "active vs pinned" only make sense for exact pins like Black's. (KIT-0035)
+- **Evaluator-before-PR round-collapse is measured, not theoretical**: PR #72 (six items, 8 files) ran the trio pre-open and got a ZERO-thread first bot round with CodeRabbit APPROVED — vs KIT-0032's four post-open rounds on one doc file. (KIT-0035 retro)
+- **Test rejection cases, not just acceptance, for detection patterns**: live-output testing only exercises the happy path; the marketplace-source bypass (`Directory (/Users/alice/github/movito/...)`) passed every live test. Now codified in TESTING-WORKFLOW.md. (KIT-0035 retro)
+
+### Empirically Disproven Reviewer Claims (decline-by-reference)
+
+- **"`sed -n '/^## X/,/^## /p'` terminates on its own start line" — FALSE.** POSIX sed searches the end address from the line AFTER the addr1 match. Asserted identically by o3, Gemini fast-v2, AND CodeRabbit in one session — model-diverse review does not protect against shared training-data folklore about classic tools. BSD-sed repro pasted in `.kit/context/reviews/KIT-0035-evaluator-review.md`; decline by linking there. (KIT-0035)
+- **"`grep -o` extracts the shortest match" — FALSE** (leftmost-longest; `26.3.1` extracts fully, not `26`). Tested live, repro in the same review record. (KIT-0035)
+- When declining any reviewer claim, paste the repro in the review record — it turns later re-litigation (bots repeating an evaluator's false claim) into a one-reply copy-paste. (KIT-0035)
 
 ---
 

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0042",
     "task_started": null,
     "brief_note": "KIT-0035 DONE (PRs #72+#73 merged 2026-07-13; F3 ordering rule ADOPTED, core scripts 3.1.0) + knowledge extracted (no retro was written). KIT-0042 evaluated (both actionable findings accepted: F1.1 gate-message pointer, code-vs-process reasoning), handoff ready with verified gate anchors. Then: ADR-0025 slim = last v0.8.0 item. Awaiting human verdicts: KIT-0032 (PR #56 merged), ASK-0048 (PR #45), 6 dependabot PRs.",
-    "details_link": ".kit/tasks/2-todo/KIT-0042-preflight-bundle-support.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md",
     "handoff_file": ".kit/context/KIT-0042-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0042",
     "task_started": null,
     "brief_note": "KIT-0042 (bundle-aware preflight Gates 5/6: glob or convention + mandatory F1.1 failure-message pointer) ready for assignment. Small task, single PR.",
-    "details_link": ".kit/tasks/2-todo/KIT-0042-preflight-bundle-support.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md",
     "handoff_file": ".kit/context/KIT-0042-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0042",
     "task_started": null,
     "brief_note": "KIT-0035 DONE (PRs #72+#73 merged 2026-07-13; F3 ordering rule ADOPTED, core scripts 3.1.0) + knowledge extracted (no retro was written). KIT-0042 evaluated (both actionable findings accepted: F1.1 gate-message pointer, code-vs-process reasoning), handoff ready with verified gate anchors. Then: ADR-0025 slim = last v0.8.0 item. Awaiting human verdicts: KIT-0032 (PR #56 merged), ASK-0048 (PR #45), 6 dependabot PRs.",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0042-preflight-bundle-support.md",
     "handoff_file": ".kit/context/KIT-0042-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0042",
     "task_started": null,
     "brief_note": "KIT-0042 (bundle-aware preflight Gates 5/6: glob or convention + mandatory F1.1 failure-message pointer) ready for assignment. Small task, single PR.",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0042-preflight-bundle-support.md",
     "handoff_file": ".kit/context/KIT-0042-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/reviews/KIT-0042-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0042-evaluator-review.md
@@ -171,3 +171,279 @@ Found 4 latent correctness/robustness issues and 3 documentation/test-gap issues
 **CONCERNS** – No immediate breakage from the two-line change, but several latent bugs in surrounding logic and new messaging inconsistencies surfaced during review.
 
 Address at least the Gate 1 limit, mixed CodeRabbit context handling, and update the user hint before relying on these gates for enforcement.
+
+---
+
+# Round 2 (2026-07-14) — internal review substituting for CodeRabbit outage
+
+CodeRabbit crashed with "Internal error occurred during review" on three
+attempts (initial + `@coderabbitai review` + `@coderabbitai full review`)
+after commit `8fcc577`. Its APPROVED review predates `7166d99` (the
+`-size +0c` gate change + tests), so the operator requested an internal
+adversarial round on the full current diff as the substitute.
+
+**Evaluators**: code-reviewer-fast-v2 (rerun) + claude-code (first run —
+security angle on the shell change, new model family vs round 1).
+
+| Evaluator | Verdict | Disposition |
+|-----------|---------|-------------|
+| claude-code | **APPROVED** | Clean pass on the full diff including `7166d99`/`8fcc577`. |
+| code-reviewer-fast-v2 | CONCERNS | All four findings are repeats of round-1 declines (Gate 1 pagination + unknown-status, Gate 7 bare wildcard, `head -1` ordering) — all out of scope per the handoff (Gates 1–4/7 untouched, KIT-0034 surface) or pre-existing/accepted. It dropped its round-1 Gate 5/6 prefix-collision claim (now acknowledges the literal separators) and marks the empty-file case as addressed by `-size +0c`. No new findings on this PR's surface. |
+
+Round-2 raw logs below.
+## Source: KIT-0042-code-review-input--code-reviewer-fast-v2.md (round 2)
+
+#  Code Reviewer Fast V2
+
+**Source**: .adversarial/inputs/KIT-0042-code-review-input.md
+**Evaluator**: code-reviewer-fast-v2
+**Model**: gemini/gemini-3-flash-preview
+**Generated**: 2026-07-13 21:58 UTC
+
+---
+
+### Findings
+
+**[ROBUSTNESS]: Gate 1 Workflow Search ignores pagination**
+- **Location**: `scripts/core/preflight-check.sh:Gate 1` (line 190, in context)
+- **Edge case**: A PR triggers more than 10 workflow runs (common in matrix builds or repositories with many specialized CI checks).
+- **What happens**: `gh run list --limit 10` is used. If there are 12 runs and the first 10 are `success` but the 11th is `failure`, the script will only see the top 10 and return a false `PASS`.
+- **Tested?**: No. Tests only stub a single run entry.
+
+**[CORRECTNESS]: Unknown GitHub run status defaults to FAIL**
+- **Location**: `scripts/core/preflight-check.sh` (Gate 1 loop)
+- **Edge case**: GitHub API returns a non-terminal status not explicitly handled (e.g., `waiting`, `requested`, `pending`, `action_required`).
+- **What happens**: The `if/elif` block only checks `completed` and `in_progress/queued`. Anything else falls into the final `else`, setting `CI_ANY_FAILED_RUN=true`. A PR waiting for a runner would incorrectly report a failure instead of `PENDING`.
+- **Tested?**: No.
+
+**[INTERACTION]: Shell Globbing Prefix Collision in Gate 7**
+- **Location**: `scripts/core/preflight-check.sh` (Gate 7)
+- **Edge case**: Task `KIT-4` exists when an artifact for `KIT-40` is in the directory.
+- **What happens**: `find ... -name "${TASK_ID}*"` is used. Unlike Gates 5/6 which have literal separators (e.g., `-code-review`), Gate 7 uses a bare wildcard. `find . -name "KIT-4*"` will match `KIT-40-task.md`.
+- **Tested?**: No. The new `test_prefix_is_not_a_match_boundary_violation` only tests Gates 5 and 6.
+
+**[ROBUSTNESS]: `head -1` on non-deterministic `find` output**
+- **Location**: `scripts/core/preflight-check.sh` (Gates 5, 6, and 7)
+- **Edge case**: Multiple files match a pattern (e.g., a manual backup `KIT-0042-REVIEW-STARTER.md.bak` or `KIT-0042-REVIEW-STARTER.md~`).
+- **What happens**: `find` returns all matches. `head -1` picks the first one returned by the filesystem. If the "real" file is empty but the backup has content, the gate might pass or fail non-deterministically depending on inode order.
+- **Tested?**: No.
+
+### Test Gap Summary
+| Edge Case | Function | Tested? | Risk |
+|-----------|----------|---------|------|
+| >10 Workflow Runs | Gate 1 | No | Med (False PASS) |
+| Non-terminal CI Status | Gate 1 | No | Med (False FAIL) |
+| Prefix Collision (KIT-4 vs KIT-40) | Gate 7 | No | Low (False PASS) |
+| Empty file check (binary/null) | Gates 5/6 | Partial | Low (Uses `-size +0c`) |
+
+### Verdict
+
+**CONCERNS**
+
+The PR successfully implements the "Route B" convention and correctly adds `-size +0c` to prevent empty pointer files from passing Gates 5 and 6. However, the core logic in **Gate 1** (CI check) contains latent correctness bugs regarding how it interprets GitHub's API (limit and unknown statuses). Additionally, while prefix collisions were addressed for the changed Gates 5/6, **Gate 7** remains vulnerable to the exact same prefix collision issue because it lacks a literal separator in its `find` pattern.
+
+**Required Fixes:**
+1. Update Gate 1 to handle non-terminal statuses (`waiting`, etc.) as `PENDING`.
+2. Increase `--limit` in Gate 1 or verify if 10 is a hard project constraint.
+3. Fix Gate 7 pattern to match the boundary safety of Gates 5/6.
+## Source: KIT-0042-code-review-input--claude-code.md (round 2)
+
+#  Claude Code
+
+**Source**: .adversarial/inputs/KIT-0042-code-review-input.md
+**Evaluator**: claude-code
+**Model**: anthropic/claude-sonnet-4-6
+**Generated**: 2026-07-13 22:00 UTC
+
+---
+
+## Phase 1: Understand Intent
+
+This is a CI/CD preflight check system for a software development workflow tool ("agentive-starter-kit"). The primary executable changes are in `scripts/core/preflight-check.sh` and `tests/test_preflight_check.py`.
+
+**What it does**: Before a PR can be submitted for human review, it must pass 7 gates:
+1. CI (GitHub Actions) is green
+2. CodeRabbit bot has reviewed
+3. BugBot has reviewed
+4. Zero unresolved review threads
+5. Evaluator review artifact exists (non-empty file)
+6. Review starter document exists (non-empty file)
+7. Task file is in the correct folder
+
+**Critical paths**: The shell script gates 5/6 were changed to add `-type f -size +0c` to `find` commands, and FAIL messages were extended to include bundle/multi-PR guidance. Four new Python tests were added.
+
+**Assumptions**: TASK_ID is fixed-width (KIT-NNNN), files are local filesystem artifacts, `gh` CLI is available and authenticated.
+
+---
+
+## Phase 2: Security Analysis
+
+### Injection Vectors
+
+**SQL/Command injection**: No SQL. Shell variable interpolation into `find -name` is quoted correctly. GraphQL queries interpolate `$OWNER`, `$NAME`, `$PR_NUMBER` directly into the query string — analyzed below.
+
+**Path traversal**: Gate 5/6 `find` is constrained to `.kit/context/reviews` and `.kit/context` with `-maxdepth 1` (Gate 6). Findings are used only for display/existence checks, not for file reads or execution.
+
+---
+
+### MEDIUM: GraphQL Injection via $OWNER, $NAME, $PR_NUMBER
+
+- **Location**: `scripts/core/preflight-check.sh` — the `gh api graphql` call (approximately line ~330 in the full file)
+- **Issue**: `$OWNER`, `$NAME`, and `$PR_NUMBER` are interpolated directly into a GraphQL query string via shell variable expansion:
+  ```bash
+  PR_DATA=$(gh api graphql -f query="{ repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUMBER) { ...
+  ```
+  `PR_NUMBER` is validated as `^[0-9]+$` before this point — that protection holds. However, `$OWNER` and `$NAME` are derived from `gh repo view --json nameWithOwner` or `$REPO_OVERRIDE` (user-supplied via `--repo`). A malicious `--repo` value like `foo\", name: \"bar`) { issues { nodes { body } } } #` could inject into the GraphQL query. In practice this is a local CLI tool run by a developer on their own machine against their own GitHub token, substantially limiting exploitability. But the injection vector is real.
+- **Remediation**: Use `-f` variable substitution for the GraphQL query rather than shell string interpolation, or use `-F` fields to pass variables separately:
+  ```bash
+  gh api graphql \
+    -F owner="$OWNER" \
+    -F name="$NAME" \
+    -F pr="$PR_NUMBER" \
+    -f query='query($owner:String!,$name:String!,$pr:Int!){ repository(owner:$owner,name:$name){ pullRequest(number:$pr){ ... } } }'
+  ```
+
+---
+
+### LOW: REPO_OVERRIDE Not Validated for Expected Format
+
+- **Location**: `preflight-check.sh` — `--repo` argument parsing and `$REPO_OVERRIDE` assignment
+- **Issue**: `$REPO_OVERRIDE` accepts any string. While a malformed value would likely cause `gh` to fail gracefully, the value flows unvalidated into `$OWNER`/`$NAME` via `cut -d/ -f1` and `cut -d/ -f2`, and then into the GraphQL query (as noted above). There is no check that the value matches `owner/repo` format.
+- **Remediation**: Add a format check:
+  ```bash
+  if ! [[ "$REPO_OVERRIDE" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+      echo "ERROR: --repo must be in owner/name format"
+      exit 1
+  fi
+  ```
+
+---
+
+### Authentication & Authorization
+
+No hardcoded credentials. The script requires `gh auth status` to pass before proceeding — this is correct. The script runs with whatever GitHub token the local `gh` CLI has; no privilege escalation is possible from within the script itself.
+
+---
+
+### Data Handling
+
+- No PII is logged beyond GitHub usernames (which are public).
+- No sensitive data is written to files.
+- Error messages embed TASK_ID and file paths — these are internal development artifacts, not production user data.
+
+---
+
+## Phase 3: Correctness Analysis
+
+### LOW: Gate 5 `find` Ordering Across `-o` with `-type f -size +0c`
+
+- **Location**: `preflight-check.sh`, Gate 5 `find` command
+- **Issue**: The `-type f -size +0c` predicates are placed *after* the `\(...-o-...\)` group. POSIX `find` evaluates left-to-right with short-circuit; `-type f -size +0c` applies only to files that matched the name group, which is correct. However, the current ordering means `-type f -size +0c` is evaluated as a global filter *after* the OR group — this is the intended behavior and it works correctly. **Not actually a bug**, but worth confirming: the parenthesized OR group is evaluated first (it's an expression), then `-type f -size +0c` applies to the result. This is correct POSIX `find` behavior.
+
+---
+
+### LOW: Gate 7 Prefix Collision (Acknowledged Out-of-Scope, but Documentably Present)
+
+- **Location**: `preflight-check.sh`, Gate 7
+  ```bash
+  TASK_FILE=$(find .kit/tasks/3-in-progress .kit/tasks/4-in-review -name "${TASK_ID}*" 2>/dev/null | head -1 || true)
+  ```
+- **Issue**: `${TASK_ID}*` without a separator could match a longer ID (e.g., `KIT-999` matching `KIT-9999-task.md`). The review record acknowledges this as pre-existing and practically nil with fixed-width `KIT-NNNN` IDs. With the convention of 4-digit zero-padded IDs this is indeed not a real risk. Documented here for completeness; the evaluator review disposition is sound.
+- **Remediation**: If variable-length IDs are ever introduced, change to `-name "${TASK_ID}-*"` (add separator).
+
+---
+
+### LOW: `head -1` on `find` Output is Filesystem-Order Dependent
+
+- **Location**: Gates 5, 6, 7 in `preflight-check.sh`
+- **Issue**: Multiple matching files (e.g., `KIT-9999-code-review.md` and `KIT-9999-code-review-r2.md`) result in `head -1` selecting arbitrarily based on filesystem traversal order. The review record acknowledges this as acceptable for Gate 5 (any persisted record satisfies the intent), and Gate 6 uses `maxdepth 1` with an exact name making multiple matches essentially impossible.
+- **Remediation**: No immediate change required given current conventions. If determinism becomes important, add `| sort | head -1`.
+
+---
+
+### LOW: Test Fixture Cleanup Assumes `missing_ok=True` (Python 3.8+)
+
+- **Location**: `tests/test_preflight_check.py`, `TestGate56Bundle` tests
+- **Issue**: `path.unlink(missing_ok=True)` requires Python 3.8+. The project appears to target 3.11+ based on context, so this is fine. The `list[str] | None` type hint also requires Python 3.10+ (for the `|` union syntax without `from __future__ import annotations`). However, `from __future__ import annotations` is present at the top of the file, making this a non-issue at runtime.
+- **Remediation**: No action needed given the `from __future__ import annotations` import.
+
+---
+
+### LOW: Test KIT-999 Boundary Test Depends on HEAD_TASK Being KIT-9999
+
+- **Location**: `tests/test_preflight_check.py`, `test_prefix_is_not_a_match_boundary_violation`
+- **Issue**: The test asserts that `KIT-999` does not match `KIT-9999` artifacts. This works correctly because the Gate 5 pattern is `${TASK_ID}-evaluator-review*.md` — `KIT-999-evaluator-review*.md` does not match `KIT-9999-code-review.md`. The test is valid and the mechanism is sound (the literal `-` separator is the boundary). However, the test comment says "KIT-9999 artifacts must NOT satisfy the gates for the shorter task ID KIT-999" but the fixture's artifact is `KIT-9999-code-review.md` which uses a different pattern than what KIT-999 would search for. This is correct behavior but the test is implicitly dependent on the fixture file name having `-code-review` not `-evaluator-review` as the suffix. If the fixture changed to use `-evaluator-review`, the name pattern `KIT-999-evaluator-review*.md` still wouldn't match `KIT-9999-evaluator-review*.md`. So the test is robust regardless.
+
+---
+
+### MEDIUM: Gate 1 `--limit 10` Can Drop Runs (Acknowledged, Unaddressed)
+
+- **Location**: `preflight-check.sh`, Gate 1 (`gh run list --commit "$LATEST_SHA" --limit 10`)
+- **Issue**: The evaluator review acknowledges this as out-of-scope. However, it is a genuine correctness issue in the changed code's context (the full file is in scope). A matrix build with >10 jobs could have a failing run silently dropped. The fix (`--commit` instead of branch-level reduces this risk significantly since commit-scoped runs are typically fewer), but the hard cap remains.
+- **Remediation**: If more than 10 runs are possible, add pagination or increase the limit to `--limit 50`. Since the `--commit` flag significantly constrains results, this is low-urgency.
+
+---
+
+### LOW: TASK_ID Derived from Branch with No Sanitization for `find`
+
+- **Location**: `preflight-check.sh` — TASK_ID derivation via `sed` and use in `find -name`
+- **Issue**: TASK_ID is derived via `sed -n 's|^feature/\([A-Z][A-Z0-9]*-[0-9][0-9]*\).*|\1|p'` which constrains it to uppercase letters, digits, and hyphens. This character set is safe for `find -name` glob patterns. The o3 evaluator confirmed this as clean. No issue.
+
+---
+
+## Phase 4: Code Quality
+
+### Positive Observations
+
+The code quality overall is high:
+
+1. **Structured output format** (`GATE:N:Name:VERDICT:detail`) is consistent and machine-parseable — downstream tools and tests rely on it correctly.
+2. **Defensive error handling**: `|| true` on `find` commands prevents `set -e` exits on empty results; `2>/dev/null` suppresses spurious errors; explicit exit code checks on `gh` calls.
+3. **Non-empty file guard** (`-type f -size +0c`) — the new addition in this PR correctly hardens Gates 5/6 against zero-byte artifacts.
+4. **Excellent test harness**: The stub-`gh` pattern is well-architected. Module-scoped fixtures, clean git environment isolation, comprehensive canned payload builders, and clear test intent via docstrings.
+5. **PR_NUMBER numeric validation** before GraphQL interpolation — correct defense against the most obvious injection vector.
+6. **Acknowledgment discipline**: The evaluator review document correctly tracks accepted vs. declined findings with evidence, making future re-litigation cheap.
+7. **`extra_args` extensibility** in `PreflightProject.run()` is cleanly added with a `None` default and safe spread.
+8. **Test cleanup via `finally`** blocks in the new bundle tests — correct resource cleanup even on test failure.
+
+---
+
+### LOW: Long FAIL Message Lines May Cause Issues in Some Terminals/Parsers
+
+- **Location**: `preflight-check.sh`, Gates 5 and 6 FAIL echo statements
+- **Issue**: The new FAIL messages are single long lines (~200 chars). The `_gates()` parser in the test harness uses `re.match(r"^GATE:(\d+):[^:]*:(PASS|FAIL|PENDING):(.*)$", line)` — the `(.*)` captures the entire remainder including the embedded colons in the file path (`${TASK_ID}-evaluator-review.md`). The regex works correctly since `[^:]*` stops at the first colon after `GATE:N:`, and `(.*)` is greedy. The REVIEW-STARTER.md path in the Gate 6 message doesn't contain colons, so parsing is clean.
+- **Remediation**: No code change required; the PR author flagged this for human visual inspection and the parser handles it correctly.
+
+---
+
+### LOW: `test_fail_details_name_bundle_convention` Does Not Assert Gate 7
+
+- **Location**: `tests/test_preflight_check.py`, `test_fail_details_name_bundle_convention`
+- **Issue**: The test runs with `--task KIT-9997`. There's no task file for KIT-9997 in `3-in-progress` or `4-in-review`, so Gate 7 also fails. The test only asserts `result.returncode == 1` and checks gates 5 and 6 — it doesn't assert Gate 7 fails. This is fine (the returncode assertion covers it), but it's a minor incompleteness.
+- **Remediation**: Optionally add `assert gates[7][0] == "FAIL"` for completeness, or add a KIT-9997 task stub file and verify Gate 7 passes to isolate the test to gates 5/6.
+
+---
+
+## Context Required / Unverifiable
+
+- **`target_repo.sh` library**: The `target_repo_init`, `target_repo_is_set`, `TARGET_REPO`, `TARGET_PATH`, `GIT_DIR_ARG`, `GH_REPO_ARG` variables are sourced from `scripts/core/lib/target_repo.sh` which is not shown in the diff. The security of cross-repo mode depends on this library's validation of `--repo` values.
+- **`dispatch` command**: The fire-and-forget `dispatch emit` call is stubbed in tests. Its actual security properties (event log integrity, injection via `$_PF_SUMMARY`) cannot be assessed without the implementation.
+- **GitHub token scope**: The `gh auth status` check confirms authentication but not token scope. If the token has write access, a compromised `--repo` value could potentially be used to query private repository data — not assessable from this code alone.
+- **Pre-commit hook interaction**: The COMMIT-PROTOCOL.md note about pre-commit aborting commits is a process concern, not a code security issue.
+
+---
+
+## Overall Assessment
+
+**APPROVED**
+
+The changes in this PR are narrow and well-executed:
+
+1. **The core change** — adding `-type f -size +0c` to Gates 5/6 `find` commands — is correct, properly motivated, and tested with a red-green harness case.
+2. **The FAIL message enhancement** is appropriately scoped (single-line, GATE prefix intact, both bundle cases covered).
+3. **The four new tests** cover the intended behavioral contract (pointer files pass, prefix boundary, empty files fail, message content).
+4. **The evaluator disposition** is sound — the prefix-collision claim was empirically disproven with correct reasoning (literal separator IS the boundary), and the accepted findings were properly implemented.
+
+The one genuine security concern (GraphQL injection via `$OWNER`/`$NAME`) is pre-existing, not introduced by this PR, and practically constrained to a local developer tool context. It warrants a follow-up issue but does not block this PR.
+
+No critical or high issues were introduced by this diff. The pre-existing issues (Gate 1 limit, Gate 7 prefix, GraphQL injection) are correctly scoped as out-of-range for this task.

--- a/.kit/context/reviews/KIT-0042-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0042-evaluator-review.md
@@ -1,0 +1,173 @@
+# KIT-0042 Evaluator Review — bundle-aware preflight Gates 5/6 (PR #74)
+
+**Date**: 2026-07-13
+**Evaluators**: code-reviewer-fast-v2 (Gemini), code-reviewer (o3) — gate logic, normal phase order (doc-dominated exception does not apply)
+**Verdicts**: fast-v2 CONCERNS · o3 (see log)
+
+## Disposition
+
+### Accepted (fixed in `7166d99`)
+
+| Finding | Source | Fix |
+|---------|--------|-----|
+| Zero-byte "pointer" files satisfied Gates 5/6 | o3 | Both finds now require `-type f -size +0c`; red-then-green harness case (`test_empty_pointer_files_do_not_pass`) |
+| Prefix false-positive untested | o3 (and the spec's conditional criterion) | Boundary pinning test added (`test_prefix_is_not_a_match_boundary_violation`: KIT-999 not satisfied by KIT-9999 artifacts) — kept despite the convention route leaving exact-name matching unchanged, so future pattern edits can't silently lose the boundary |
+
+### Declined with evidence
+
+| Finding | Source | Why declined |
+|---------|--------|--------------|
+| Gate 5 glob prefix collision (KIT-4 matches KIT-40's record) | fast-v2 (headline) | Empirically false: every Gate 5/6 pattern has a literal separator (`-evaluator-review`, `-code-review`, `-REVIEW-STARTER`) immediately after `${TASK_ID}` — that IS the boundary. Tested: `KIT-4-…`/`KIT-004-…` patterns matched neither `KIT-40-evaluator-review.md` nor `KIT-0042-evaluator-review.md`; control (`KIT-40-…`) matched. Now also pinned by the boundary test. |
+| Gate 7 prefix collision (`${TASK_ID}*`, no separator) | fast-v2 | Real in principle, but Gate 7 is explicitly out of scope ("other preflight gates — KIT-0034 landed those; don't touch") and pre-existing. Practically nil with the kit's fixed-width KIT-NNNN IDs (`KIT-0004*` cannot match `KIT-0040-…`). Candidate follow-up if variable-length IDs ever appear. |
+| Gate 1 `--limit 10` can drop failing runs; unknown statuses count as FAIL; auth errors waste poll retries | o3 | Out of scope (Gate 1, KIT-0034 surface, untouched by this PR). |
+| Gate 2 fallback mixed commit-status contexts | o3 | Out of scope (Gate 2, untouched). |
+| `head -1` on multiple matches is arbitrary | fast-v2, o3 | Pre-existing and acceptable: Gate 6 is exact-name + maxdepth 1 (≤1 match); Gate 5's wildcard exists to accept preserved rounds (`-r1.md`) — any persisted record satisfies the gate's intent. |
+| FAIL hint names only the `-evaluator-review.md` variant | o3 | Deliberate: the hint targets the bundle-pointer case, whose convention (review-handoff skill + KIT-0037/38/39 reference files) uses exactly that name. One canonical filename to create beats a three-pattern menu in an error message; the accepted-pattern list lives in the script comment above the find. |
+
+## Raw evaluator logs
+
+## Source: KIT-0042-code-review-input--code-reviewer-fast-v2.md
+
+#  Code Reviewer Fast V2
+
+**Source**: .adversarial/inputs/KIT-0042-code-review-input.md
+**Evaluator**: code-reviewer-fast-v2
+**Model**: gemini/gemini-3-flash-preview
+**Generated**: 2026-07-13 21:43 UTC
+
+---
+
+### Findings
+
+**[ROBUSTNESS]: Filename Prefix Collision in Gate 5 Search**
+- **Location**: `scripts/core/preflight-check.sh:Gate 5`
+- **Edge case**: Searching for `KIT-4` when `KIT-40-evaluator-review.md` exists but `KIT-4-evaluator-review.md` does not.
+- **What happens**: The `find` command uses `${TASK_ID}-evaluator-review*.md`. If `TASK_ID` is `KIT-4`, the glob matches `KIT-40-evaluator-review.md`. The script then sets `EVAL_FILE` and returns a false `PASS` for Gate 5.
+- **Tested?**: No. (The implementation guidance explicitly warned about this "prefix safety trap" from KIT-0040, but the developer used a loose glob instead of boundary-safe logic).
+
+**[CORRECTNESS]: False Positive in Gate 7 Task Location**
+- **Location**: `scripts/core/preflight-check.sh:Gate 7`
+- **Edge case**: Searching for task `KIT-9` when `KIT-99-some-task.md` exists in the `3-in-progress` folder.
+- **What happens**: `find ... -name "${TASK_ID}*"` will match any filename starting with that ID. This results in Gate 7 passing for the wrong task.
+- **Tested?**: No.
+
+**[ROBUSTNESS]: Potential for Multiple Matches in Head-1 Selection**
+- **Location**: `scripts/core/preflight-check.sh:Gates 5, 6, and 7`
+- **Edge case**: Multiple files matching the glob (e.g., a backup file like `KIT-0042-REVIEW-STARTER.md.bak`).
+- **What happens**: `find` returns all matches; `head -1` picks one arbitrarily based on filesystem order. While not a "break," it makes the gate non-deterministic and potentially masks issues where the "wrong" file is being validated.
+- **Tested?**: No.
+
+**[INTERACTION]: Shell-Specific Globbing vs. Find behavior**
+- **Location**: `scripts/core/preflight-check.sh:487`
+- **Edge case**: `TASK_ID` contains characters that are shell-special but valid in filenames (though unlikely for IDs).
+- **What happens**: The variable is quoted in the `-name` argument, which is correct, but the logic relies on `find` interpreting the internal glob. If the convention moves to something more complex, this remains a brittle point.
+- **Tested?**: Yes (baseline only).
+
+### Test Gap Summary
+| Edge Case | Function | Tested? | Risk |
+|-----------|----------|---------|------|
+| Prefix collision (KIT-4 vs KIT-40) | Gate 5 `find` | No | High - False PASS on missing artifacts |
+| Prefix collision (KIT-9 vs KIT-99) | Gate 7 `find` | No | Medium - False PASS on task location |
+| Multiple matches (Starters/Reviews) | Gates 5/6/7 | No | Low - Non-deterministic PASS |
+
+### Verdict
+
+**CONCERNS**
+
+The implementation correctly fulfills the **F1.1** requirement (improving the failure messages) and the **F2** requirement (adding a test for the bundle convention). However, it ignored a specific warning in the **Implementation Guidance** regarding prefix collisions (`KIT-0004` vs `KIT-0040`).
+
+Because the `find` commands use `${TASK_ID}-...*` without boundaries, a PR for a low-numbered task will "steal" the pass status of a higher-numbered task if those files exist in the directory.
+
+**Required Fixes:**
+1. In `preflight-check.sh`, ensure globs are anchored or use exact matching where possible. For Gate 5, the glob should likely be `${TASK_ID}-evaluator-review.md` (or specific variants) rather than a trailing wildcard that allows digits to follow the ID.
+2. Update `tests/test_preflight_check.py` to include a collision test case as requested in the task spec.
+## Source: KIT-0042-code-review-input--code-reviewer.md
+
+#  Code Reviewer
+
+**Source**: .adversarial/inputs/KIT-0042-code-review-input.md
+**Evaluator**: code-reviewer
+**Model**: o3
+**Generated**: 2026-07-13 21:45 UTC
+
+---
+
+### Summary
+Reviewed the only executable change (preflight-check.sh; two `echo … FAIL:` lines) plus the new tests that exercise them.
+No new logic landed, but the wider file still contains edge-case traps.
+Found 4 latent correctness/robustness issues and 3 documentation/test-gap issues.
+
+### Findings
+
+**ROBUSTNESS: Gate-1 status list can miss failing workflows**
+- Location: `preflight-check.sh` – Gate 1, `gh run list --limit 10` (≈ line 190)
+- Edge case: A push that launches > 10 workflow runs (matrix build with 12 jobs + “Lint”, etc.).
+- What happens: `--limit 10` silently drops older runs. If one of the dropped runs has concluded ≠ success, Gate 1 still reports PASS.
+- Expected: Fetch *all* runs for the commit (or page until none remain) before deciding.
+- Test coverage: NOT covered (all tests stub a single run).
+- Severity: Latent.
+
+**CORRECTNESS: Unknown GitHub run status marked as FAIL**
+- Location: Gate 1 loop (`if [ "$WF_STATUS" = "in_progress" ] … elif … else …`)
+- Edge case: New status values (“waiting”, “requested”, “pending”) returned by the API.
+- What happens: Branch falls into the final `else` ⇒ counted as a *failed* run, even though the run is merely queued.
+- Expected: Treat unknown-but-non-terminal states like “queued”/“in_progress” → PENDING, not FAIL.
+- Test coverage: NOT covered.
+- Severity: Latent.
+
+**CORRECTNESS: CodeRabbit fallback wrongly passes when *some* contexts succeed**
+- Location: Gate 2 fallback, commit-status query (`all(. == "success")`)
+- Edge case: CodeRabbit publishes two contexts (“CodeRabbit/Static”, “CodeRabbit/Runtime”) and *one* of them fails.
+- What happens: `map(select(. != "success")) | first` picks the first **non-success** element only if *all* succeed; if *one* succeeds and one fails, `all(. == "success")` returns false, branch falls into “… else (map(select(. != "success")) | first)” which **does** surface the failing state *but* the subsequent logic only tests `if [ "$CR_SIGNAL" = "success" ]`. Any non-empty non-success string still counts as “signal present” and can pass fallback when other conditions hold.
+- Expected: Require exactly “success”; anything else (including mixed) should fail.
+- Test coverage: NOT covered (tests stub a single “success”).
+- Severity: Latent.
+
+**ROBUSTNESS: Gate 5/6 PASS with empty or binary “pointer” files**
+- Location: Gate 5 (`find … | head -1`) and Gate 6 (similar)
+- Edge case: File exists but is empty, contains only NUL bytes, or is a symlink outside the repo.
+- What happens: Gates pass; later human reviewer clicks a broken link and sees no content.
+- Expected: At minimum, non-empty regular file check (`-s` and `-type f`).
+- Test coverage: NOT covered (tests write non-empty pointers).
+- Severity: Latent.
+
+**TESTING: Prefix-collision false-positive still untested**
+- Location: Tests `TestGate56Bundle`
+- Edge case: Task `KIT-0004` vs file `KIT-0040-evaluator-review.md`.
+- What happens: Current `find -name "${TASK_ID}-code-review*.md"` would not match, but if option (a) is ever chosen the risk returns. The contract in the task spec explicitly called for this test.
+- Test coverage: NOT covered.
+- Severity: Gap.
+
+**DOCUMENTATION: New FAIL hint hard-codes `-evaluator-review.md` variant only**
+- Location: Two new echo strings (Gate 5/6)
+- Edge case: Team follows *current* naming (`${TASK_ID}-code-review.md`).
+- What happens: Gate fails, operator reads hint that shows *only* the legacy “evaluator-review” filename, thinks the file is mis-named, churn ensues.
+- Expected: Hint should list all three accepted patterns or phrase generically.
+- Severity: Robustness / UX.
+
+**INTERACTION: CI poll loop ignores repo-level rate-limit / auth errors**
+- Location: Gate 1; when `gh run list` starts returning 403/401 after the first attempt, script still sleeps and retries twice, wasting 10 s before deterministic FAIL.
+- Edge case: Token with insufficient scopes.
+- What happens: needless delay; could short-circuit on auth error.
+- Severity: Minor.
+
+### Edge Cases Verified Clean
+• TASK_ID with lowercase → rejected earlier in branch-name regex
+• TASK_ID containing glob metacharacters → safe (quoted in `find -name`)
+• Multiple evaluator files ‑ first one wins but semantics acceptable
+• Long Unicode em-dash in new message does not corrupt `grep "^GATE:"` parsing
+
+### Test Gap Summary
+
+| Edge Case | Function / Gate | Tested? | Risk |
+|-----------|-----------------|---------|------|
+| >10 workflow runs | Gate 1 | ❌ | Med |
+| Unknown run status “waiting” | Gate 1 | ❌ | Med |
+| Mixed CodeRabbit contexts (one fail) | Gate 2 | ❌ | Med |
+| Prefix collision KIT-0004 vs KIT-0040 | Gate 5/6 | ❌ | Low-Med |
+| Empty pointer file | Gate 5/6 | ❌ | Low |
+
+### Verdict
+**CONCERNS** – No immediate breakage from the two-line change, but several latent bugs in surrounding logic and new messaging inconsistencies surfaced during review.
+
+Address at least the Gate 1 limit, mixed CodeRabbit context handling, and update the user hint before relying on these gates for enforcement.

--- a/.kit/context/workflows/COMMIT-PROTOCOL.md
+++ b/.kit/context/workflows/COMMIT-PROTOCOL.md
@@ -99,6 +99,13 @@ EOF
 - ✅ Run pytest: Ensure tests pass
 - ✅ Check git status: Verify all intended files staged
 - ✅ Review diff: Ensure no unintended changes
+- ✅ **Verify HEAD moved after committing** (`git log --oneline -1`) whenever
+  the staged set includes appended or generated markdown (review records,
+  logs, retros). Pre-commit auto-fixers (trailing-whitespace,
+  end-of-file-fixer) reformat such files and **abort the commit** — the
+  long hook output can read as success while nothing was committed. If
+  aborted: re-stage the hook's fixes and commit fresh (never `--amend`).
+  (KIT-0035 retro #4 — happened twice in one session.)
 
 ---
 

--- a/.kit/context/workflows/TESTING-WORKFLOW.md
+++ b/.kit/context/workflows/TESTING-WORKFLOW.md
@@ -59,6 +59,26 @@ pytest tests/ -n auto
 
 ---
 
+## Testing Detection Patterns (greps, regexes, matchers)
+
+**Added**: 2026-07-13 (KIT-0035 retro #1)
+
+When hardening or writing detection patterns (grep/sed/regex in scripts,
+gate logic, or guides), test the **rejection cases, not just acceptance**:
+
+1. Run the pattern against real current output (acceptance — the happy path)
+2. Run it against the documented bypass/negative cases (rejection) — e.g.
+   a path that *contains* the expected string in the wrong position
+   (`Directory (/Users/alice/github/movito/...)` passing a
+   `github.*movito` source check), prefix collisions (`KIT-0004` vs
+   `KIT-0040`), suffix collisions (`agentive-skills-beta`)
+3. Anchor both ends when the match is meant to be exact
+
+Live output only exercises the happy path; every real bypass found in
+KIT-0035 was a rejection case no live test could produce.
+
+---
+
 ## Interpreting Results
 
 | Symbol | Meaning |

--- a/.kit/skills/review-handoff/SKILL.md
+++ b/.kit/skills/review-handoff/SKILL.md
@@ -47,6 +47,13 @@ Reference shape: the KIT-0037/38/39 bundle (PR #71) —
 `.kit/context/reviews/KIT-0038-evaluator-review.md` are the canonical
 examples of pointer files.
 
+**Multi-PR task** (one task ID, several sequential PRs — KIT-0035's
+shape): the task-level artifacts live on ONE branch (put them on the
+first/primary PR's branch; sibling PRs must not touch them, or the
+branches conflict). Until that PR merges, preflight run against a
+sibling branch shows spurious Gate 5–7 FAILs — expected, not a
+regression; re-run after the artifact-carrying PR merges.
+
 If you forget, Gates 5/6's FAIL output names this convention — but doing
 it here, before preflight, is the intended path.
 

--- a/.kit/skills/review-handoff/SKILL.md
+++ b/.kit/skills/review-handoff/SKILL.md
@@ -1,10 +1,10 @@
 ---
 description: How to hand off a PR for human code review after automated reviews pass
 user-invocable: false
-version: 1.0.0
+version: 1.1.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-02-27
+last-updated: 2026-07-13
 created-by: "@movito with planner2"
 ---
 
@@ -21,6 +21,34 @@ After automated review is complete, you **MUST** request human code review befor
 5. **Notify user**: Include thread count proof (mandatory)
 6. **Address feedback**: Fix any issues from human reviewer
 7. **After approval**: `./scripts/core/project complete <TASK-ID>`
+
+## Bundled PR? Do this FIRST (multiple task IDs, one PR)
+
+Preflight Gates 5/6 check for artifacts named exactly
+`<TASK-ID>-REVIEW-STARTER.md` and `<TASK-ID>-evaluator-review.md` —
+**per task ID**, deliberately (KIT-0042: the gates stay strict; the
+bundle intelligence lives here, in process). When one PR ships several
+tasks, follow the lead-task + pointer-files convention **up front**, not
+after a gate failure:
+
+1. **Pick the lead task** (usually the lowest ID) and write the full
+   review starter and evaluator record under the lead's name, covering
+   the whole bundle.
+2. **For every other bundled task**, create two short pointer files with
+   the exact solo-task names:
+   - `.kit/context/<TASK-ID>-REVIEW-STARTER.md` — a few lines: names the
+     bundle + PR, points at the lead's starter, and states this task's
+     slice of the change.
+   - `.kit/context/reviews/<TASK-ID>-evaluator-review.md` — points at the
+     lead's evaluator record (and notes any per-task skip rationale).
+
+Reference shape: the KIT-0037/38/39 bundle (PR #71) —
+`.kit/context/KIT-0038-REVIEW-STARTER.md` and
+`.kit/context/reviews/KIT-0038-evaluator-review.md` are the canonical
+examples of pointer files.
+
+If you forget, Gates 5/6's FAIL output names this convention — but doing
+it here, before preflight, is the intended path.
 
 ## Creating Review Starter
 

--- a/.kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md
+++ b/.kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md
@@ -1,6 +1,6 @@
 # KIT-0042: Preflight support for task bundles (Gates 5/6 exact-name match)
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: medium
 **Assigned To**: unassigned
 **Estimated Effort**: 1-2 hours

--- a/.kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md
+++ b/.kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md
@@ -83,3 +83,20 @@ Planner disposition:
 - **Declined — `.bundle-manifest` / programmatic bundle definition**: the
   evaluator itself notes it exceeds the task's effort; two observed bundles
   don't justify a manifest format. Revisit if bundle shapes diversify.
+
+## Addendum (2026-07-13, planner — from the KIT-0035 retro, filed after this task started)
+
+**F1.1 gains a second case.** KIT-0035 ran as ONE task across TWO
+sequential PRs, and preflight on PR 2's branch showed 3 spurious FAILs
+(Gates 5–7) by design — the task-level artifacts lived on PR 1's branch
+until it merged. The output read like a real failure
+(`No evaluator review found for KIT-0035`).
+
+So the F1.1 FAIL text should name BOTH situations, e.g.:
+
+> `(bundled PR? each task needs its own pointer file — see review-handoff
+> skill. Multi-PR task? artifacts may live on the sibling PR's branch
+> until it merges.)`
+
+One extended message string covers both; no new logic required. Evidence:
+`.kit/context/retros/KIT-0035-retro.md` (Surprising #3, Should Change #3).

--- a/.kit/tasks/4-in-review/KIT-0042-preflight-bundle-support.md
+++ b/.kit/tasks/4-in-review/KIT-0042-preflight-bundle-support.md
@@ -1,6 +1,6 @@
 # KIT-0042: Preflight support for task bundles (Gates 5/6 exact-name match)
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: medium
 **Assigned To**: unassigned
 **Estimated Effort**: 1-2 hours

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -478,7 +478,7 @@ EVAL_FILE=$(find .kit/context/reviews \
 if [ -n "$EVAL_FILE" ]; then
     echo "GATE:5:Evaluator:PASS:$EVAL_FILE"
 else
-    echo "GATE:5:Evaluator:FAIL:No evaluator review found for $TASK_ID (bundled PR? each task needs its own pointer record named ${TASK_ID}-evaluator-review.md — see the review-handoff skill: lead-task + pointer files)"
+    echo "GATE:5:Evaluator:FAIL:No evaluator review found for $TASK_ID (bundled PR? each task needs its own pointer record named ${TASK_ID}-evaluator-review.md — see the review-handoff skill. Multi-PR task? artifacts may live on the sibling PR's branch until it merges.)"
     ANY_FAILED=true
 fi
 
@@ -489,7 +489,7 @@ STARTER_FILE=$(find .kit/context -maxdepth 1 -name "${TASK_ID}-REVIEW-STARTER.md
 if [ -n "$STARTER_FILE" ]; then
     echo "GATE:6:ReviewStarter:PASS:$STARTER_FILE"
 else
-    echo "GATE:6:ReviewStarter:FAIL:No review starter found for $TASK_ID (bundled PR? each task needs its own pointer starter named ${TASK_ID}-REVIEW-STARTER.md — see the review-handoff skill: lead-task + pointer files)"
+    echo "GATE:6:ReviewStarter:FAIL:No review starter found for $TASK_ID (bundled PR? each task needs its own pointer starter named ${TASK_ID}-REVIEW-STARTER.md — see the review-handoff skill. Multi-PR task? artifacts may live on the sibling PR's branch until it merges.)"
     ANY_FAILED=true
 fi
 

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -478,7 +478,7 @@ EVAL_FILE=$(find .kit/context/reviews \
 if [ -n "$EVAL_FILE" ]; then
     echo "GATE:5:Evaluator:PASS:$EVAL_FILE"
 else
-    echo "GATE:5:Evaluator:FAIL:No evaluator review found for $TASK_ID"
+    echo "GATE:5:Evaluator:FAIL:No evaluator review found for $TASK_ID (bundled PR? each task needs its own pointer record named ${TASK_ID}-evaluator-review.md — see the review-handoff skill: lead-task + pointer files)"
     ANY_FAILED=true
 fi
 
@@ -489,7 +489,7 @@ STARTER_FILE=$(find .kit/context -maxdepth 1 -name "${TASK_ID}-REVIEW-STARTER.md
 if [ -n "$STARTER_FILE" ]; then
     echo "GATE:6:ReviewStarter:PASS:$STARTER_FILE"
 else
-    echo "GATE:6:ReviewStarter:FAIL:No review starter found for $TASK_ID"
+    echo "GATE:6:ReviewStarter:FAIL:No review starter found for $TASK_ID (bundled PR? each task needs its own pointer starter named ${TASK_ID}-REVIEW-STARTER.md — see the review-handoff skill: lead-task + pointer files)"
     ANY_FAILED=true
 fi
 

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -478,7 +478,7 @@ EVAL_FILE=$(find .kit/context/reviews \
 if [ -n "$EVAL_FILE" ]; then
     echo "GATE:5:Evaluator:PASS:$EVAL_FILE"
 else
-    echo "GATE:5:Evaluator:FAIL:No evaluator review found for $TASK_ID (bundled PR? each task needs its own pointer record named ${TASK_ID}-evaluator-review.md — see the review-handoff skill. Multi-PR task? artifacts may live on the sibling PR's branch until it merges.)"
+    echo "GATE:5:Evaluator:FAIL:No evaluator review found for $TASK_ID (bundled PR? each task needs its own pointer record named .kit/context/reviews/${TASK_ID}-evaluator-review.md — see the review-handoff skill. Multi-PR task? artifacts may live on the sibling PR's branch until it merges.)"
     ANY_FAILED=true
 fi
 
@@ -489,7 +489,7 @@ STARTER_FILE=$(find .kit/context -maxdepth 1 -name "${TASK_ID}-REVIEW-STARTER.md
 if [ -n "$STARTER_FILE" ]; then
     echo "GATE:6:ReviewStarter:PASS:$STARTER_FILE"
 else
-    echo "GATE:6:ReviewStarter:FAIL:No review starter found for $TASK_ID (bundled PR? each task needs its own pointer starter named ${TASK_ID}-REVIEW-STARTER.md — see the review-handoff skill. Multi-PR task? artifacts may live on the sibling PR's branch until it merges.)"
+    echo "GATE:6:ReviewStarter:FAIL:No review starter found for $TASK_ID (bundled PR? each task needs its own pointer starter named .kit/context/${TASK_ID}-REVIEW-STARTER.md — see the review-handoff skill. Multi-PR task? artifacts may live on the sibling PR's branch until it merges.)"
     ANY_FAILED=true
 fi
 

--- a/scripts/core/preflight-check.sh
+++ b/scripts/core/preflight-check.sh
@@ -469,10 +469,13 @@ fi
 #   <TASK>-evaluator-review*.md  (legacy)
 #   <TASK>-code-review*.md       (current)
 #   <TASK>-code-reviewer*.md     (alt — code-reviewer-fast variant)
+# -type f -size +0c: an empty file (botched write, bare touch) is not a
+# persisted review — require a non-empty regular file (KIT-0042).
 EVAL_FILE=$(find .kit/context/reviews \
     \( -name "${TASK_ID}-evaluator-review*.md" \
     -o -name "${TASK_ID}-code-review*.md" \
     -o -name "${TASK_ID}-code-reviewer*.md" \) \
+    -type f -size +0c \
     2>/dev/null | head -1 || true)
 
 if [ -n "$EVAL_FILE" ]; then
@@ -484,7 +487,7 @@ fi
 
 # ─── Gate 6: Review starter exists ──────────────────────────────────
 
-STARTER_FILE=$(find .kit/context -maxdepth 1 -name "${TASK_ID}-REVIEW-STARTER.md" 2>/dev/null | head -1 || true)
+STARTER_FILE=$(find .kit/context -maxdepth 1 -name "${TASK_ID}-REVIEW-STARTER.md" -type f -size +0c 2>/dev/null | head -1 || true)
 
 if [ -n "$STARTER_FILE" ]; then
     echo "GATE:6:ReviewStarter:PASS:$STARTER_FILE"

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -454,6 +454,35 @@ class TestGate56Bundle:
             for path in (starter, record, task):
                 path.unlink(missing_ok=True)
 
+    def test_prefix_is_not_a_match_boundary_violation(self, proj):
+        # Boundary pinning (KIT-0040 lesson, kept even on the convention
+        # route): the fixture's KIT-9999 artifacts must NOT satisfy the
+        # gates for the shorter task ID KIT-999 — the literal separator
+        # after ${TASK_ID} in every Gate 5/6 pattern is the boundary.
+        result = proj.run(_baseline(proj.head), extra_args=["--task", "KIT-999"])
+        gates = _gates(result.stdout)
+        assert gates[5][0] == "FAIL", result.stdout
+        assert gates[6][0] == "FAIL", result.stdout
+
+    def test_empty_pointer_files_do_not_pass(self, proj):
+        # A zero-byte "pointer" (botched write, or a bare touch) must
+        # not satisfy Gates 5/6 — the find requires a non-empty regular
+        # file.
+        starter = proj.root / ".kit" / "context" / "KIT-9996-REVIEW-STARTER.md"
+        record = (
+            proj.root / ".kit" / "context" / "reviews" / "KIT-9996-evaluator-review.md"
+        )
+        try:
+            starter.write_text("", encoding="utf-8")
+            record.write_text("", encoding="utf-8")
+            result = proj.run(_baseline(proj.head), extra_args=["--task", "KIT-9996"])
+            gates = _gates(result.stdout)
+            assert gates[5][0] == "FAIL", result.stdout
+            assert gates[6][0] == "FAIL", result.stdout
+        finally:
+            for path in (starter, record):
+                path.unlink(missing_ok=True)
+
     def test_fail_details_name_bundle_convention(self, proj):
         # No artifacts exist for KIT-9997 → Gates 5/6 FAIL, and each
         # detail must point at BOTH conventions (F1.1 + the 2026-07-13

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -122,7 +122,9 @@ class PreflightProject:
         self.env = env
         self.head = head
 
-    def run(self, files: dict[str, str]) -> subprocess.CompletedProcess:
+    def run(
+        self, files: dict[str, str], extra_args: list[str] | None = None
+    ) -> subprocess.CompletedProcess:
         # The project fixture is module-scoped (the git repo and .kit
         # artifacts are read-only during a run); the canned payloads are
         # per-scenario, so wipe leftovers from the previous test first.
@@ -136,6 +138,7 @@ class PreflightProject:
                 str(self.root / "scripts" / "core" / "preflight-check.sh"),
                 "--pr",
                 "42",
+                *(extra_args or []),
             ],
             cwd=self.root,
             env=self.env,
@@ -415,3 +418,52 @@ class TestGate3BugBot:
         assert verdict == "PASS", result.stdout
         assert "check-run" in detail
         assert result.returncode == 0
+
+
+# ── Gates 5/6: bundled-PR convention (KIT-0042) ──────────────────────────
+class TestGate56Bundle:
+    """A bundled PR satisfies Gates 5/6 via per-task pointer files named
+    exactly like a solo task's artifacts (reference shape: the
+    KIT-0037/38/39 bundle's pointer files), and the FAIL detail names
+    that convention so nobody discovers it by failing the gate.
+    """
+
+    def test_pointer_files_pass_gates_5_6_for_non_lead_task(self, proj):
+        # Bundle lead is HEAD_TASK (fixture artifacts); a bundled task
+        # KIT-9998 carries its own pointer starter + pointer record.
+        starter = proj.root / ".kit" / "context" / "KIT-9998-REVIEW-STARTER.md"
+        record = (
+            proj.root / ".kit" / "context" / "reviews" / "KIT-9998-evaluator-review.md"
+        )
+        task = proj.root / ".kit" / "tasks" / "3-in-progress" / "KIT-9998-stub-task.md"
+        try:
+            starter.write_text(
+                f"Pointer: see {HEAD_TASK}-REVIEW-STARTER.md (bundle lead)\n",
+                encoding="utf-8",
+            )
+            record.write_text(
+                f"Pointer: see {HEAD_TASK}-evaluator-review.md (bundle lead)\n",
+                encoding="utf-8",
+            )
+            task.write_text("task\n", encoding="utf-8")
+            result = proj.run(_baseline(proj.head), extra_args=["--task", "KIT-9998"])
+            gates = _gates(result.stdout)
+            assert gates[5][0] == "PASS", result.stdout
+            assert gates[6][0] == "PASS", result.stdout
+        finally:
+            for path in (starter, record, task):
+                path.unlink(missing_ok=True)
+
+    def test_fail_details_name_bundle_convention(self, proj):
+        # No artifacts exist for KIT-9997 → Gates 5/6 FAIL, and each
+        # detail must point at the bundle convention (F1.1) while the
+        # parseable GATE:N:Name:FAIL: prefix stays intact (harness
+        # regex in _gates would not match otherwise).
+        result = proj.run(_baseline(proj.head), extra_args=["--task", "KIT-9997"])
+        gates = _gates(result.stdout)
+        for gate_num in (5, 6):
+            verdict, detail = gates[gate_num]
+            assert verdict == "FAIL", result.stdout
+            assert "bundled PR" in detail, detail
+            assert "review-handoff" in detail, detail
+        assert result.returncode == 1

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -456,9 +456,12 @@ class TestGate56Bundle:
 
     def test_fail_details_name_bundle_convention(self, proj):
         # No artifacts exist for KIT-9997 → Gates 5/6 FAIL, and each
-        # detail must point at the bundle convention (F1.1) while the
-        # parseable GATE:N:Name:FAIL: prefix stays intact (harness
-        # regex in _gates would not match otherwise).
+        # detail must point at BOTH conventions (F1.1 + the 2026-07-13
+        # spec addendum): the bundle pointer files and the multi-PR-task
+        # case (artifacts on a sibling PR's branch — the KIT-0035
+        # spurious-FAIL evidence). The parseable GATE:N:Name:FAIL:
+        # prefix stays intact (harness regex in _gates would not match
+        # otherwise).
         result = proj.run(_baseline(proj.head), extra_args=["--task", "KIT-9997"])
         gates = _gates(result.stdout)
         for gate_num in (5, 6):
@@ -466,4 +469,5 @@ class TestGate56Bundle:
             assert verdict == "FAIL", result.stdout
             assert "bundled PR" in detail, detail
             assert "review-handoff" in detail, detail
+            assert "Multi-PR task" in detail, detail
         assert result.returncode == 1


### PR DESCRIPTION
## Summary

Makes multi-task (bundled) PRs stop discovering the Gates 5/6 artifact convention by failing the gate. **Route chosen: (b) convention + F1.1** — the gates stay strict; the FAIL message and the review-handoff skill teach the fix. Includes the planner's 2026-07-13 spec addendum: the FAIL text also names the **multi-PR-task** case.

### Mechanism + code-vs-process reasoning (acceptance criterion)

Bundle intelligence belongs in **process, not gate code**:

- The gates' value is an unambiguous per-task artifact contract (exact `<TASK-ID>-...` names). Pointer files keep that contract **shape-agnostic**: bundles have already taken two shapes (KIT-0036's two-PR arc, KIT-0037/38/39's single-PR bundle), and a glob would hardcode the `LEAD-NN-NN` filename shape into the gate — needing rework the first time a bundle looks different.
- The glob route is also boundary-unsafe in shell: `find -name` globs cannot express a name terminator, so prefix safety (KIT-0004 must not match `KIT-0040-...`) would force regex matching into a safety-critical script — to save N−1 five-line pointer files that have independent value (a human looking up KIT-0038 finds a file *named* KIT-0038).
- F1.1 closes the actual discoverability gap: whoever hits the gate without reading the skill learns the fix from the FAIL line itself. The test proves the convention needs **zero gate-logic change** — pointer files pass the exact-name find natively.

### Changes

- **`scripts/core/preflight-check.sh`**: Gates 5/6 FAIL details name the bundle convention with the exact expected filename, plus the multi-PR-task case ("artifacts may live on the sibling PR's branch until it merges" — the KIT-0035 spurious-FAIL evidence). `GATE:N:Name:FAIL:` prefix format untouched (harness regex asserts it).
- **`.kit/skills/review-handoff/SKILL.md` (1.1.0)**: new "Bundled PR? Do this FIRST" section — lead-task naming + one pointer starter and one pointer evaluator record per bundled task, citing the KIT-0037/38/39 pointer files (`KIT-0038-REVIEW-STARTER.md`, `reviews/KIT-0038-evaluator-review.md`) as the reference shape — plus the multi-PR-task artifact-placement note.
- **`tests/test_preflight_check.py`**: bundle scenario (pointer files → Gates 5/6 PASS for a non-lead task) + FAIL-message content assertions pinning both F1.1 pointers; harness `run()` gains `extra_args` for `--task`.

Prefix false-positive tests are N/A per the spec (conditional on the glob route; exact-name matching is unchanged).

**Note**: this branch also carries `f7a6c90` ("docs(planner): KIT-0035 retro follow-through") — a planner-session commit that landed on the checked-out branch while this task was in flight. It's docs-only (TESTING-WORKFLOW/COMMIT-PROTOCOL/REVIEW-INSIGHTS updates + the KIT-0042 spec addendum this PR implements) and merges harmlessly with it.

## Test plan

- [x] TDD: FAIL-message assertions written first, red against old messages, green after (both rounds)
- [x] `pytest tests/test_preflight_check.py` — 12 passed
- [x] `./scripts/core/ci-check.sh` green
- [x] Gate 5/6 detail-line consumers checked: only the harness regex and agent-read command docs parse `GATE:` lines — no colon-sensitive field splitters

## Task

`.kit/tasks/3-in-progress/KIT-0042-preflight-bundle-support.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULQcU9dmD1fxxZNZ6fD1a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to preflight messaging, find predicates, process docs, and tests on a developer-run script; no auth, payment, or production runtime paths.
> 
> **Overview**
> **Preflight Gates 5/6** stay on exact per-task artifact names; this PR makes bundled and multi-PR workflows discoverable without loosening gate logic. **`preflight-check.sh`** now requires **non-empty regular files** (`-type f -size +0c`) for evaluator records and review starters, and **FAIL lines** spell out repo-relative pointer paths, the **review-handoff** skill, and the **multi-PR task** case (artifacts on a sibling branch until merge).
> 
> **`review-handoff` skill (v1.1.0)** adds a **“Bundled PR? Do this FIRST”** section (lead task + per-task pointer files, KIT-0037/38/39 as reference) plus multi-PR placement guidance.
> 
> **`tests/test_preflight_check.py`** gains four bundle tests (pointer PASS, prefix boundary, empty file FAIL, F1.1 message content) and **`PreflightProject.run()`** accepts **`extra_args`** (e.g. `--task`). Docs/bookkeeping: task moved to **4-in-review**, review starter and evaluator disposition record, **TESTING-WORKFLOW** / **COMMIT-PROTOCOL** / **REVIEW-INSIGHTS** updates from related retro work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5644cdbc9c13a9837a6b37e579811d7d95f8247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->