### PR TITLE
feat(KIT-0049): shape-scoped project sync — manifest intersection replaces the refusal

### DIFF
--- a/.kit/context/KIT-0049-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0049-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0049 Handoff — feature-developer
 
-**Task**: `.kit/tasks/3-in-progress/KIT-0049-shape-scoped-sync.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0049-shape-scoped-sync.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-14 (planner-f5)
 **Estimated effort**: 2–3 hours

--- a/.kit/context/KIT-0049-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0049-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0049 Handoff — feature-developer
 
-**Task**: `.kit/tasks/2-todo/KIT-0049-shape-scoped-sync.md`
+**Task**: `.kit/tasks/3-in-progress/KIT-0049-shape-scoped-sync.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-14 (planner-f5)
 **Estimated effort**: 2–3 hours

--- a/.kit/context/KIT-0049-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0049-REVIEW-STARTER.md
@@ -1,0 +1,38 @@
+# KIT-0049 Review Starter — Shape-Scoped `project sync`
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/79
+**Branch**: `feature/KIT-0049-shape-scoped-sync` (worktree: `../ask-worktrees/KIT-0049`)
+**Task**: `.kit/tasks/4-in-review/KIT-0049-shape-scoped-sync.md`
+**Date**: 2026-07-15
+**Agent**: feature-developer-f5 (fifth worktree session)
+
+## What shipped
+
+Replaces the KIT-0048 refusal stopgap. **This completes P2's promise: planning repos can now update.**
+
+| Piece | Deliverable |
+|-------|-------------|
+| Engine | `SyncOptions.allowlist` — candidates intersected after `--tier`/`--only`; excluded upstream entries → `SyncReport.skipped_additions` (named, never silent, NOT warnings — exit contract 0/1/2/3/4 untouched); preserved manifests **pruned of upstream-dropped entries**; `--only` outside the allowlist = UsageError; empty entitlement∩allowlist scope is **never** complete (no vacuous version bumps) |
+| Wrapper | Planning shape reads its own manifest → allowlist (locked decision 1); implicit shape-read trigger via `_doctor_shape()` (locked decision 2); full `dict[str, list[str]]` schema validation with refusals (string tier, non-string member, null files, traversal/absolute entries, empty list); malformed shape still exit 2 |
+| Design call | Intersection lives in the **engine** — manifest preservation happens inside `_build_new_manifest`, unreachable from the wrapper |
+| v1 limitation | Planning repos receive *updates*, not *additions* — skipped additions named in every report with the re-bootstrap pointer |
+
+## Review state
+
+- **CI**: green. **BugBot**: pass. **CodeRabbit**: completing re-review of the final commit at handoff time.
+- **Bots**: 3 threads / 3 rounds — all real, all faces of the **same masking class** (string-tier char-iteration; mixed-list silent discard; vacuous completeness on empty entitled scope).
+- **Evaluators** (trio BEFORE PR): fast-v2 CONCERNS / **o3 FAIL** / claude-code CONCERNS — 7 accepted (headline: **upstream-deletion divergence** — verbatim manifest preservation froze stale records forever while core_version converged; also the `--only` silent drop, a stranded `skipif` decorator pytest silently ignored, `"files": null` AttributeError, traversal defense-in-depth), 4 declined with evidence. Disposition: `.kit/context/reviews/KIT-0049-evaluator-review.md`.
+- **The pattern worth naming**: five reviewers (three evaluators + two bots) found five different faces of one design risk — *set-intersection code masks absence*. Every face is now closed with a refusal, a pruning rule, or a completeness guard, each with a test.
+- **Tests**: 34 in `tests/test_project_sync.py`, incl. the single-shape characterization (additions still arrive, full manifest replaced — byte-identical) and the reduced-manifest preservation pin.
+
+## Reviewer attention points
+
+1. Engine + wrapper both ship via `scripts_core` — 3.2.0+ consumers receive this through `project sync` itself
+2. `complete` semantics for allowlist runs are new: "everything the allowlist records within entitlement, non-vacuously" — see the engine comment block
+3. o3's FAIL verdict is now 3-for-3 on real blockers across KIT-0046/0048/0049
+
+## Post-merge planner actions
+
+- `git worktree remove ../ask-worktrees/KIT-0049` (may need `--force` for the untracked evaluator input), `project complete KIT-0049`, branch delete
+- Planning repos (none exist yet beyond scratch) can sync from the next core version
+- Retro: `.kit/context/retros/KIT-0049-retro.md`

