### PR TITLE
feat(KIT-0044): worktree-based implementation sessions — helper, LAUNCH block, workflow doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,7 +159,9 @@ logs/
 
 # Adversarial Workflow
 # Evaluators are installed via: ./scripts/core/project install-evaluators
-.adversarial/evaluators/
+# No trailing slash: in provisioned worktrees this is a SYMLINK to the
+# primary clone's install, and dir-only patterns don't match symlinks
+.adversarial/evaluators
 
 # Dispatch (runtime artifacts)
 .dispatch/config.local.yml

--- a/.kit/context/KIT-0044-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0044-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0044 Handoff — feature-developer
 
-**Task**: `.kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0044-worktree-based-implementation-sessions.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-14 (planner-f5)
 **Estimated effort**: 3–4 hours

--- a/.kit/context/KIT-0044-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0044-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0044 Handoff — feature-developer
 
-**Task**: `.kit/tasks/2-todo/KIT-0044-worktree-based-implementation-sessions.md`
+**Task**: `.kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-14 (planner-f5)
 **Estimated effort**: 3–4 hours

--- a/.kit/context/KIT-0044-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0044-REVIEW-STARTER.md
@@ -1,0 +1,44 @@
+# KIT-0044 Review Starter — Worktree-Based Implementation Sessions
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/76
+**Branch**: `feature/KIT-0044-worktree-sessions` (worktree: `../ask-worktrees/KIT-0044`)
+**Task**: `.kit/tasks/4-in-review/KIT-0044-worktree-based-implementation-sessions.md`
+**Date**: 2026-07-14
+**Agent**: feature-developer-f5 (second worktree pilot — self-demonstrating task)
+
+## What shipped
+
+| Req | Deliverable |
+|-----|-------------|
+| F1 | `scripts/local/new-worktree.sh` — create from fresh `origin/main`, enumerated provisioning list (`.venv`, `.env`, `.adversarial/evaluators` symlinks), sources pre-flighted before creation, refuses on existing path/branch/multiple specs/bare primary/missing origin-main |
+| F2 | `TASK-STARTER-TEMPLATE.md` 1.1.0 — un-skippable LAUNCH block above FIRST ACTIONS; first action is branch-verify |
+| F3 | Lifecycle in `WORKTREE-WORKFLOW.md` — session leaves worktree clean; planner removes post-retro |
+| F4 | `.kit/context/workflows/WORKTREE-WORKFLOW.md` — topology, creation, GIT_DIR contract + canary, closeout; linked from CLAUDE.md |
+| F5 | Bare-hub decision record in the doc — declined at current scale, 3 revisit triggers |
+| — | `.gitignore`: `.adversarial/evaluators` (no trailing slash) so the provisioning symlink is ignored — keeps `git worktree remove` working without `--force` |
+| — | `prepare-review-input.sh` 1.5.1 — dead `ADVERSARIAL_UNATTENDED` hint replaced with the working `echo y \|` pattern |
+
+## Review state
+
+- **CI**: green (lint, tests 418 passed / 92.6% coverage)
+- **Bots**: BugBot pass (0 findings); CodeRabbit CHANGES_REQUESTED → 3 threads all fixed in `23c2e8f` → **APPROVED**; 3/3 threads resolved with replies
+- **Evaluators** (run BEFORE PR, doc-dominated rule): fast-v2 CONCERNS / o3 CONCERNS / claude-code APPROVED — 4 accepted, 9 declined with evidence, incl. 2 disproven o3 claims. Disposition: `.kit/context/reviews/KIT-0044-evaluator-review.md`
+- **Preflight**: 6/7 before this file existed; Gate 6 satisfied by this starter
+
+## Verification highlights
+
+- Helper exercised live from inside a worktree: symlinks resolve to the primary (common-dir logic verified)
+- Scratch cycle: create → 419 tests collect → adversarial CLI lists evaluators → refusals (path/branch/bad-ID/no-spec/multi-spec) all exit 1 → empty-commit pre-commit run → **canary green** (`core.bare=false` in primary after every pre-commit run this session)
+- Plain `git worktree remove` verified to work once symlinks are gitignored (isolated-repo experiment); worktrees created before this PR merges still need `--force`
+
+## Reviewer attention points
+
+1. `scripts/local/` placement (N3 default) — argued in the PR body; a `project worktree` subcommand would ship a bigger contract downstream
+2. The bare-hub decision record (F5) — confirm the revisit triggers match planner expectations
+3. `prepare-review-input.sh` is `scripts/core/` (synced downstream) — version bumped 1.5.0 → 1.5.1, no manifest count change
+
+## Post-merge planner actions
+
+- Remove this worktree after reading the retro: `git worktree remove ../ask-worktrees/KIT-0044` (may need `--force` — created pre-fix)
+- `./scripts/core/project complete KIT-0044`
+- Retro: `.kit/context/retros/KIT-0044-retro.md`

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0044",
     "task_started": null,
     "brief_note": "KIT-0043 DONE + retro processed (bare-repo state was GIT_DIR damage, corrected + restored by fd; conftest-wide isolation shipped 7ef104d; knowledge extracted). KIT-0044 drafted from the 6 verified pilot frictions, evaluated (2 minor findings accepted), promoted; worktree pre-provisioned at ../ask-worktrees/KIT-0044 (venv+env+evaluators, fresh origin/main). After KIT-0044: ADR-0025 slim = last v0.8.0 content, then release mechanics. Verdict queue EMPTY; zero open PRs.",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0044-worktree-based-implementation-sessions.md",
     "handoff_file": ".kit/context/KIT-0044-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0044",
     "task_started": null,
     "brief_note": "KIT-0044 (codify worktree sessions: helper, template LAUNCH block, lifecycle, WORKTREE-WORKFLOW.md, bare-hub decision record) ready. SECOND PILOT: repo root is ../ask-worktrees/KIT-0044 (fully provisioned incl. evaluators). Doc-dominated: evaluator trio BEFORE PR open.",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0044-worktree-based-implementation-sessions.md",
     "handoff_file": ".kit/context/KIT-0044-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0044",
     "task_started": null,
     "brief_note": "KIT-0043 DONE + retro processed (bare-repo state was GIT_DIR damage, corrected + restored by fd; conftest-wide isolation shipped 7ef104d; knowledge extracted). KIT-0044 drafted from the 6 verified pilot frictions, evaluated (2 minor findings accepted), promoted; worktree pre-provisioned at ../ask-worktrees/KIT-0044 (venv+env+evaluators, fresh origin/main). After KIT-0044: ADR-0025 slim = last v0.8.0 content, then release mechanics. Verdict queue EMPTY; zero open PRs.",
-    "details_link": ".kit/tasks/2-todo/KIT-0044-worktree-based-implementation-sessions.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md",
     "handoff_file": ".kit/context/KIT-0044-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0044",
     "task_started": null,
     "brief_note": "KIT-0044 (codify worktree sessions: helper, template LAUNCH block, lifecycle, WORKTREE-WORKFLOW.md, bare-hub decision record) ready. SECOND PILOT: repo root is ../ask-worktrees/KIT-0044 (fully provisioned incl. evaluators). Doc-dominated: evaluator trio BEFORE PR open.",