--- a/.kit/context/retros/KIT-0049-retro.md
+++ b/.kit/context/retros/KIT-0049-retro.md
@@ -1,0 +1,82 @@
+## KIT-0049 — Shape-Scoped `project sync` (PR #79)
+
+**Date**: 2026-07-15
+**Agent**: feature-developer-f5
+**Mode**: single-repo (fifth worktree session: `ask-worktrees/KIT-0049`)
+**Scorecard**: 3 threads (3 rounds, all real), 0 regressions, 4 fix rounds (1 evaluator pre-PR + 3 bot), 7 commits
+
+### What Worked
+
+1. **The engine-side design call validated itself** — placing the
+   intersection in the engine (because manifest preservation lives in
+   `_build_new_manifest`) meant the biggest evaluator finding (deletion
+   pruning) landed entirely inside the function the call had already
+   chosen. A wrapper-side intersection would have needed engine surgery
+   anyway.
+2. **Check `--only` semantics first (per handoff) saved parallel
+   machinery** — `--only` was close-but-wrong (usage-errors on unknown
+   keys, silent on skips, replaces the manifest), which made the delta
+   crisp: `allowlist` is `--only` minus the errors plus the naming plus
+   preservation. Half the engine change is comments explaining that
+   contrast.
+3. **Trio-before-PR converted rounds again** — o3's FAIL (deletion
+   divergence) and six other findings were fixed before the PR existed;
+   the bots then found genuinely NEW faces of the risk instead of
+   re-finding the evaluator layer.
+4. **Locked-decision specs are fast** — with both architecture calls
+   pre-locked by the planner, implementation went spec→green in one
+   pass with zero re-litigation. The evaluation-refuses-undecided-
+   architecture loop (planner-side) did its job upstream of me.
+
+### What Was Surprising
+
+1. **Five reviewers found five faces of ONE design risk** — the
+   intersection-masking class: upstream-deletion divergence (o3),
+   allowlist-not-in-upstream completeness masking (fast-v2 +
+   claude-code), string-tier char-iteration (BugBot), mixed-list silent
+   discard (CodeRabbit), vacuous empty-scope completeness (BugBot).
+   Set-intersection code structurally *masks absence* — nothing in
+   `A ∩ B` tells you what fell out or why. Worth remembering whenever
+   intersection semantics appear in a contract.
+2. **o3's FAIL verdict is 3-for-3 on real blockers** (KIT-0046 dup-key,
+   KIT-0048 reader fail-loud, KIT-0049 deletion divergence). Its FAILs
+   have earned default-serious treatment; its individual claims still
+   need verify-before-believing (2 disproven in KIT-0046).
+3. **The stranded `skipif` decorator** — replacing KIT-0048's test class
+   left its decorator attached to the helper function above the
+   replacement, where pytest silently ignores it. Second
+   block-replacement artifact this arc (KIT-0048 lost a deletion the
+   same way).
+
+### What Should Change
+
+1. **Block-replacement hygiene → self-review checklist**: when replacing
+   a large text block, inspect what sits immediately ABOVE and BELOW the
+   replaced span (decorators, comments, staged-vs-disk state). Two
+   artifacts in two tasks is a pattern.
+2. **Consider a masking-class note in patterns.yml** — "intersection/
+   filter code must name what it drops" generalizes the sync report
+   rule (never silent) into a defensive-coding pattern.
+
+### Permission Prompts Hit
+
+None.
+
+### Process Actions Taken
+
+- [x] KIT-0048 refusal guard replaced; malformed-shape refusal retained;
+      engine exit contract untouched (frozen-contract tests green)
+- [x] 3 bot threads + 11 evaluator findings dispositioned (7 accepted /
+      4 declined with evidence)
+- [ ] Planner: post-merge — worktree remove, `project complete
+      KIT-0049`, branch delete
+- [ ] Planner: block-replacement hygiene item (Should Change #1);
+      patterns.yml masking note (Should Change #2)
+
+### Incident Closure
+
+| Incident (this session) | Closure |
+|--------------------------|---------|
+| Stranded `skipif` decorator after block replacement — consumer-checkout CI would ERROR instead of skip (pytest silently ignores marks on plain functions) | **Fixed + hygiene note** — decorator moved to class level with a docstring recording why; block-replacement hygiene filed as a self-review checklist candidate |
+| The intersection-masking class (5 faces: deletion divergence, completeness masking, string-tier, mixed-list, vacuous scope) | **Closed with validation + guards + tests** — dict[str, list[str]] schema refusals, preserved-manifest pruning, `--only`-clash UsageError, non-vacuous completeness; 9 refusal/pin tests. Pattern noted for patterns.yml (intersections must name what they drop) |
+| Hook auto-fix aborted 1 commit (Black on the test file) | **Triage-guide exists** — COMMIT-PROTOCOL's verify-HEAD-moved caught it; formatting now runs before committing |

--- a/.kit/context/reviews/KIT-0049-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0049-evaluator-review.md
@@ -1,0 +1,45 @@
+# KIT-0049 — Adversarial Evaluator Review
+
+**Date**: 2026-07-14
+**Input**: `.adversarial/inputs/KIT-0049-code-review-input.md` (full-file, 5 files)
+**Ordering**: trio ran BEFORE PR open (standing rule)
+**Post-run `git status`**: clean after all three runs (no evaluator mutations)
+
+| Evaluator | Model | Verdict |
+|-----------|-------|---------|
+| code-reviewer-fast-v2 | gemini-3-flash-preview | CONCERNS |
+| code-reviewer | o3 | FAIL |
+| claude-code | claude-sonnet-4-6 | CONCERNS |
+
+Raw logs: `.adversarial/logs/KIT-0049-code-review-input--*.md`
+
+## Disposition — accepted (fixed pre-PR)
+
+| # | Finding (source) | Fix |
+|---|------------------|-----|
+| 1 | **Upstream-deletion divergence**: `preserve_files` copied the target's record verbatim, freezing upstream-dropped entries forever — stale file, converged core_version, never heals (o3, the FAIL driver; fast-v2 + claude-code hit the same masking from the completeness side) | Preserved `files` copy is pruned to entries upstream still ships; pruned entries are the `removed_entries` the report already announces (single-shape parity — manifest drops them, disk cleanup stays advisory). Regression test with a real upstream deletion |
+| 2 | **`--only` outside the allowlist silently became a skipped addition** — an explicit request dropped with exit 0 (o3) | `UsageError` (exit 2) naming the offending entries; test |
+| 3 | **`@pytest.mark.skipif` stranded on a plain helper function** — pytest silently ignores marks on non-test functions, so consumer-checkout CI would ERROR instead of skip (claude-code; a KIT-0048 block-replacement artifact) | Decorator moved to the class; docstring records why |
+| 4 | **`"files": null` in the consumer manifest raised AttributeError past the except tuple** (fast-v2 + claude-code convergent) | `AttributeError` added to the tuple (schema violations refuse with exit 2); test |
+| 5 | **Consumer-manifest allowlist entries skip the source-manifest path rules** — a traversal/absolute entry rides the allowlist (claude-code, MEDIUM, defense-in-depth) | Wrapper refuses entries with `..` parts or absolute paths (exit 2); test |
+| 6 | Raw exception text in the refusal message duplicated the path (claude-code, LOW) | Message prints the exception class only |
+| 7 | `skipped_additions` vs `--tier` semantics undocumented (claude-code, LOW) | Comment added at the intersection block |
+
+## Disposition — declined (with evidence)
+
+| # | Finding (source) | Why declined |
+|---|------------------|--------------|
+| 8 | `complete` logic "fragile" when `--only` exactly matches the allowlist∩entitlement (fast-v2 + claude-code) | If `--only` names exactly everything the allowlist records within entitlement, the run genuinely synced everything this target tracks — `complete=True` is the documented definition, not an accident. And fix #2 now errors when `--only` reaches outside the allowlist |
+| 9 | `_apply` staging atomicity / kill-between-moves risk (fast-v2 + claude-code) | Pre-existing engine architecture (two-pass temp-then-commit, KIT-0034 F3), explicitly out of this PR's scope; both reviewers note it as an existing risk |
+| 10 | Warn when allowlist records entries in non-entitled tiers (claude-code, LOW) | A warning flips the exit code to 1 (attention) under the frozen contract — wrong severity for a legitimate, documented state (opted-out tier entries stay recorded, unsynced). The completeness definition covers it; fix #1 removes the dangerous subcase (upstream deletions) |
+| 11 | Engine CLI doesn't expose `--allowlist` (claude-code, informational) | Intentional per design — the wrapper is the shape-aware caller; reviewer agrees |
+
+## Notes
+
+- o3's FAIL was earned again: the deletion-divergence bug was real and its
+  fix materially changed `_build_new_manifest`. Two of three evaluators
+  converged on the masking behavior from different angles.
+- The stranded-decorator find (claude-code) is the second
+  block-replacement artifact this arc (KIT-0048's was the lost deletion)
+  — large old_string replacements need a scan of what sat immediately
+  ABOVE the replaced block.

--- a/.kit/tasks/3-in-progress/KIT-0049-shape-scoped-sync.md
+++ b/.kit/tasks/3-in-progress/KIT-0049-shape-scoped-sync.md
@@ -1,6 +1,6 @@
 # KIT-0049: Shape-scoped `project sync`
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: high (raised by planner 2026-07-14: this completes P2's
 promise — planning repos are live but update-locked until it lands.
 Recommended sequence: KIT-0049 next, small and unblocking, then P1.)

--- a/.kit/tasks/4-in-review/KIT-0049-shape-scoped-sync.md
+++ b/.kit/tasks/4-in-review/KIT-0049-shape-scoped-sync.md
@@ -1,6 +1,6 @@
 # KIT-0049: Shape-scoped `project sync`
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: high (raised by planner 2026-07-14: this completes P2's
 promise — planning repos are live but update-locked until it lands.
 Recommended sequence: KIT-0049 next, small and unblocking, then P1.)

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1563,6 +1563,12 @@ def cmd_sync(args, project_dir):
             with open(manifest_path, encoding="utf-8") as f:
                 consumer_manifest = json.load(f)
             files_section = consumer_manifest["files"]
+            for tier, entries in files_section.items():
+                if not isinstance(entries, list):
+                    # a string tier would iterate as CHARACTERS, silently
+                    # poisoning the allowlist while sync exits clean
+                    # (BugBot finding on PR #79) — schema violations refuse
+                    raise TypeError(f"files tier {tier!r} is not a list")
             allowlist = sorted(
                 {
                     entry

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1571,11 +1571,31 @@ def cmd_sync(args, project_dir):
                     if isinstance(entry, str)
                 }
             )
-        except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
-            print(f"❌ sync refused: planning shape requires a readable manifest")
-            print(f"   ({manifest_path}: {exc.__class__.__name__}: {exc})")
+        except (
+            OSError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            AttributeError,  # "files": null / list — schema violations
+        ) as exc:
+            print("❌ sync refused: planning shape requires a readable manifest")
+            print(f"   ({manifest_path}: {exc.__class__.__name__})")
             print("   Re-bootstrap with --shape planning to restore it.")
             # Wrapper-level precondition failure → 2.
+            return 2
+        # Defense in depth: the consumer manifest is consumer-owned, so
+        # hold its entries to the same path rules the engine applies to
+        # the source manifest — a traversal/absolute entry must refuse,
+        # not ride the allowlist (claude-code review).
+        bad_entries = [
+            entry
+            for entry in allowlist
+            if ".." in Path(entry).parts or Path(entry).is_absolute()
+        ]
+        if bad_entries:
+            print("❌ sync refused: manifest records unsafe path entries:")
+            for entry in bad_entries:
+                print(f"     {entry}")
             return 2
         if not allowlist:
             print("❌ sync refused: the manifest records no files to sync")

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1249,6 +1249,19 @@ def _print_sync_report(report, *, dry_run, committed, project_dir):
                 print(f"     {entry}")
         print("   (dropped upstream — remove your local copy if unused)")
 
+    if report.skipped_additions:
+        print(
+            f"\nℹ️  Upstream has {len(report.skipped_additions)} entr"
+            f"{'y' if len(report.skipped_additions) == 1 else 'ies'} "
+            "this shape does not record (skipped):"
+        )
+        for entry in report.skipped_additions:
+            print(f"     {entry}")
+        print(
+            "   (additions arrive via re-bootstrap or a manual manifest add "
+            "— KIT-0049 v1)"
+        )
+
     if report.would_set_partial_sync or not report.complete:
         print(
             "\n   Note: partial sync — core_version left unchanged "
@@ -1515,11 +1528,13 @@ def cmd_doctor(args, project_dir):
 def cmd_sync(args, project_dir):
     """`project sync`: pull core files from upstream via the sync engine.
 
-    Shape guard (KIT-0048): the engine selects entries from the UPSTREAM
-    manifest, so a full sync into a planning-shaped repo would install
-    the single-shape toolchain files the shape must never ship (BugBot
-    finding on PR #78). Until sync learns shape-scoped subsets
-    (KIT-0049), refuse loudly rather than mis-provision.
+    Shape-scoped sync (KIT-0049, replacing the KIT-0048 refusal): a
+    planning-shaped repo syncs via manifest intersection — the engine's
+    ``allowlist`` is the consumer's own recorded file list, so sync
+    updates what the repo HAS and never introduces unrecorded files.
+    Upstream additions are skipped BY NAME in the report (v1 limitation:
+    additions arrive via re-bootstrap or a manual manifest add). A
+    malformed/unreadable shape record still refuses with exit 2.
 
     Resolution/branch mechanics per KIT-ADR-0026 §2. Returns a process exit
     code (the engine's exit-code contract).
@@ -1534,14 +1549,38 @@ def cmd_sync(args, project_dir):
     checklist item (``.kit/skills/self-review/SKILL.md``).
     """
     shape, shape_error = _doctor_shape(project_dir)
-    if shape == "planning" or shape_error:
-        reason = shape_error or "this repo records shape: planning"
-        print(f"❌ sync refused: {reason}")
-        print("   The sync engine selects entries from the UPSTREAM manifest —")
-        print("   a full run would install single-shape toolchain files into a")
-        print("   planning repo. Shape-scoped sync is tracked as KIT-0049.")
+    if shape_error:
+        print(f"❌ sync refused: {shape_error}")
+        print("   Fix the kit-install region in CLAUDE.md before syncing —")
+        print("   an unreadable shape record could mis-provision this repo.")
         # Wrapper-level refusal → 2 (wrapper exit-code convention above).
         return 2
+
+    allowlist = None
+    if shape == "planning":
+        manifest_path = project_dir / "scripts" / ".core-manifest.json"
+        try:
+            with open(manifest_path, encoding="utf-8") as f:
+                consumer_manifest = json.load(f)
+            files_section = consumer_manifest["files"]
+            allowlist = sorted(
+                {
+                    entry
+                    for entries in files_section.values()
+                    for entry in entries
+                    if isinstance(entry, str)
+                }
+            )
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+            print(f"❌ sync refused: planning shape requires a readable manifest")
+            print(f"   ({manifest_path}: {exc.__class__.__name__}: {exc})")
+            print("   Re-bootstrap with --shape planning to restore it.")
+            # Wrapper-level precondition failure → 2.
+            return 2
+        if not allowlist:
+            print("❌ sync refused: the manifest records no files to sync")
+            return 2
+        print(f"🔷 planning shape: syncing the {len(allowlist)} recorded entries")
 
     known_bool = {"--dry-run", "--no-branch"}
     known_val = {"--ref", "--source", "--tier", "--only"}
@@ -1608,7 +1647,11 @@ def cmd_sync(args, project_dir):
                     source_path,
                     project_dir,
                     engine.SyncOptions(
-                        tiers=tiers, only=only, dry_run=True, is_kit=is_kit
+                        tiers=tiers,
+                        only=only,
+                        dry_run=True,
+                        is_kit=is_kit,
+                        allowlist=allowlist,
                     ),
                 )
             except engine.SyncError as exc:
@@ -1638,7 +1681,11 @@ def cmd_sync(args, project_dir):
                 source_path,
                 project_dir,
                 engine.SyncOptions(
-                    tiers=tiers, only=only, dry_run=dry_run, is_kit=is_kit
+                    tiers=tiers,
+                    only=only,
+                    dry_run=dry_run,
+                    is_kit=is_kit,
+                    allowlist=allowlist,
                 ),
             )
         except engine.SyncError as exc:

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1563,19 +1563,21 @@ def cmd_sync(args, project_dir):
             with open(manifest_path, encoding="utf-8") as f:
                 consumer_manifest = json.load(f)
             files_section = consumer_manifest["files"]
+            # full dict[str, list[str]] validation: a string tier would
+            # iterate as CHARACTERS and a non-string member would be
+            # silently discarded — either way the allowlist is poisoned
+            # while sync exits clean (BugBot + CodeRabbit, PR #79).
+            # Schema violations refuse.
             for tier, entries in files_section.items():
                 if not isinstance(entries, list):
-                    # a string tier would iterate as CHARACTERS, silently
-                    # poisoning the allowlist while sync exits clean
-                    # (BugBot finding on PR #79) — schema violations refuse
                     raise TypeError(f"files tier {tier!r} is not a list")
+                for entry in entries:
+                    if not isinstance(entry, str):
+                        raise TypeError(
+                            f"files tier {tier!r} has a non-string entry: " f"{entry!r}"
+                        )
             allowlist = sorted(
-                {
-                    entry
-                    for entries in files_section.values()
-                    for entry in entries
-                    if isinstance(entry, str)
-                }
+                {entry for entries in files_section.values() for entry in entries}
             )
         except (
             OSError,

--- a/scripts/core/sync_from_manifest.py
+++ b/scripts/core/sync_from_manifest.py
@@ -742,7 +742,11 @@ def sync(source: str | Path, target: str | Path, options: SyncOptions) -> SyncRe
         # complete = "synced everything the allowlist records within this
         # target's entitlement" — an allowlisted target that got all its
         # recorded files IS complete (core_version bumps, no partial flag).
-        complete = effective_entries == (full_entitlement & set(options.allowlist))
+        # An EMPTY intersection is never complete: nothing was verified
+        # against upstream, so a vacuous match must not advance
+        # core_version (BugBot, PR #79 round 3).
+        allow_scope = full_entitlement & set(options.allowlist)
+        complete = bool(allow_scope) and effective_entries == allow_scope
     else:
         complete = effective_entries == full_entitlement
 

--- a/scripts/core/sync_from_manifest.py
+++ b/scripts/core/sync_from_manifest.py
@@ -110,6 +110,14 @@ class SyncOptions:
     only: list[str] | None = None
     dry_run: bool = False
     is_kit: bool = False
+    # Shape-scoped sync (KIT-0049): when set, candidates are intersected
+    # with this entry set and everything else is reported as a skipped
+    # addition — never a usage error (unlike ``only``, which names
+    # entries the caller explicitly asked for). The target's reduced
+    # manifest ``files`` record is preserved instead of being replaced
+    # by upstream's. ``complete`` becomes "synced everything the
+    # allowlist records within entitlement", so core_version still bumps.
+    allowlist: list[str] | None = None
 
 
 @dataclass
@@ -134,6 +142,11 @@ class SyncReport:
     removed_files: list[str] = field(default_factory=list)
     removed_entries: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    # Upstream entries excluded by SyncOptions.allowlist (KIT-0049) —
+    # named, never silent, and deliberately NOT warnings: skipping
+    # unrecorded additions is the allowlist working as designed, so it
+    # must not flip the exit code to attention.
+    skipped_additions: list[str] = field(default_factory=list)
     would_bump_core_version: bool = False
     would_set_partial_sync: bool = False
     core_version: str = ""
@@ -154,6 +167,7 @@ class SyncReport:
             "removed_files": self.removed_files,
             "removed_entries": self.removed_entries,
             "warnings": self.warnings,
+            "skipped_additions": self.skipped_additions,
             "would_bump_core_version": self.would_bump_core_version,
             "would_set_partial_sync": self.would_set_partial_sync,
             "core_version": self.core_version,
@@ -514,13 +528,26 @@ def _build_new_manifest(
     upstream: dict,
     target_manifest: dict | None,
     complete: bool,
+    preserve_files: bool = False,
 ) -> dict:
     """Build the manifest to write to the target.
 
     Takes the upstream ``files``/``source_repo`` (the sync contract), preserves
     the target's ``opted_in`` verbatim, and sets metadata per completeness.
+
+    ``preserve_files`` (allowlist/shape-scoped runs, KIT-0049): the
+    target's reduced ``files`` record is the source of truth for what it
+    ships — replacing it with upstream's full list would re-entitle the
+    very entries the shape excludes on the NEXT sync.
     """
     new_manifest = json.loads(json.dumps(upstream))  # deep copy, key order kept
+
+    if (
+        preserve_files
+        and target_manifest is not None
+        and isinstance(target_manifest.get("files"), dict)
+    ):
+        new_manifest["files"] = json.loads(json.dumps(target_manifest["files"]))
 
     if target_manifest is not None and isinstance(
         target_manifest.get("opted_in"), list
@@ -669,8 +696,27 @@ def sync(source: str | Path, target: str | Path, options: SyncOptions) -> SyncRe
     ]
     candidates = _apply_only_filter(candidates, upstream_files, options.only)
 
+    # ── Allowlist intersection (shape-scoped sync, KIT-0049) ──
+    # Entries upstream has but the allowlist does not record are skipped
+    # ADDITIONS: named in the report, never a usage error and never a
+    # warning. Additions reach an allowlisted target via re-bootstrap or
+    # a manual manifest add (the recorded v1 limitation).
+    skipped_additions: list[str] = []
+    if options.allowlist is not None:
+        allow = set(options.allowlist)
+        skipped_additions = sorted(
+            {entry for _tier, entry in candidates if entry not in allow}
+        )
+        candidates = [(tier, entry) for tier, entry in candidates if entry in allow]
+
     effective_entries = {entry for _tier, entry in candidates}
-    complete = effective_entries == full_entitlement
+    if options.allowlist is not None:
+        # complete = "synced everything the allowlist records within this
+        # target's entitlement" — an allowlisted target that got all its
+        # recorded files IS complete (core_version bumps, no partial flag).
+        complete = effective_entries == (full_entitlement & set(options.allowlist))
+    else:
+        complete = effective_entries == full_entitlement
 
     # ── Plan (only source-reading phase) ──
     plan, plan_warnings = _build_plan(source_root, candidates)
@@ -683,7 +729,12 @@ def sync(source: str | Path, target: str | Path, options: SyncOptions) -> SyncRe
     upstream_all_entries = _all_entries(upstream_files)
     removed_entries = sorted(target_old_entries - upstream_all_entries)
 
-    new_manifest = _build_new_manifest(upstream, target_manifest, complete)
+    new_manifest = _build_new_manifest(
+        upstream,
+        target_manifest,
+        complete,
+        preserve_files=options.allowlist is not None,
+    )
     new_core_version = new_manifest["core_version"]
 
     would_bump = complete and (
@@ -726,6 +777,7 @@ def sync(source: str | Path, target: str | Path, options: SyncOptions) -> SyncRe
         removed_files=sorted(removed_files),
         removed_entries=removed_entries,
         warnings=warnings,
+        skipped_additions=skipped_additions,
         would_bump_core_version=would_bump,
         would_set_partial_sync=would_set_partial,
         core_version=new_core_version,
@@ -802,6 +854,8 @@ def _print_report(report: SyncReport) -> None:
             print(f"  {label}: {item}", file=sys.stderr)
     for warning in report.warnings:
         print(f"  warning: {warning}", file=sys.stderr)
+    for entry in report.skipped_additions:
+        print(f"  skipped addition (not in allowlist): {entry}", file=sys.stderr)
     if report.would_set_partial_sync:
         print("  note: partial sync — core_version left unchanged", file=sys.stderr)
 

--- a/scripts/core/sync_from_manifest.py
+++ b/scripts/core/sync_from_manifest.py
@@ -547,7 +547,20 @@ def _build_new_manifest(
         and target_manifest is not None
         and isinstance(target_manifest.get("files"), dict)
     ):
-        new_manifest["files"] = json.loads(json.dumps(target_manifest["files"]))
+        preserved = json.loads(json.dumps(target_manifest["files"]))
+        # Prune entries upstream no longer ships — copying them back
+        # verbatim would freeze a stale record forever: the entry never
+        # becomes a candidate again, the file never updates, yet
+        # core_version keeps converging (o3 review finding). The pruned
+        # entries are the removed_entries the report already announces
+        # (single-shape parity: manifest drops them, disk cleanup stays
+        # advisory).
+        upstream_entries = _all_entries(upstream.get("files"))
+        for tier in list(preserved):
+            entries = preserved[tier]
+            if isinstance(entries, list):
+                preserved[tier] = [e for e in entries if e in upstream_entries]
+        new_manifest["files"] = preserved
 
     if target_manifest is not None and isinstance(
         target_manifest.get("opted_in"), list
@@ -701,9 +714,24 @@ def sync(source: str | Path, target: str | Path, options: SyncOptions) -> SyncRe
     # ADDITIONS: named in the report, never a usage error and never a
     # warning. Additions reach an allowlisted target via re-bootstrap or
     # a manual manifest add (the recorded v1 limitation).
+    # Semantics note: skipped_additions is computed AFTER --tier/--only
+    # narrowing, so it means "upstream has these within the tiers/entries
+    # this run selected, but the allowlist doesn't record them" — entries
+    # excluded by --tier never appear here (they were never candidates).
     skipped_additions: list[str] = []
     if options.allowlist is not None:
         allow = set(options.allowlist)
+        # An explicit --only request that falls OUTSIDE the allowlist
+        # must not be silently converted into a skipped addition — the
+        # caller named it; dropping it would mis-sync scripted runs
+        # (o3 review finding).
+        if options.only:
+            outside = sorted(set(options.only) - allow)
+            if outside:
+                raise UsageError(
+                    "--only entr(y/ies) not in this target's allowlist "
+                    f"(its manifest does not record them): {', '.join(outside)}"
+                )
         skipped_additions = sorted(
             {entry for _tier, entry in candidates if entry not in allow}
         )

--- a/tests/test_project_sync.py
+++ b/tests/test_project_sync.py
@@ -567,6 +567,24 @@ class TestShapeScopedSync:
         )
         assert rc == 2
 
+    def test_nonstring_list_member_refused(self, kit_with_addition, tmp_path):
+        """CodeRabbit PR #79: a non-string member in a tier list must
+        refuse, not be silently discarded from the allowlist."""
+        root = _shaped_root(tmp_path, "shape: planning\n", name="mixedtier")
+        _write(
+            root / "scripts" / ".core-manifest.json",
+            json.dumps(
+                {
+                    "core_version": "1.0.0",
+                    "files": {"scripts_core": ["core/foo.sh", 42]},
+                }
+            ),
+        )
+        rc = project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--dry-run"], root
+        )
+        assert rc == 2
+
     def test_traversal_entry_in_manifest_refused(
         self, kit_with_addition, tmp_path, capsys
     ):

--- a/tests/test_project_sync.py
+++ b/tests/test_project_sync.py
@@ -354,9 +354,6 @@ class TestBranchAndCommit:
 KIT_MARKERS = REPO / "scripts" / "local" / "kit_markers.py"
 
 
-@pytest.mark.skipif(
-    not KIT_MARKERS.exists(), reason="kit_markers.py absent (consumer checkout)"
-)
 def _shaped_root(tmp_path: Path, region: str, name: str = "shaped") -> Path:
     """A consumer root with a shape record (kit_markers + CLAUDE.md)."""
     root = tmp_path / name
@@ -395,8 +392,15 @@ def seed_planning_manifest(root: Path) -> None:
     _write(root / "scripts" / ".core-manifest.json", json.dumps(manifest, indent=2))
 
 
+@pytest.mark.skipif(
+    not KIT_MARKERS.exists(), reason="kit_markers.py absent (consumer checkout)"
+)
 class TestShapeScopedSync:
-    """KIT-0049: planning repos sync by manifest intersection."""
+    """KIT-0049: planning repos sync by manifest intersection.
+
+    Class-level skipif: pytest silently ignores marks on plain helper
+    functions (claude-code review caught the decorator stranded on
+    _shaped_root after the KIT-0048 class was replaced)."""
 
     @pytest.fixture
     def planning(self, tmp_path):
@@ -496,6 +500,78 @@ class TestShapeScopedSync:
         captured = capsys.readouterr()
         assert "sync refused" not in captured.out
         assert rc != 2 or "KIT-0049" not in captured.out
+
+    def test_upstream_deletion_pruned_from_preserved_manifest(
+        self, kit_with_addition, planning, capsys
+    ):
+        """o3 review: an upstream-dropped entry must be pruned from the
+        preserved manifest, not frozen into a stale record forever."""
+        manifest_path = kit_with_addition / "scripts" / ".core-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["files"]["commands_core"].remove("cmd.md")
+        manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        (kit_with_addition / ".claude" / "commands" / "cmd.md").unlink()
+
+        rc = project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--no-branch"], planning
+        )
+        assert rc == 0
+        result = json.loads(
+            (planning / "scripts" / ".core-manifest.json").read_text(encoding="utf-8")
+        )
+        # pruned from the record; announced in the output
+        assert result["files"]["commands_core"] == []
+        assert result["files"]["scripts_core"] == ["core/foo.sh"]
+        assert "cmd.md" in capsys.readouterr().out
+
+    def test_only_outside_allowlist_is_usage_error(self, kit_with_addition, planning):
+        """o3 review: an explicit --only request outside the allowlist
+        must refuse (exit 2), never silently become a skipped addition."""
+        rc = project_cli.cmd_sync(
+            [
+                "--source",
+                str(kit_with_addition),
+                "--no-branch",
+                "--only",
+                "core/extra.sh",
+            ],
+            planning,
+        )
+        assert rc == 2
+
+    def test_null_files_section_refused_not_crash(self, kit_with_addition, tmp_path):
+        """fast-v2 review: "files": null raised AttributeError past the
+        except tuple — must refuse with exit 2 instead."""
+        root = _shaped_root(tmp_path, "shape: planning\n", name="nullfiles")
+        _write(
+            root / "scripts" / ".core-manifest.json",
+            json.dumps({"core_version": "1.0.0", "files": None}),
+        )
+        rc = project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--dry-run"], root
+        )
+        assert rc == 2
+
+    def test_traversal_entry_in_manifest_refused(
+        self, kit_with_addition, tmp_path, capsys
+    ):
+        """claude-code review: consumer-manifest entries get the same
+        path rules as the source manifest (defense in depth)."""
+        root = _shaped_root(tmp_path, "shape: planning\n", name="traversal")
+        _write(
+            root / "scripts" / ".core-manifest.json",
+            json.dumps(
+                {
+                    "core_version": "1.0.0",
+                    "files": {"scripts_core": ["core/foo.sh", "../../evil"]},
+                }
+            ),
+        )
+        rc = project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--dry-run"], root
+        )
+        assert rc == 2
+        assert "unsafe path" in capsys.readouterr().out
 
     def test_engine_allowlist_report_fields(self, kit_with_addition, tmp_path):
         # engine-level: skipped additions land in the report, sorted;