-    "details_link": ".kit/tasks/2-todo/KIT-0044-worktree-based-implementation-sessions.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md",
     "handoff_file": ".kit/context/KIT-0044-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/retros/KIT-0044-retro.md
+++ b/.kit/context/retros/KIT-0044-retro.md
@@ -1,0 +1,113 @@
+## KIT-0044 — Worktree-Based Implementation Sessions (PR #76) — SECOND WORKTREE PILOT
+
+**Date**: 2026-07-14
+**Agent**: feature-developer-f5
+**Mode**: single-repo (session ran in `ask-worktrees/KIT-0044`, pre-provisioned by the planner)
+**Scorecard**: 3 threads, 0 regressions, 1 fix round, 4 commits (+1 pending: handoff/retro)
+
+### Six-friction confirmation (the acceptance criterion)
+
+| # | KIT-0043 friction | Status |
+|---|-------------------|--------|
+| 1 | Session tab not in worktree (~40 `cd` prefixes) | **ADDRESSED** (LAUNCH block un-skippable in template 1.1.0; helper prints it) — but see Surprising #1: the harness *still* resets shell cwd between Bash calls even in a worktree-launched session, so `cd` prefixes persist at a level no kit artifact can fix |
+| 2 | Stale pre-created branch | **ADDRESSED** — helper branches from fresh `origin/main` after fetch; reproduced live this session (worktree was 1 behind at start because it predated the planner's task-spec commit; ff-merged) |
+| 3 | Missing gitignored runtime artifacts | **ADDRESSED** — enumerated list in the helper, sources pre-flighted before creation (CodeRabbit hardening), `.gitignore` audit done (Serena/dispatch/caches deliberately excluded, reasons in the helper comments) |
+| 4 | GIT_DIR env contract | **ADDRESSED** — documented in WORKTREE-WORKFLOW.md (contract + canary); conftest fix NOT re-implemented (N2); canary green after every pre-commit run this session |
+| 5 | Bare-repo closeout / bare-hub question | **ADDRESSED** — decision record in the doc: declined at current scale, enumerated migration costs, 3 revisit triggers |
+| 6 | Worktree lifecycle ownership | **ADDRESSED** — planner removes post-retro; plain `remove` works once the `.gitignore` symlink fix merges (verified in isolated repo) |
+
+### What Worked
+
+1. **The task was genuinely self-demonstrating** — running the helper from
+   *inside* the KIT-0044 worktree proved the `git-common-dir` resolution
+   (symlinks landed on the primary, not the invoking worktree), which then
+   became the decline evidence for o3's nested-worktree finding. Build
+   artifact and test fixture were the same object.
+2. **Evaluator-before-PR ordering (KIT-0035 F3) again produced a quiet PR** —
+   4 evaluator findings fixed pre-push; the bots then found only 3 issues,
+   all fixable in one round, and CodeRabbit flipped to APPROVED on the fix
+   commit. Second consecutive validation of the ordering rule.
+3. **Verify-before-believing killed two o3 claims in one command each** —
+   "`--path-format` needs git ≥2.43" (works on local 2.39.2; landed in
+   2.31) and "nested-worktree dirname math is one level too high"
+   (`dirname /repo/.git` = `/repo`, verified from both primary and
+   worktree). Cost: ~20 seconds; saved: two pointless rewrites.
+4. **The scratch-worktree test loop surfaced a real design bug the spec
+   didn't anticipate** — plain `git worktree remove` was permanently blocked
+   by the unignored evaluators symlink (dir-only `.gitignore` pattern).
+   The empirical cycle (create → commit → remove) found it; static review
+   had not.
+5. **Canary discipline held all session** — `core.bare=false` checked after
+   every pre-commit run in the worktree (4 runs). The KIT-0043 leak class
+   stayed dead under real hook conditions; the conftest fix is validated.
+
+### What Was Surprising
+
+1. **A worktree-launched session still pays cd prefixes** — the harness
+   resets the shell cwd to the *primary clone* after every Bash call
+   (`Shell cwd was reset to …/agentive-starter-kit`), even though this
+   session's tab was opened in the worktree. Friction #1 is only half-fixed:
+   the LAUNCH block puts file tools in the right place, but shell commands
+   still need explicit `cd`/`git -C` prefixes. This is harness behavior,
+   not something a kit artifact can change — worth a note in
+   WORKTREE-WORKFLOW.md if it persists next session.
+2. **The aider-based evaluator MUTATED the working tree during review** —
+   `code-reviewer-fast-v2` applied its nullglob SEARCH/REPLACE edit
+   directly to `scripts/local/new-worktree.sh` mid-review ("Applied edit
+   to…" in its log) despite the input being added read-only. The edit was
+   benign and kept, but a hostile-or-wrong edit would have been silently
+   committed later. New rule: **run `git status` immediately after every
+   evaluator invocation**.
+3. **`ADVERSARIAL_UNATTENDED` never existed** — all three first-round
+   evaluator runs died on the interactive large-input prompt (EOFError).
+   The env flag that `prepare-review-input.sh` 1.5.0 advertised (added in
+   the KIT-0035/0040 era) appears nowhere in the installed library source.
+   I shipped a hint in a core script without verifying it against the
+   installed package — same lesson as the bare-repo misattribution, one
+   layer down. Fixed in 1.5.1 (`echo y |` piping, verified working).
+4. **CodeRabbit's three findings were all real** — no noise round this
+   time: the template example genuinely drifted (derived slug ≠ shown
+   branch), the "from anywhere" claim was genuinely wrong, and
+   warn-and-continue genuinely contradicted the "fully-provisioned"
+   contract. Fix quality benefited from the temp-then-commit pattern
+   already being documented — pre-flight-then-mutate was the obvious shape.
+
+### What Should Change
+
+1. **Evaluator post-run `git status` check** — add to the
+   code-review-evaluator skill and/or Phase 7 of feature-developer:
+   aider-based evaluators can write to the repo; diff/status must be
+   inspected after every run before anything is staged (Surprising #2).
+2. **Verify shipped hints against installed tool versions** — a
+   "helpful hint" printed by a core script is a claim about another tool's
+   interface; it needs the same verify-before-believing treatment as an
+   evaluator finding (grep the installed package, run it once). Candidate
+   for the self-review checklist (Surprising #3).
+3. **Harness cwd-reset needs one more session of data** — if the next
+   worktree session also gets per-call cwd resets to the primary, document
+   the `git -C`/`cd`-prefix requirement in WORKTREE-WORKFLOW.md as the
+   standing pattern instead of treating it as friction to eliminate
+   (Surprising #1).
+4. **Preflight arg shape is easy to get wrong** — `preflight-check.sh
+   KIT-0044 --pr 76` fails ("Unknown argument"); it wants `--task KIT-0044
+   --pr 76`. The preflight skill's own Step 1 example shows the positional
+   form. Fix the skill doc (or accept a positional task-id in the script).
+
+### Permission Prompts Hit
+
+None.
+
+### Process Actions Taken
+
+- [x] All six KIT-0043 frictions addressed (table above) — none re-filed
+- [x] `prepare-review-input.sh` 1.5.1: dead UNATTENDED hint replaced with
+      verified `echo y |` pattern
+- [x] Evaluator review + 13-finding disposition persisted
+      (`.kit/context/reviews/KIT-0044-evaluator-review.md`)
+- [x] Scratch worktree + branch fully cleaned up; primary worktree list
+      back to primary + KIT-0044 only
+- [ ] Planner: post-merge, remove this worktree (`--force` — it predates
+      the `.gitignore` fix), `project complete KIT-0044`, delete branch
+- [ ] Planner: consider retro items 1 (evaluator git-status check), 2
+      (verify shipped hints), 4 (preflight skill arg example) as process
+      fixes; item 3 waits for next worktree session's data

--- a/.kit/context/reviews/KIT-0044-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0044-evaluator-review.md
@@ -1,0 +1,46 @@
+# KIT-0044 — Adversarial Evaluator Review
+
+**Date**: 2026-07-14
+**Input**: `.adversarial/inputs/KIT-0044-code-review-input.md` (full-file, 8 files, ~17.5k tokens)
+**Ordering**: evaluators run BEFORE PR open (doc-dominated rule, KIT-0035 F3)
+
+| Evaluator | Model | Verdict |
+|-----------|-------|---------|
+| code-reviewer-fast-v2 | gemini-3-flash-preview | CONCERNS |
+| code-reviewer | o3 | CONCERNS |
+| claude-code | claude-sonnet-4-6 | APPROVED |
+
+Raw logs: `.adversarial/logs/KIT-0044-code-review-input--*.md.md`
+
+## Disposition
+
+| # | Finding (source) | Disposition | Evidence / change |
+|---|------------------|-------------|-------------------|
+| 1 | Multiple task specs for one ID → first glob hit wins (o3 + claude-code, convergent) | **ACCEPTED** | Helper now collects all matches and refuses with the file list when >1 (tested live with a temp duplicate: clean error, exit 1) |
+| 2 | `PRIMARY_ROOT` dirname math silently wrong for a bare primary (claude-code, MEDIUM) | **ACCEPTED** | Guard added: refuse if `$PRIMARY_ROOT/.git` doesn't exist — thematically apt given the pilot's core.bare damage |
+| 3 | No friendly error when `origin/main` missing after fetch (claude-code, LOW) | **ACCEPTED** | `show-ref --verify refs/remotes/origin/main` guard with actionable message |
+| 4 | Unmatched glob passes literal string into loop (fast-v2) | **ACCEPTED (already mitigated)** | `[ -f "$f" ]` made the original safe (the "corrupted SLUG" claim was wrong), but the evaluator's nullglob edit is clearer — kept. Note: the aider-based evaluator APPLIED this edit to the working tree itself; see review note below |
+| 5 | Git < 2.43 lacks `--path-format` → hard fail (o3) | **DECLINED — disproven** | `--path-format` landed in git 2.31; verified live on git 2.39.2: `git rev-parse --path-format=absolute --git-common-dir` succeeds |
+| 6 | Nested-worktree invocation resolves `PRIMARY_ROOT` "one level too high" (o3) | **DECLINED — disproven** | `dirname /repo/.git` = `/repo`, which is correct, not "too high". Verified from both primary and worktree: common-dir → `<primary>/.git`, dirname → primary root. The helper was exercised live from inside the KIT-0044 worktree and symlinked correctly |
+| 7 | `ln -s` "File exists" on re-run after partial deletion (o3) | **DECLINED — structurally impossible** | Any pre-existing worktree path is refused before `ln` can run; `dst` lives inside the just-created worktree, so it cannot pre-exist |
+| 8 | Script invoked via symlink from `~/bin` corrupts paths (fast-v2) | **DECLINED — fails safe** | If `SCRIPT_DIR` is outside the repo, `git -C "$SCRIPT_DIR" rev-parse` errors and `set -e` aborts — loud failure, not corruption. Invocation convention is `./scripts/local/…` (same pattern as `bootstrap-consumer.sh`) |
+| 9 | Slug prefix-strip wrong if TASK-ID appears elsewhere in filename (fast-v2) | **DECLINED — structurally impossible** | The glob `"$TASK_ID"-*.md` guarantees the basename starts with `TASK_ID-`; `${SLUG#…}` strips exactly that anchored prefix |
+| 10 | `mkdir -p` failure yields generic error (fast-v2) | **DECLINED — acceptable** | `set -e` aborts before any mutation beyond the worktree; local operator tool, generic OS error is sufficient |
+| 11 | Broken-symlink provisioning source (fast-v2) | **DECLINED — handled** | `[ ! -e "$src" ]` follows symlinks, so a broken source hits the warn-and-skip path |
+| 12 | `trap ERR` + `continue` interplay (claude-code, LOW) | **DECLINED — no change per reviewer** | Reviewer's own remediation: "No change required; behavior is correct" |
+| 13 | `.gitignore` scope widening to files named `evaluators` (claude-code, LOW) | **DECLINED — acknowledged** | Intentional; the in-file comment covers it (reviewer agreed no change needed) |
+
+## Review notes
+
+- **Evaluator mutated the working tree**: `code-reviewer-fast-v2` (aider-based)
+  *applied* its nullglob SEARCH/REPLACE edit directly to
+  `scripts/local/new-worktree.sh` during the review run ("Applied edit to…"
+  in the log), despite the input file being added read-only. The edit was
+  benign and kept, but evaluator runs must be followed by a `git status`
+  check. Filed as a retro item.
+- **`ADVERSARIAL_UNATTENDED` does not exist**: all three first-round runs
+  died on the interactive large-input prompt (`EOFError` under non-TTY).
+  The env flag advertised by `prepare-review-input.sh` 1.5.0 appears
+  nowhere in the installed library source (verified by grep of the
+  package). Fixed in 1.5.1: the hint now prescribes `echo y |` piping.
+  Related upstream: movito/adversarial-workflow#74.

--- a/.kit/context/workflows/WORKTREE-WORKFLOW.md
+++ b/.kit/context/workflows/WORKTREE-WORKFLOW.md
@@ -25,7 +25,8 @@ planner-side branch-verify habit stays as defense in depth.
 
 ## Creation
 
-One command, run from anywhere in the repo (or any of its worktrees):
+One command, run from the repository root (the primary clone's or any
+worktree's — the helper always resolves the primary internally):
 
 ```bash
 ./scripts/local/new-worktree.sh <TASK-ID> [slug]

--- a/.kit/context/workflows/WORKTREE-WORKFLOW.md
+++ b/.kit/context/workflows/WORKTREE-WORKFLOW.md
@@ -1,0 +1,158 @@
+# Worktree-Based Implementation Sessions
+
+**Purpose**: Per-task git worktrees are the default implementation
+topology — the primary clone stays on `main` for the planner, code
+happens in isolated worktrees
+**Agents**: planner (creation + removal), feature-developer (the session)
+**Last Updated**: 2026-07-14 (KIT-0044, codifying the KIT-0043 pilot)
+
+---
+
+## Topology
+
+- **Primary clone** (`~/Github/agentive-starter-kit/`): the planner's
+  workspace. Always a normal (non-bare) checkout, always on `main`.
+  Task bookkeeping, retros, and merges happen here.
+- **Task worktrees** (`../ask-worktrees/<TASK-ID>/`): one per active
+  implementation task, each on its own `feature/<TASK-ID>-<slug>`
+  branch. All code changes, commits, and pushes happen here.
+
+This makes the shared-mutable-branch hazard class structurally
+impossible: the planner cannot commit onto a checked-out feature branch
+(the f7a6c90 incident), a session cannot be yanked to another branch
+mid-turn, and two sessions never contend for one working tree. The
+planner-side branch-verify habit stays as defense in depth.
+
+## Creation
+
+One command, run from anywhere in the repo (or any of its worktrees):
+
+```bash
+./scripts/local/new-worktree.sh <TASK-ID> [slug]
+```
+
+The helper:
+
+1. Fetches origin and branches from **fresh `origin/main`** — never a
+   local `main` that may be silently stale (the KIT-0043 pilot's
+   pre-created branch was 10 commits behind).
+2. Provisions the gitignored runtime artifacts from an **explicit,
+   enumerated list** maintained inside the helper itself — currently
+   `.venv`, `.env`, and `.adversarial/evaluators/`, all symlinked to
+   the primary clone. New artifacts get added to the list by name,
+   never via an "everything gitignored" glob.
+3. Refuses cleanly if the worktree path or branch already exists.
+4. Prints the launch instruction (below).
+
+Deliberately **not** provisioned: `.serena/project.yml` (Serena
+registers the project by name against the primary path — a second copy
+at another path collides), `.adversarial/logs/` (regenerates),
+`.dispatch/` runtime files and tool caches (regenerate on demand), and
+user-owned untracked directories such as `.kit/adversarial/` (stay in
+the primary; never copied, staged, or deleted).
+
+## Launch
+
+**Open the session tab with its working directory set to the worktree
+path.** This is the un-skippable LAUNCH block in every task starter
+(`.kit/templates/TASK-STARTER-TEMPLATE.md`). A session run from the
+primary clone instead pays a `cd` prefix on every command — measured at
+~40 extra prefixes in the KIT-0043 pilot — and risks operating on the
+wrong checkout.
+
+## The pre-commit GIT_DIR contract
+
+pre-commit exports an **absolute `GIT_DIR`** when it runs inside a
+worktree. Any test or script that shells out to git without cleaning
+its environment silently operates on the REAL repository — and the
+damage is not limited to failing tests. During the KIT-0043 pilot a
+leaked subprocess flipped `core.bare=true` on the primary clone: state
+corruption, second occurrence of the KIT-0036 gotcha class.
+
+The contract, since commit `7ef104d`:
+
+- **Suite-wide isolation is in place**: an autouse fixture in
+  `tests/conftest.py` strips every ambient `GIT_*` variable for every
+  test. Do not re-implement per-module isolation.
+- **New tests rely on the fixture, never on ambient env.** Any new test
+  (or script a test invokes) that spawns git must assume `GIT_*` can be
+  hostile; the conftest fixture covers pytest, but a script that runs
+  git outside pytest must scrub `GIT_*` itself.
+- **Canary**: after any pre-commit run inside a worktree, the primary
+  clone must still report
+
+  ```bash
+  git -C <primary> config core.bare   # must print: false
+  ```
+
+  Run it after your first commit of a session. The exact leak vector
+  from the pilot was never conclusively pinned, so the canary is the
+  proof the isolation holds — a `true` here means a new vector is live:
+  stop, restore (`git -C <primary> config core.bare false`), and file it.
+
+## Closeout
+
+When the task completes:
+
+1. **Session (feature-developer)**: leave the worktree clean — all
+   commits pushed, PR opened/merged per the normal workflow, no
+   uncommitted files. The session never removes its own worktree.
+2. **Planner**: completes the task in the primary clone (task move to
+   `5-done`, retro archived, merged branch deleted).
+
+## Lifecycle — who removes the worktree, and when
+
+The **planner** removes the worktree at task completion, **after the
+retro has been read** (the retro may reference in-worktree state worth
+inspecting first):
+
+```bash
+git worktree remove ../ask-worktrees/<TASK-ID>
+git worktree prune
+git branch -d feature/<TASK-ID>-<slug>   # if not already deleted at merge
+```
+
+`git worktree remove` refuses if the tree is dirty — that refusal is
+the safety net, not an obstacle; inspect before forcing. For this to
+work, every provisioned artifact must be gitignored in a form that
+matches a **symlink** (no trailing slash — dir-only patterns don't
+match symlinks; verified empirically in KIT-0044: an unignored
+provisioning symlink forces `--force` on every removal and erodes the
+safety net). Check `git -C <worktree> status --porcelain` — it must be
+empty before removal.
+
+## Design note: bare-hub layout — evaluated and declined (2026-07-14)
+
+**Option considered**: convert the primary clone to a deliberate bare
+hub (`agentive-starter-kit.git`) with a standing `ask-worktrees/main`
+worktree for the planner, making every checkout — including main — a
+worktree peer.
+
+**Real migration costs** (each verified against current tooling):
+
+- **Claude Code scoping is per-path**: sessions, memory, and permission
+  allow-lists are keyed to the primary clone's path. A bare-hub
+  migration re-keys every one of them; `/resume` history and project
+  memory would strand at the old path.
+- **The adversarial CLI requires a repo-root `.adversarial/`**
+  (ADV-0053 tracks making it configurable). A bare hub has no root
+  working tree to host it; every worktree would need its own installed
+  evaluator set or the symlink scheme extended.
+- **Every script assumes a repo-root working tree**: the ASK-0043
+  root-resolution preambles resolve `PROJECT_ROOT` from the script
+  path, which does not exist in a bare hub.
+- Session cwd conventions, retro/task paths in memory, and the
+  operator's muscle memory all point at the current primary path.
+
+**Decision: declined at current scale.** The non-bare primary +
+per-task worktrees topology captures the isolation benefit without
+paying any migration cost. The KIT-0043 recovery recipe (ff `main`
+inside the bare repo, work from worktrees) is a tested starting point
+if this is ever revisited.
+
+**Revisit triggers** — re-open this decision if any of these change:
+
+1. Claude Code's per-path session/memory/permission scoping model
+   changes (e.g. repo-identity-keyed instead of path-keyed).
+2. The adversarial CLI's repo-root requirement lifts (ADV-0053).
+3. A second operator joins and the primary clone becomes contended.

--- a/.kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md
+++ b/.kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md
@@ -1,6 +1,6 @@
 # KIT-0044: Worktree-based implementation sessions (codify the pilot)
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 3-4 hours

--- a/.kit/tasks/4-in-review/KIT-0044-worktree-based-implementation-sessions.md
+++ b/.kit/tasks/4-in-review/KIT-0044-worktree-based-implementation-sessions.md
@@ -1,6 +1,6 @@
 # KIT-0044: Worktree-based implementation sessions (codify the pilot)
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 3-4 hours

--- a/.kit/templates/TASK-STARTER-TEMPLATE.md
+++ b/.kit/templates/TASK-STARTER-TEMPLATE.md
@@ -1,7 +1,7 @@
 # Task Starter Message Template
 
-**Version**: 1.0.0
-**Last Updated**: 2025-11-16
+**Version**: 1.1.0
+**Last Updated**: 2026-07-14
 **Purpose**: Standardized format for handing off tasks to implementation agents
 **Used By**: Coordinators (planner, coordinator) when assigning tasks
 
@@ -106,10 +106,22 @@ Your mission: [Clear, action-oriented statement of the agent's goal]
 - All [CRITICAL/HIGH/etc.] feedback addressed
 - See handoff file for detailed implementation guidance
 
+**⚠️ LAUNCH** (un-skippable — see `WORKTREE-WORKFLOW.md`):
+Open the session tab with its working directory set to
+`[worktree path, e.g. ../ask-worktrees/[TASK-ID]]` — branch
+`feature/[TASK-ID]-short-description`, created and provisioned via
+`./scripts/local/new-worktree.sh [TASK-ID]`.
+Do NOT run the session from the primary clone.
+
 **⚠️ FIRST ACTIONS** (in order):
-1. `git checkout -b feature/[TASK-ID]-short-description` (create feature branch)
+1. `git branch --show-current` (expect: `feature/[TASK-ID]-short-description`)
 2. `./scripts/core/project start [TASK-ID]` (move task to `3-in-progress/`)
 ```
+
+The LAUNCH block is **mandatory** in every starter — the KIT-0043 pilot
+measured the cost of skipping it (~40 `cd` prefixes when the session ran
+from the primary clone). Create the worktree with the helper BEFORE
+writing the starter, so the path and branch in the block are real.
 
 ### Footer
 
@@ -180,8 +192,14 @@ Your mission: Follow the RED-GREEN-REFACTOR TDD cycle to create a properly teste
 - See handoff file for starting point and implementation details
 - Follow `tests/test_linear_comments.py` as TDD example pattern
 
+**⚠️ LAUNCH** (un-skippable — see `WORKTREE-WORKFLOW.md`):
+Open the session tab with its working directory set to
+`../ask-worktrees/TASK-0102` — branch `feature/TASK-0102-linear-sync-tdd`,
+created and provisioned via `./scripts/local/new-worktree.sh TASK-0102`.
+Do NOT run the session from the primary clone.
+
 **⚠️ FIRST ACTIONS** (in order):
-1. `git checkout -b feature/TASK-0102-linear-sync-tdd`
+1. `git branch --show-current` (expect: `feature/TASK-0102-linear-sync-tdd`)
 2. `./scripts/core/project start TASK-0102`
 
 ---
@@ -312,6 +330,8 @@ Before sending task starter to user:
 - [ ] Time estimate is realistic and broken down by phase
 - [ ] Evaluation status mentioned (if applicable)
 - [ ] Both task file and handoff file links included
+- [ ] **Worktree created** (`./scripts/local/new-worktree.sh <TASK-ID>`) and
+      **LAUNCH block included** with the real worktree path and branch
 - [ ] **FIRST ACTION reminder included** (`./scripts/core/project start <TASK-ID>`)
 - [ ] Recommended agent type specified
 - [ ] agent-handoffs.json updated with task assignment
@@ -327,14 +347,17 @@ After creating task specification and addressing evaluation feedback:
 
 1. Create handoff file: `.kit/context/[TASK-ID]-HANDOFF-[agent-type].md`
 2. Update `agent-handoffs.json` with task assignment
-3. Create task starter message using this template
-4. Send task starter to user
-5. User invokes agent in new tab with task starter
+3. Create the task worktree: `./scripts/local/new-worktree.sh [TASK-ID]`
+4. Create task starter message using this template (LAUNCH block carries
+   the worktree path and branch the helper just printed)
+5. Send task starter to user
+6. User invokes agent in new tab **with cwd set to the worktree path**
 
 ### For Implementation Agents
 
 When receiving task starter:
-1. **Create feature branch**: `git checkout -b feature/<TASK-ID>-short-description`
+1. **Verify the worktree**: `git branch --show-current` must match the
+   LAUNCH block's branch (the worktree already exists — never `checkout -b`)
 2. **Start task**: `./scripts/core/project start <TASK-ID>` to move task to `3-in-progress/`
 3. Read task file for full specification
 4. Read handoff file for implementation guidance
@@ -344,7 +367,8 @@ When receiving task starter:
 
 ---
 
-**Template Version**: 1.0.0
+**Template Version**: 1.1.0
 **Created**: 2025-11-16
 **Maintained By**: Coordinators (planner, coordinator)
-**Related**: AGENT-TEMPLATE.md, OPERATIONAL-RULES.md
+**Related**: AGENT-TEMPLATE.md, OPERATIONAL-RULES.md,
+`.kit/context/workflows/WORKTREE-WORKFLOW.md`

--- a/.kit/templates/TASK-STARTER-TEMPLATE.md
+++ b/.kit/templates/TASK-STARTER-TEMPLATE.md
@@ -110,7 +110,10 @@ Your mission: [Clear, action-oriented statement of the agent's goal]
 Open the session tab with its working directory set to
 `[worktree path, e.g. ../ask-worktrees/[TASK-ID]]` — branch
 `feature/[TASK-ID]-short-description`, created and provisioned via
-`./scripts/local/new-worktree.sh [TASK-ID]`.
+`./scripts/local/new-worktree.sh [TASK-ID] short-description`.
+(Pass the slug explicitly, or omit it and copy the branch name the
+helper derives from the task filename — the LAUNCH block's branch must
+match what the helper actually created.)
 Do NOT run the session from the primary clone.
 
 **⚠️ FIRST ACTIONS** (in order):
@@ -195,7 +198,8 @@ Your mission: Follow the RED-GREEN-REFACTOR TDD cycle to create a properly teste
 **⚠️ LAUNCH** (un-skippable — see `WORKTREE-WORKFLOW.md`):
 Open the session tab with its working directory set to
 `../ask-worktrees/TASK-0102` — branch `feature/TASK-0102-linear-sync-tdd`,
-created and provisioned via `./scripts/local/new-worktree.sh TASK-0102`.
+created and provisioned via
+`./scripts/local/new-worktree.sh TASK-0102 linear-sync-tdd`.
 Do NOT run the session from the primary clone.
 
 **⚠️ FIRST ACTIONS** (in order):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ See `.kit/templates/AGENT-TEMPLATE.md` for creating new agents.
 | Coverage | `.kit/context/workflows/COVERAGE-WORKFLOW.md` |
 | Task completion | `.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md` |
 | Atomic multi-file scripts | `.kit/context/workflows/TEMP-THEN-COMMIT-PATTERN.md` |
+| Worktree sessions | `.kit/context/workflows/WORKTREE-WORKFLOW.md` |
 
 ## Key Scripts
 

--- a/scripts/core/prepare-review-input.sh
+++ b/scripts/core/prepare-review-input.sh
@@ -3,7 +3,7 @@
 # Usage: ./scripts/core/prepare-review-input.sh <TASK-ID> [--base main] [--format diff|full] [--help]
 #
 # Metadata:
-#   version: 1.5.0
+#   version: 1.5.1
 #   origin: ixda-services-2.0 (ID2-0015)
 #   last-updated: 2026-07-05
 #   created-by: "@movito with feature-developer-v6"
@@ -102,9 +102,10 @@ Output:
   .adversarial/inputs/<TASK-ID>-code-review-input.md
 
 Next steps:
-  export ADVERSARIAL_UNATTENDED=1   # non-TTY sessions only: large inputs auto-cancel without it
   set -a && source .env && set +a
-  adversarial code-reviewer-fast .adversarial/inputs/<TASK-ID>-code-review-input.md
+  echo y | adversarial code-reviewer-fast .adversarial/inputs/<TASK-ID>-code-review-input.md
+  # 'echo y |' answers the large-input confirm prompt in non-TTY sessions
+  # (the installed library has no unattended env flag; upstream #74)
 EOF
 }
 
@@ -469,15 +470,20 @@ echo "  Files changed: $CHANGED_COUNT"
 echo
 echo "Next steps:"
 # In a non-TTY session (agent, CI) the adversarial CLI auto-cancels on
-# large (>50k-token) inputs instead of prompting — surface the env flag
-# that prevents it (KIT-0040 retro). A script can't export into the
-# caller's shell, so the export line is printed, not set. Either fd
+# large (>17k-token) inputs instead of prompting — surface the stdin
+# workaround (KIT-0040 retro; corrected in KIT-0044). The previously
+# advertised ADVERSARIAL_UNATTENDED env flag does NOT exist in the
+# installed library (verified: no match in the package source) — the
+# only thing the prompt reads is stdin, so pipe the answer. Either fd
 # being non-TTY marks the session non-interactive: stdin is what the
 # CLI prompt reads, stdout catches piped/captured agent sessions.
 if [ ! -t 0 ] || [ ! -t 1 ]; then
-    echo "  export ADVERSARIAL_UNATTENDED=1  # non-TTY session: large inputs auto-cancel without this"
+    PIPE_Y="echo y | "
+    echo "  # 'echo y |' answers the large-input confirm prompt (no unattended env flag exists; upstream #74)"
+else
+    PIPE_Y=""
 fi
 echo "  set -a && source .env && set +a"
-echo "  adversarial code-reviewer-fast $OUTPUT_FILE  # fast gate (~\$0.01)"
-echo "  adversarial code-reviewer $OUTPUT_FILE       # deep (~\$0.33)"
-echo "  adversarial claude-code $OUTPUT_FILE         # security"
+echo "  ${PIPE_Y}adversarial code-reviewer-fast $OUTPUT_FILE  # fast gate (~\$0.01)"
+echo "  ${PIPE_Y}adversarial code-reviewer $OUTPUT_FILE       # deep (~\$0.33)"
+echo "  ${PIPE_Y}adversarial claude-code $OUTPUT_FILE         # security"

--- a/scripts/local/new-worktree.sh
+++ b/scripts/local/new-worktree.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Create a fully-provisioned per-task worktree for an implementation session.
+#
+# Encodes the KIT-0043/KIT-0044 pilot recipe: branch from FRESH origin/main
+# (never a possibly-stale local main), then provision the gitignored runtime
+# artifacts a session needs. See .kit/context/workflows/WORKTREE-WORKFLOW.md
+# for the topology, the pre-commit GIT_DIR contract, and the lifecycle
+# (the planner removes the worktree after the task's retro is read).
+#
+# Usage:
+#   ./scripts/local/new-worktree.sh <TASK-ID> [slug]
+#
+#   TASK-ID   e.g. KIT-0051 — must have a task spec in .kit/tasks/ unless
+#             a slug is given explicitly
+#   slug      short branch suffix; derived from the task spec filename
+#             when omitted (KIT-0051-fix-the-thing.md -> fix-the-thing)
+#
+# Result:
+#   ../ask-worktrees/<TASK-ID>/  on branch feature/<TASK-ID>-<slug>,
+#   created from origin/main, with .venv, .env and .adversarial/evaluators
+#   symlinked to the primary clone.
+#
+# Refuses (exit 1) if the worktree path or the branch already exists.
+
+set -euo pipefail
+
+# ─────────────────────────────────────────
+# Resolve the PRIMARY clone, not just this script's checkout
+# ─────────────────────────────────────────
+# The script may be invoked from inside another worktree (its checkout has
+# its own copy of scripts/). Symlink sources and the worktree parent dir
+# must always resolve to the primary clone, so derive it from the shared
+# git common dir instead of the script location.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir)"
+PRIMARY_ROOT="$(dirname "$GIT_COMMON_DIR")"
+
+# Sibling directory holding all task worktrees (pilot convention).
+WORKTREES_DIR="$(dirname "$PRIMARY_ROOT")/ask-worktrees"
+
+# ─────────────────────────────────────────
+# Provisioning list — explicit and enumerated, never a glob
+# ─────────────────────────────────────────
+# Gitignored runtime artifacts a session needs, symlinked from the primary.
+# Audited against .gitignore 2026-07-14 (KIT-0044). Deliberately absent:
+#   .serena/project.yml   — Serena registers by name against the primary
+#                           path; a second copy would collide
+#   .adversarial/logs/    — regenerates; history is nice-to-have only
+#   .dispatch/*, caches   — runtime, regenerate on demand
+# Add new entries here by name when a session needs them — never switch
+# to "everything gitignored" (evaluator finding, KIT-0044 spec F1.2).
+# Each entry must be gitignored WITHOUT a trailing slash: dir-only
+# patterns don't match the symlink, which then blocks a plain
+# `git worktree remove` at end of life.
+PROVISION_LINKS=(
+    ".venv"
+    ".env"
+    ".adversarial/evaluators"
+)
+
+# ─────────────────────────────────────────
+# Args
+# ─────────────────────────────────────────
+TASK_ID="${1:-}"
+SLUG="${2:-}"
+
+if [ -z "$TASK_ID" ]; then
+    echo "Usage: $0 <TASK-ID> [slug]" >&2
+    exit 1
+fi
+if ! printf '%s' "$TASK_ID" | grep -qE '^[A-Za-z]+-[0-9]+$'; then
+    echo "Error: TASK-ID must look like PREFIX-NNNN (got: $TASK_ID)" >&2
+    exit 1
+fi
+
+# Derive the slug from the task spec filename when not given.
+if [ -z "$SLUG" ]; then
+    for f in "$PRIMARY_ROOT"/.kit/tasks/*/"$TASK_ID"-*.md; do
+        if [ -f "$f" ]; then
+            SLUG="$(basename "$f")"
+            SLUG="${SLUG%.md}"          # strip extension (never .replace)
+            SLUG="${SLUG#"$TASK_ID"-}"  # strip the TASK-ID- prefix
+            break
+        fi
+    done
+    if [ -z "$SLUG" ]; then
+        echo "Error: no task spec found for $TASK_ID in .kit/tasks/ —" >&2
+        echo "       pass a slug explicitly: $0 $TASK_ID <slug>" >&2
+        exit 1
+    fi
+fi
+
+BRANCH="feature/$TASK_ID-$SLUG"
+WORKTREE_PATH="$WORKTREES_DIR/$TASK_ID"
+
+# ─────────────────────────────────────────
+# Refuse on anything that already exists (idempotent-safe, N1)
+# ─────────────────────────────────────────
+if [ -e "$WORKTREE_PATH" ]; then
+    echo "Error: worktree path already exists: $WORKTREE_PATH" >&2
+    echo "       Remove it first (planner owns removal, post-retro):" >&2
+    echo "       git -C $PRIMARY_ROOT worktree remove $WORKTREE_PATH" >&2
+    exit 1
+fi
+if git -C "$PRIMARY_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    echo "Error: branch already exists: $BRANCH" >&2
+    echo "       Delete it or pass a different slug." >&2
+    exit 1
+fi
+
+# ─────────────────────────────────────────
+# Create: fetch fresh, branch from origin/main (pilot friction #2)
+# ─────────────────────────────────────────
+echo "Fetching origin..."
+git -C "$PRIMARY_ROOT" fetch origin
+
+mkdir -p "$WORKTREES_DIR"
+echo "Creating worktree $WORKTREE_PATH on $BRANCH (from origin/main)..."
+git -C "$PRIMARY_ROOT" worktree add "$WORKTREE_PATH" -b "$BRANCH" origin/main
+
+# From here on, a failure leaves a half-provisioned worktree; tell the
+# operator how to reset rather than deleting anything automatically.
+trap 'echo "Provisioning failed — to retry from scratch:" >&2;
+      echo "  git -C $PRIMARY_ROOT worktree remove --force $WORKTREE_PATH" >&2;
+      echo "  git -C $PRIMARY_ROOT branch -D $BRANCH" >&2' ERR
+
+# ─────────────────────────────────────────
+# Provision (pilot friction #3)
+# ─────────────────────────────────────────
+for rel in "${PROVISION_LINKS[@]}"; do
+    src="$PRIMARY_ROOT/$rel"
+    dst="$WORKTREE_PATH/$rel"
+    if [ ! -e "$src" ]; then
+        echo "⚠️  Skipping $rel — missing in primary clone ($src)." >&2
+        if [ "$rel" = ".adversarial/evaluators" ]; then
+            echo "   Install first: ./scripts/core/project install-evaluators" >&2
+        fi
+        continue
+    fi
+    mkdir -p "$(dirname "$dst")"
+    ln -s "$src" "$dst"
+    echo "Linked $rel -> $src"
+done
+
+trap - ERR
+
+# ─────────────────────────────────────────
+# Launch instruction (pilot friction #1 — un-skippable in the starter too)
+# ─────────────────────────────────────────
+echo ""
+echo "✅ Worktree ready: $WORKTREE_PATH (branch: $BRANCH)"
+echo ""
+echo "⚠️  LAUNCH: open the session tab with its working directory set to"
+echo "    $WORKTREE_PATH"
+echo "    Running the session from the primary clone costs a cd prefix on"
+echo "    every command (measured: ~40 in the KIT-0043 pilot)."

--- a/scripts/local/new-worktree.sh
+++ b/scripts/local/new-worktree.sh
@@ -81,6 +81,9 @@ if ! printf '%s' "$TASK_ID" | grep -qE '^[A-Za-z]+-[0-9]+$'; then
     echo "Error: TASK-ID must look like PREFIX-NNNN (got: $TASK_ID)" >&2
     exit 1
 fi
+# Normalize case like `project start` does — task files, branches and
+# worktree dirs are always uppercase-ID; the glob below is case-sensitive.
+TASK_ID="$(printf '%s' "$TASK_ID" | tr '[:lower:]' '[:upper:]')"
 
 # Derive the slug from the task spec filename when not given.
 if [ -z "$SLUG" ]; then

--- a/scripts/local/new-worktree.sh
+++ b/scripts/local/new-worktree.sh
@@ -128,6 +128,22 @@ if git -C "$PRIMARY_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
 fi
 
 # ─────────────────────────────────────────
+# Pre-flight the provisioning sources BEFORE creating anything
+# (temp-then-commit spirit: all fallible checks first, then mutate —
+# a missing artifact must refuse cleanly, never leave a half-provisioned
+# worktree behind a "Worktree ready" message)
+# ─────────────────────────────────────────
+for rel in "${PROVISION_LINKS[@]}"; do
+    if [ ! -e "$PRIMARY_ROOT/$rel" ]; then
+        echo "Error: required artifact missing in primary clone: $rel" >&2
+        if [ "$rel" = ".adversarial/evaluators" ]; then
+            echo "       Install first: ./scripts/core/project install-evaluators" >&2
+        fi
+        exit 1
+    fi
+done
+
+# ─────────────────────────────────────────
 # Create: fetch fresh, branch from origin/main (pilot friction #2)
 # ─────────────────────────────────────────
 echo "Fetching origin..."
@@ -152,16 +168,11 @@ trap 'echo "Provisioning failed — to retry from scratch:" >&2;
 # ─────────────────────────────────────────
 # Provision (pilot friction #3)
 # ─────────────────────────────────────────
+# Sources were verified up front, so every entry links or the ERR trap
+# fires — no silent partial provisioning.
 for rel in "${PROVISION_LINKS[@]}"; do
     src="$PRIMARY_ROOT/$rel"
     dst="$WORKTREE_PATH/$rel"
-    if [ ! -e "$src" ]; then
-        echo "⚠️  Skipping $rel — missing in primary clone ($src)." >&2
-        if [ "$rel" = ".adversarial/evaluators" ]; then
-            echo "   Install first: ./scripts/core/project install-evaluators" >&2
-        fi
-        continue
-    fi
     mkdir -p "$(dirname "$dst")"
     ln -s "$src" "$dst"
     echo "Linked $rel -> $src"

--- a/scripts/local/new-worktree.sh
+++ b/scripts/local/new-worktree.sh
@@ -35,6 +35,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir)"
 PRIMARY_ROOT="$(dirname "$GIT_COMMON_DIR")"
 
+# Guard: the dirname math assumes a normal clone (<root>/.git). A bare
+# hub (declined in WORKTREE-WORKFLOW.md, but the pilot proved the state
+# can occur as damage) would resolve to the wrong directory silently.
+if [ ! -e "$PRIMARY_ROOT/.git" ]; then
+    echo "Error: could not resolve primary clone root (got: $PRIMARY_ROOT)" >&2
+    echo "       Is the primary clone bare? See WORKTREE-WORKFLOW.md." >&2
+    exit 1
+fi
+
 # Sibling directory holding all task worktrees (pilot convention).
 WORKTREES_DIR="$(dirname "$PRIMARY_ROOT")/ask-worktrees"
 
@@ -75,19 +84,29 @@ fi
 
 # Derive the slug from the task spec filename when not given.
 if [ -z "$SLUG" ]; then
+    # Use nullglob to ensure the loop doesn't run if no files match
+    shopt -s nullglob
+    matches=()
     for f in "$PRIMARY_ROOT"/.kit/tasks/*/"$TASK_ID"-*.md; do
         if [ -f "$f" ]; then
-            SLUG="$(basename "$f")"
-            SLUG="${SLUG%.md}"          # strip extension (never .replace)
-            SLUG="${SLUG#"$TASK_ID"-}"  # strip the TASK-ID- prefix
-            break
+            matches+=("$f")
         fi
     done
-    if [ -z "$SLUG" ]; then
+    shopt -u nullglob
+    if [ "${#matches[@]}" -eq 0 ]; then
         echo "Error: no task spec found for $TASK_ID in .kit/tasks/ —" >&2
         echo "       pass a slug explicitly: $0 $TASK_ID <slug>" >&2
         exit 1
     fi
+    if [ "${#matches[@]}" -gt 1 ]; then
+        echo "Error: multiple task specs found for $TASK_ID:" >&2
+        printf '       %s\n' "${matches[@]}" >&2
+        echo "       Fix the duplicate or pass a slug explicitly." >&2
+        exit 1
+    fi
+    SLUG="$(basename "${matches[0]}")"
+    SLUG="${SLUG%.md}"          # strip extension (never .replace)
+    SLUG="${SLUG#"$TASK_ID"-}"  # strip the TASK-ID- prefix
 fi
 
 BRANCH="feature/$TASK_ID-$SLUG"
@@ -113,6 +132,12 @@ fi
 # ─────────────────────────────────────────
 echo "Fetching origin..."
 git -C "$PRIMARY_ROOT" fetch origin
+
+if ! git -C "$PRIMARY_ROOT" show-ref --verify --quiet "refs/remotes/origin/main"; then
+    echo "Error: origin/main does not exist after fetch —" >&2
+    echo "       check the remote's default branch." >&2
+    exit 1
+fi
 
 mkdir -p "$WORKTREES_DIR"
 echo "Creating worktree $WORKTREE_PATH on $BRANCH (from origin/main)..."


### PR DESCRIPTION
## Summary

Codifies the KIT-0043 worktree pilot into the kit's default implementation topology. All six pilot frictions traced and addressed (task spec: `.kit/tasks/3-in-progress/KIT-0044-worktree-based-implementation-sessions.md`).

- **F1 — `scripts/local/new-worktree.sh`**: one command creates a fully-provisioned worktree from **fresh `origin/main`** (friction #2). Provisioning is an **explicit, enumerated list** in the helper (`.venv`, `.env`, `.adversarial/evaluators` symlinks — friction #3, evaluator finding F1.2). Refuses cleanly on existing path/branch (N1), on multiple task-spec matches, on a bare primary, and on missing `origin/main`. Resolves the primary clone via `git rev-parse --git-common-dir`, so it works when invoked from inside any worktree. `scripts/local/` placement per N3: this is operator topology for this repo, not synced downstream unaudited; a `project worktree` subcommand would ship a bigger contract than the pilot warrants.
- **F2 — starter template 1.1.0**: un-skippable **LAUNCH block** above FIRST ACTIONS (friction #1, ~40 measured `cd` prefixes); first action is now branch-verify, never `checkout -b`.
- **F3/F4 — `WORKTREE-WORKFLOW.md`** (linked from CLAUDE.md): topology, creation, the pre-commit **GIT_DIR contract + canary** (friction #4; conftest isolation documented, not re-implemented — N2), closeout, lifecycle (planner removes post-retro — friction #6).
- **F5 — bare-hub decision record**: declined at current scale, with enumerated migration costs and three revisit triggers (friction #5).
- **`.gitignore`**: `.adversarial/evaluators` loses its trailing slash — dir-only patterns don't match the provisioning *symlink*, which otherwise blocks plain `git worktree remove` forever (verified empirically).
- **`prepare-review-input.sh` 1.5.1**: the advertised `ADVERSARIAL_UNATTENDED` flag doesn't exist in the installed library (verified by package grep); hint now prescribes `echo y |`.

## Test plan

- [x] Helper creates provisioned worktree from origin/main (run live from inside a worktree — symlinks resolve to the primary)
- [x] `pytest --collect-only` (419 tests) + `adversarial --help` (full evaluator list) + `.env` readable inside the scratch worktree
- [x] Refusals: existing path, existing branch, bad TASK-ID, no spec, multiple specs — all exit 1 with clear messages
- [x] Full commit cycle inside scratch worktree; **canary green** (`core.bare` = false in primary after every pre-commit run)
- [x] Plain `git worktree remove` works once symlinks are properly gitignored (verified in isolated repo)
- [x] `ci-check.sh` green (418 passed, 92.6% coverage)

## Evaluator review (run BEFORE PR — doc-dominated ordering)

fast-v2 CONCERNS / o3 CONCERNS / claude-code APPROVED. 4 findings accepted (multi-match refusal, bare-primary guard, origin/main guard, nullglob), 9 declined with pasted evidence (incl. two disproven o3 claims: `--path-format` works on git 2.39.2, and the nested-worktree path math is correct). Full disposition: `.kit/context/reviews/KIT-0044-evaluator-review.md`.

This task is self-demonstrating: the session ran in a worktree built with the F1 recipe (second pilot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULQcU9dmD1fxxZNZ6fD1a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a git-mutating operator helper and updates a synced `scripts/core/` script, but changes are confined to local dev workflow with explicit guards and mostly documentation.
> 
> **Overview**
> Makes **per-task git worktrees** the documented default: planner stays on `main`, implementation runs under `../ask-worktrees/<TASK-ID>/`.
> 
> **`scripts/local/new-worktree.sh`** fetches `origin/main`, creates the feature branch/worktree, pre-flights then symlinks `.venv`, `.env`, and `.adversarial/evaluators` from the primary (resolved via `git-common-dir`), and refuses duplicate paths/branches, ambiguous task specs, bare primaries, or missing remotes/artifacts.
> 
> **Process/docs**: new **`WORKTREE-WORKFLOW.md`** (topology, GIT_DIR + `core.bare` canary, closeout/lifecycle, bare-hub declined with revisit triggers), linked from **`CLAUDE.md`**; **`TASK-STARTER-TEMPLATE` 1.1.0** adds a mandatory **LAUNCH** block and replaces `checkout -b` with branch-verify; task moves to in-review with handoff/review/retro artifacts.
> 
> **Fixes**: **`.gitignore`** drops the trailing slash on `.adversarial/evaluators` so provisioned symlinks are ignored and plain `git worktree remove` works; **`prepare-review-input.sh` 1.5.1** replaces the nonexistent `ADVERSARIAL_UNATTENDED` hint with **`echo y |`** for large-input prompts in non-TTY sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8942869285546a135b2fe147b56ebd59b42e101b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->