--- a/tests/test_project_sync.py
+++ b/tests/test_project_sync.py
@@ -606,6 +606,36 @@ class TestShapeScopedSync:
         assert rc == 2
         assert "unsafe path" in capsys.readouterr().out
 
+    def test_empty_entitled_scope_never_complete(self, kit_with_addition, tmp_path):
+        """BugBot round 3: every recorded entry outside entitlement →
+        empty intersection must NOT vacuously report complete and bump
+        core_version."""
+        target = tmp_path / "unentitled"
+        target.mkdir()
+        # records ONLY an opt-gated entry, without the opt-in
+        _write(
+            target / "scripts" / ".core-manifest.json",
+            json.dumps(
+                {
+                    "core_version": "1.0.0",
+                    "source_repo": "movito/test-kit",
+                    "synced_at": "2026-01-01T00:00:00Z",
+                    "files": {"commands_optional": ["opt.md"]},
+                    "opted_in": [],
+                }
+            ),
+        )
+        report = sync_from_manifest.sync(
+            kit_with_addition,
+            target,
+            sync_from_manifest.SyncOptions(allowlist=["opt.md"]),
+        )
+        assert report.complete is False
+        manifest = json.loads(
+            (target / "scripts" / ".core-manifest.json").read_text(encoding="utf-8")
+        )
+        assert manifest["core_version"] == "1.0.0"  # NOT bumped
+
     def test_engine_allowlist_report_fields(self, kit_with_addition, tmp_path):
         # engine-level: skipped additions land in the report, sorted;
         # allowlist runs count as complete for their scope

--- a/tests/test_project_sync.py
+++ b/tests/test_project_sync.py
@@ -552,6 +552,21 @@ class TestShapeScopedSync:
         )
         assert rc == 2
 
+    def test_string_tier_refused_not_char_iterated(self, kit_with_addition, tmp_path):
+        """BugBot PR #79: a string-valued tier iterates as characters,
+        silently poisoning the allowlist — must refuse (exit 2)."""
+        root = _shaped_root(tmp_path, "shape: planning\n", name="strtier")
+        _write(
+            root / "scripts" / ".core-manifest.json",
+            json.dumps(
+                {"core_version": "1.0.0", "files": {"scripts_core": "core/foo.sh"}}
+            ),
+        )
+        rc = project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--dry-run"], root
+        )
+        assert rc == 2
+
     def test_traversal_entry_in_manifest_refused(
         self, kit_with_addition, tmp_path, capsys
     ):

--- a/tests/test_project_sync.py
+++ b/tests/test_project_sync.py
@@ -21,6 +21,8 @@ REPO = Path(__file__).resolve().parent.parent
 CORE = REPO / "scripts" / "core"
 sys.path.insert(0, str(CORE))  # for `import sync_from_manifest`
 
+import sync_from_manifest  # noqa: E402
+
 # Load the `project` script (no .py extension) as a module, mirroring
 # test_project_script.py.
 _project_path = CORE / "project"
@@ -355,39 +357,157 @@ KIT_MARKERS = REPO / "scripts" / "local" / "kit_markers.py"
 @pytest.mark.skipif(
     not KIT_MARKERS.exists(), reason="kit_markers.py absent (consumer checkout)"
 )
-class TestShapeGuard:
-    """KIT-0048: sync refuses planning-shaped repos until KIT-0049."""
+def _shaped_root(tmp_path: Path, region: str, name: str = "shaped") -> Path:
+    """A consumer root with a shape record (kit_markers + CLAUDE.md)."""
+    root = tmp_path / name
+    (root / "scripts" / "local").mkdir(parents=True)
+    (root / "scripts" / "local" / "kit_markers.py").write_text(
+        KIT_MARKERS.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (root / "CLAUDE.md").write_text(
+        "# Repo\n\n<!-- BEGIN KIT-LOCAL: kit-install -->\n"
+        f"{region}"
+        "<!-- END KIT-LOCAL: kit-install -->\n",
+        encoding="utf-8",
+    )
+    return root
 
-    @staticmethod
-    def _shaped_root(tmp_path: Path, region: str) -> Path:
-        root = tmp_path / "shaped"
-        (root / "scripts" / "local").mkdir(parents=True)
-        (root / "scripts" / "local" / "kit_markers.py").write_text(
-            KIT_MARKERS.read_text(encoding="utf-8"), encoding="utf-8"
-        )
-        (root / "CLAUDE.md").write_text(
-            "# Repo\n\n<!-- BEGIN KIT-LOCAL: kit-install -->\n"
-            f"{region}"
-            "<!-- END KIT-LOCAL: kit-install -->\n",
-            encoding="utf-8",
-        )
+
+def add_upstream_entry(kit: Path, tier: str, entry: str, relpath: str, body: str):
+    """Add a brand-new upstream entry — the 'addition' a planning repo
+    must skip and a single repo must receive."""
+    manifest_path = kit / "scripts" / ".core-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"][tier].append(entry)
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    _write(kit / relpath, body)
+
+
+def seed_planning_manifest(root: Path) -> None:
+    """The reduced manifest a planning bootstrap writes (KIT-0048)."""
+    manifest = {
+        "core_version": "1.0.0",
+        "source_repo": "movito/test-kit",
+        "synced_at": "2026-01-01T00:00:00Z",
+        "files": {"scripts_core": ["core/foo.sh"], "commands_core": ["cmd.md"]},
+        "opted_in": [],
+    }
+    _write(root / "scripts" / ".core-manifest.json", json.dumps(manifest, indent=2))
+
+
+class TestShapeScopedSync:
+    """KIT-0049: planning repos sync by manifest intersection."""
+
+    @pytest.fixture
+    def planning(self, tmp_path):
+        root = _shaped_root(tmp_path, "shape: planning\n", name="planning")
+        seed_planning_manifest(root)
         return root
 
-    def test_planning_shape_refused(self, tmp_path):
-        root = self._shaped_root(tmp_path, "shape: planning\n")
+    @pytest.fixture
+    def kit_with_addition(self, tmp_path):
+        kit = build_kit(tmp_path / "kit")
+        add_upstream_entry(
+            kit,
+            "scripts_core",
+            "core/extra.sh",
+            "scripts/core/extra.sh",
+            "#!/bin/sh\necho extra\n",
+        )
+        return kit
+
+    def test_planning_sync_updates_only_recorded_files(
+        self, kit_with_addition, planning
+    ):
+        rc = project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--no-branch"], planning
+        )
+        assert rc == 0
+        assert (planning / "scripts" / "core" / "foo.sh").exists()
+        assert (planning / ".claude" / "commands" / "cmd.md").exists()
+        # the unrecorded addition must never appear
+        assert not (planning / "scripts" / "core" / "extra.sh").exists()
+        # opt-gated tiers stay out too (not recorded, not opted in)
+        assert not (planning / ".claude" / "commands" / "opt.md").exists()
+
+    def test_planning_sync_preserves_reduced_manifest(
+        self, kit_with_addition, planning
+    ):
+        project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--no-branch"], planning
+        )
+        manifest = json.loads(
+            (planning / "scripts" / ".core-manifest.json").read_text(encoding="utf-8")
+        )
+        # the reduced record survives — NOT upstream's full list
+        assert manifest["files"] == {
+            "scripts_core": ["core/foo.sh"],
+            "commands_core": ["cmd.md"],
+        }
+        # everything recorded was synced: this run IS complete for this
+        # shape — core_version converges, no partial flag
+        assert manifest["core_version"] == "9.9.0"
+        assert "partial_sync" not in manifest
+
+    def test_planning_sync_names_skipped_additions(
+        self, kit_with_addition, planning, capsys
+    ):
+        project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--no-branch"], planning
+        )
+        out = capsys.readouterr().out
+        assert "core/extra.sh" in out
+        assert "does not record" in out
+
+    def test_single_shape_receives_additions_unchanged(
+        self, kit_with_addition, tmp_path
+    ):
+        # characterization: a single-shape consumer still gets upstream
+        # additions and the full upstream manifest
+        consumer = tmp_path / "single-consumer"
+        consumer.mkdir()
+        rc = project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--no-branch"], consumer
+        )
+        assert rc == 0
+        assert (consumer / "scripts" / "core" / "extra.sh").exists()
+        manifest = json.loads(
+            (consumer / "scripts" / ".core-manifest.json").read_text(encoding="utf-8")
+        )
+        assert "core/extra.sh" in manifest["files"]["scripts_core"]
+
+    def test_malformed_shape_still_refused(self, tmp_path):
+        root = _shaped_root(tmp_path, "shape: pyramid\n")
         rc = project_cli.cmd_sync(["--dry-run"], root)
         assert rc == 2
 
-    def test_malformed_shape_refused(self, tmp_path):
-        root = self._shaped_root(tmp_path, "shape: pyramid\n")
-        rc = project_cli.cmd_sync(["--dry-run"], root)
+    def test_planning_without_manifest_refused(self, kit_with_addition, tmp_path):
+        root = _shaped_root(tmp_path, "shape: planning\n")
+        rc = project_cli.cmd_sync(
+            ["--source", str(kit_with_addition), "--dry-run"], root
+        )
         assert rc == 2
 
     def test_single_shape_not_blocked_by_guard(self, tmp_path, capsys):
-        root = self._shaped_root(tmp_path, "shape: single\n")
+        root = _shaped_root(tmp_path, "shape: single\n")
         rc = project_cli.cmd_sync(["--dry-run"], root)
         # proceeds past the guard (fails later for engine reasons, but
         # never with the shape-refusal message)
         captured = capsys.readouterr()
         assert "sync refused" not in captured.out
         assert rc != 2 or "KIT-0049" not in captured.out
+
+    def test_engine_allowlist_report_fields(self, kit_with_addition, tmp_path):
+        # engine-level: skipped additions land in the report, sorted;
+        # allowlist runs count as complete for their scope
+        target = tmp_path / "engine-target"
+        target.mkdir()
+        seed_planning_manifest(target)
+        report = sync_from_manifest.sync(
+            kit_with_addition,
+            target,
+            sync_from_manifest.SyncOptions(allowlist=["core/foo.sh", "cmd.md"]),
+        )
+        assert report.skipped_additions == ["core/extra.sh"]
+        assert report.complete is True
+        assert report.to_dict()["skipped_additions"] == ["core/extra.sh"]


### PR DESCRIPTION
## Summary

Replaces the KIT-0048 refusal stopgap: planning-shaped repos now sync by **manifest intersection**. Both locked decisions honored — single source = the consumer's own `scripts/.core-manifest.json`; trigger = implicit shape-read via `_doctor_shape()`, no flag.

**The one design call** (stated per handoff): the intersection lives in the **engine** (`SyncOptions.allowlist`), not the wrapper — because manifest preservation has to happen inside `_build_new_manifest`, which only the engine reaches. The wrapper's job is reading the shape + supplying the recorded entry list.

- **Engine**: `allowlist` intersects candidates after `--tier`/`--only` narrowing; excluded upstream entries land in `SyncReport.skipped_additions` — **named, never silent, deliberately NOT warnings** (exit contract 0/1/2/3/4 untouched). `complete` = "synced everything the allowlist records within entitlement", so `core_version` still converges. Preserved manifests are **pruned of entries upstream no longer ships** (evaluator catch — a verbatim copy would freeze stale records forever). `--only` naming an entry outside the allowlist is a UsageError, never a silent drop.
- **Wrapper**: planning shape loads the consumer manifest → allowlist (validated against the source-manifest path rules — traversal/absolute entries refuse); malformed shape still refuses exit 2; missing/corrupt/null-files manifest refuses exit 2; skipped additions printed with the re-bootstrap pointer.
- **v1 limitation, loud**: planning repos receive *updates* to recorded files, not *additions* — skipped additions are named in every report; additions arrive via re-bootstrap or a manual manifest add (P3-era revisit recorded in the spec).

## Evaluator review (trio BEFORE PR)

fast-v2 CONCERNS / **o3 FAIL** / claude-code CONCERNS → **7 accepted** (headline: the upstream-deletion divergence — preserve-verbatim froze stale records while core_version converged; also the `--only`/allowlist silent drop, a stranded `skipif` decorator pytest silently ignored [consumer CI would error, not skip], `"files": null` AttributeError, traversal-entry defense-in-depth), **4 declined with evidence**. Disposition: `.kit/context/reviews/KIT-0049-evaluator-review.md`.

## Test plan

- [x] 31 tests in `tests/test_project_sync.py` — planning updates-only-recorded, reduced-manifest preservation pin, skipped-addition naming, **single-shape characterization (additions still arrive, full manifest replaced — byte-identical behavior)**, upstream-deletion pruning, `--only`-clash exit 2, malformed-shape / missing-manifest / null-files / traversal refusals, guard pass-through, engine-level report fields
- [x] `ci-check.sh` green; canary green after every pre-commit run
- [x] Engine exit-code contract untouched (frozen-contract tests still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULQcU9dmD1fxxZNZ6fD1a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sync engine semantics (completeness, manifest writes, and reporting) and the planning provisioning path; behavior is heavily tested and exit codes stay frozen, but mistakes could mis-sync or stall `core_version` for planning consumers.
> 
> **Overview**
> **Planning-shaped repos can sync again** — the KIT-0048 hard refusal is removed and replaced with **manifest-intersection** sync driven by the consumer’s own `scripts/.core-manifest.json`.
> 
> The **sync engine** gains `SyncOptions.allowlist`: after tier/`--only` narrowing, candidates are intersected with the allowlist; upstream entries outside it are reported in **`SyncReport.skipped_additions`** (named in CLI output, not warnings). Allowlist runs **preserve the target’s reduced `files` manifest** (with **pruning** when upstream drops entries), redefine **`complete`** as “all allowlisted entries within entitlement” (blocking vacuous bumps), and treat **`--only` outside the allowlist** as a `UsageError`.
> 
> The **`project sync` wrapper** loads and validates the planning consumer manifest into the allowlist (schema, unsafe paths, empty list) and passes it through on dry-run and apply; malformed shape still exits **2**.
> 
> **Tests** replace the old shape-guard class with a broad `TestShapeScopedSync` suite (planning updates-only, manifest pin, skipped-addition messaging, single-shape parity, refusal edge cases, engine report fields). Task/review kit docs move KIT-0049 to in-review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f23fb6fecddd0ca8ce07bea1474113cd69beb670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->