### PR TITLE
docs(KIT-0053): docs convergence on the setup door (F4, PR 2/2)

### DIFF
--- a/.claude/agents/bootstrap.md
+++ b/.claude/agents/bootstrap.md
@@ -127,7 +127,7 @@ grep -ri "agentive.starter.kit\|agentive-starter-kit" \
    - `docs/UPSTREAM-CHANGES-*.md` — upgrade guides referencing the source repo
    - `docs/archive/agentive-development/` — archive directory path
    - `tests/test_project_script.py` — test fixtures that detect upstream patterns
-   - `scripts/bootstrap.sh` — this script references ASK as the source (correct)
+   - `scripts/local/bootstrap` + `scripts/local/engine-*.sh` — the kit setup door and its engines reference ASK as the source (correct)
    - `onboarding.md` — references to ASK git URLs for upstream tracking
    - README footer: "Built with Agentive Starter Kit" link (this is attribution)
 

--- a/.claude/agents/create-project.md
+++ b/.claude/agents/create-project.md
@@ -54,21 +54,28 @@ Infer what you can (e.g., prefix from name, description from context).
 > `cd <target-dir> && ...` (or use absolute paths). Do not assume CWD carries
 > over.
 
-### Step 1: Run create-project.sh
+### Step 1: Run the setup door (--new)
 
-The mechanical export and cleanup is handled by a script. Run it from the
-agentive-starter-kit repo root:
+The mechanical export and cleanup is handled by the kit's one setup
+door (KIT-0053). Run it from the agentive-starter-kit repo root:
 
 ```bash
-./scripts/optional/create-project.sh <target-dir> --name "<name>" --prefix <PREFIX>
+./scripts/local/bootstrap --new <target-dir> --name "<name>" --prefix <PREFIX> --without-evaluators --without-venv
 ```
 
-**If the script fails**: Read the error, diagnose, and fix. Common issues:
-- Target directory already exists → ask user if they want to delete it
-- Not running from ASK root → cd to the right place first
+It exports a clean copy, records the install (shape/profile) in the
+new project's CLAUDE.md, and ends with a `project doctor` report —
+read it; WARNs about missing .env keys are expected at this stage.
+(Evaluator install happens in Step 5, so pass `--without-evaluators`
+here.)
 
-Verify the script succeeded by checking that the target directory has a clean
-git repo with one commit.
+**If the door fails**: Read the error, diagnose, and fix. Common issues:
+- Exit 2, target already exists → ask user if they want to delete it
+- Exit 2, not running from ASK root → cd to the right place first
+- Exit 1, no git identity → have the user set git user.name/user.email
+
+Verify it succeeded by checking that the target directory has a clean
+git repo with two commits (export + install record).
 
 ### Step 2: Customize CLAUDE.md
 

--- a/.claude/agents/feature-developer-f5.md
+++ b/.claude/agents/feature-developer-f5.md
@@ -42,7 +42,7 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > worked example for downstream projects to model their own fill on.
 >
 > Everything between the `KIT-LOCAL: project-context` markers below is
-> consumer-owned. `bootstrap-consumer.sh` overwrites it with project
+> consumer-owned. `engine-consumer.sh` (the setup door's consumer engine) overwrites it with project
 > values on first bootstrap and preserves it across re-bootstraps;
 > upstream refreshes everything outside the markers. Keep the marker
 > comments intact when editing.
@@ -206,7 +206,7 @@ For each change:
 > repo below.
 >
 > Everything between the `KIT-LOCAL: stack-notes` markers below is
-> consumer-owned and is overwritten/preserved by `bootstrap-consumer.sh`
+> consumer-owned and is overwritten/preserved by `engine-consumer.sh` (the setup door's consumer engine)
 > exactly like Project Context above. Keep the marker comments intact.
 
 <!-- BEGIN KIT-LOCAL: stack-notes -->
@@ -231,7 +231,7 @@ For each change:
   <KIT-NNNN>` moves task files between status folders
 - **Consumer test boundary**: any new test importing or reading
   `scripts/local/` must be excluded from the consumer `tests/` rsync in
-  `bootstrap-consumer.sh` (both `--exclude` and the `rm -f` sweep) and
+  `engine-consumer.sh` (the setup door's consumer engine) (both `--exclude` and the `rm -f` sweep) and
   must module-skip when its dependency is absent (pattern:
   `tests/test_kit_markers.py`)
 <!-- END KIT-LOCAL: stack-notes -->

--- a/.claude/agents/feature-developer.md
+++ b/.claude/agents/feature-developer.md
@@ -37,7 +37,7 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > worked example for downstream projects to model their own fill on.
 >
 > Everything between the `KIT-LOCAL: project-context` markers below is
-> consumer-owned. `bootstrap-consumer.sh` overwrites it with project
+> consumer-owned. `engine-consumer.sh` (the setup door's consumer engine) overwrites it with project
 > values on first bootstrap and preserves it across re-bootstraps;
 > upstream refreshes everything outside the markers. Keep the marker
 > comments intact when editing.
@@ -201,7 +201,7 @@ For each change:
 > repo below.
 >
 > Everything between the `KIT-LOCAL: stack-notes` markers below is
-> consumer-owned and is overwritten/preserved by `bootstrap-consumer.sh`
+> consumer-owned and is overwritten/preserved by `engine-consumer.sh` (the setup door's consumer engine)
 > exactly like Project Context above. Keep the marker comments intact.
 
 <!-- BEGIN KIT-LOCAL: stack-notes -->
@@ -226,7 +226,7 @@ For each change:
   <KIT-NNNN>` moves task files between status folders
 - **Consumer test boundary**: any new test importing or reading
   `scripts/local/` must be excluded from the consumer `tests/` rsync in
-  `bootstrap-consumer.sh` (both `--exclude` and the `rm -f` sweep) and
+  `engine-consumer.sh` (the setup door's consumer engine) (both `--exclude` and the `rm -f` sweep) and
   must module-skip when its dependency is absent (pattern:
   `tests/test_kit_markers.py`)
 <!-- END KIT-LOCAL: stack-notes -->

--- a/.claude/agents/planner-f5.md
+++ b/.claude/agents/planner-f5.md
@@ -43,7 +43,7 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > A vague agent performs worse than a specific one — fill this in.
 >
 > Everything between the `KIT-LOCAL: project-context` markers below is
-> consumer-owned. `bootstrap-consumer.sh` overwrites it with project
+> consumer-owned. `engine-consumer.sh` (the setup door's consumer engine) overwrites it with project
 > values on first bootstrap and preserves it across re-bootstraps;
 > upstream refreshes everything outside the markers. Keep the marker
 > comments intact when editing.

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -39,7 +39,7 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > A vague agent performs worse than a specific one — fill this in.
 >
 > Everything between the `KIT-LOCAL: project-context` markers below is
-> consumer-owned. `bootstrap-consumer.sh` overwrites it with project
+> consumer-owned. `engine-consumer.sh` (the setup door's consumer engine) overwrites it with project
 > values on first bootstrap and preserves it across re-bootstraps;
 > upstream refreshes everything outside the markers. Keep the marker
 > comments intact when editing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ See `.kit/templates/AGENT-TEMPLATE.md` for creating new agents.
 | `./scripts/core/verify-ci.sh` | Verify CI status on GitHub |
 | `./scripts/core/pattern_lint.py` | Check for defensive coding violations |
 | `./scripts/optional/create-agent.sh` | Create a new agent definition |
+| `./scripts/local/bootstrap` | The one setup door: `--new`/`--adopt` × shape × profile (KIT-0053) |
 | `.kit/launchers/launch` | Interactive agent launcher |
 | `.kit/launchers/onboarding` | First-time project setup |
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Claude will:
 1. Clone the kit to a working directory (it will pick a sensible location, or ask)
 2. Read `.claude/agents/create-project.md` and follow that recipe
 3. Ask you the same questions the `create-project` agent asks (target directory, project name, task prefix, description, GitHub visibility, optional target codebase)
-4. Run `scripts/local/bootstrap --new` (the kit's one setup door), customize identity files, init adversarial-workflow, install evaluators, and create the GitHub repo
+4. Run `./scripts/local/bootstrap --new <target-dir>` (the kit's one setup door), customize identity files, init adversarial-workflow, install evaluators, and create the GitHub repo
 
 **What you need installed beforehand**:
 
@@ -129,7 +129,7 @@ cd agentive-starter-kit
 
 **4. The agent does the rest**. It will:
 
-- Run `scripts/local/bootstrap --new <dir>` (the one setup door) to export a clean copy (via `git archive`, no kit history)
+- Run `./scripts/local/bootstrap --new <dir>` (the one setup door) to export a clean copy (via `git archive`, no kit history)
 - Customize `CLAUDE.md`, `pyproject.toml`, and `README.md` with your project identity
 - Initialize `adversarial-workflow` and install the default evaluator library
 - Create the GitHub repo with `gh repo create` and push the first commit
@@ -496,7 +496,7 @@ Bootstrap an existing project with the implementation tools — agents, scripts,
 ./scripts/local/bootstrap --adopt ~/Github/my-planning --shape planning
 ```
 
-Use this when you want agentive coding help in an existing repo. Add `--no-kit` to skip the task-management workflow entirely. Run `scripts/local/bootstrap --help` for the full shape × profile matrix.
+Use this when you want agentive coding help in an existing repo. Add `--no-kit` to skip the task-management workflow entirely. Run `./scripts/local/bootstrap --help` for the full shape × profile matrix.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Claude will:
 1. Clone the kit to a working directory (it will pick a sensible location, or ask)
 2. Read `.claude/agents/create-project.md` and follow that recipe
 3. Ask you the same questions the `create-project` agent asks (target directory, project name, task prefix, description, GitHub visibility, optional target codebase)
-4. Run `scripts/optional/create-project.sh`, customize identity files, init adversarial-workflow, install evaluators, and create the GitHub repo
+4. Run `scripts/local/bootstrap --new` (the kit's one setup door), customize identity files, init adversarial-workflow, install evaluators, and create the GitHub repo
 
 **What you need installed beforehand**:
 
@@ -129,7 +129,7 @@ cd agentive-starter-kit
 
 **4. The agent does the rest**. It will:
 
-- Run `scripts/optional/create-project.sh` to export a clean copy (via `git archive`, no kit history)
+- Run `scripts/local/bootstrap --new <dir>` (the one setup door) to export a clean copy (via `git archive`, no kit history)
 - Customize `CLAUDE.md`, `pyproject.toml`, and `README.md` with your project identity
 - Initialize `adversarial-workflow` and install the default evaluator library
 - Create the GitHub repo with `gh repo create` and push the first commit
@@ -485,14 +485,18 @@ See [Quick Start → Option C](#option-c--launcher-based-onboarding). Use this w
 
 ### Consumer Project (Lightweight)
 
-Bootstrap a project with just the implementation tools — agents, scripts, and commands — without the builder layer. No `.kit/` directory, no planning agents, no evaluators.
+Bootstrap an existing project with the implementation tools — agents, scripts, commands, and the minimal `.kit/` workflow skeleton — without the full builder layer (no evaluator library, no kit ADRs).
 
 ```bash
-# From your agentive-starter-kit checkout:
-./scripts/local/bootstrap-consumer.sh ~/Github/my-app
+# From your agentive-starter-kit checkout (the one setup door):
+./scripts/local/bootstrap --adopt ~/Github/my-app
+
+# Docs-only repo (no toolchain gauntlet) / planning repo (forces profile none):
+./scripts/local/bootstrap --adopt ~/Github/my-docs --profile none
+./scripts/local/bootstrap --adopt ~/Github/my-planning --shape planning
 ```
 
-Use this when you want agentive coding help but don't need task management or multi-agent coordination.
+Use this when you want agentive coding help in an existing repo. Add `--no-kit` to skip the task-management workflow entirely. Run `scripts/local/bootstrap --help` for the full shape × profile matrix.
 
 ---
 

--- a/docs/CROSS-REPO-PATTERN.md
+++ b/docs/CROSS-REPO-PATTERN.md
@@ -96,17 +96,18 @@ for cross-repo projects and preflight-validated.
 From the agentive-starter-kit directory:
 
 ```bash
-# Using the create-project agent (recommended):
-# Invoke create-project agent in a new tab and tell it:
-#   - target directory
-#   - project name
-#   - task prefix
-#   - that it will manage an existing codebase at <path>
+# Using the one setup door (KIT-0053) with the planning shape
+# (ADR-0027 P2): coordination machinery only, no Python toolchain,
+# profile forced to none, target pointers recorded in CLAUDE.md
+./scripts/local/bootstrap --new ~/Github/my-project-planning \
+  --shape planning \
+  --target-path ../my-project \
+  --target-github acme/my-project
 
-# Or using the script directly:
-./scripts/optional/create-project.sh ~/Github/my-project-planning \
-  --name "My Project Planning" \
-  --prefix MPP
+# Or via the create-project agent (recommended for full-kit planning
+# repos): invoke it in a new tab and tell it the target directory,
+# project name, task prefix, and that it will manage an existing
+# codebase at <path>
 ```
 
 ### 2. Ensure sibling directory layout

--- a/docs/DISTRIBUTION-ARCHITECTURE.md
+++ b/docs/DISTRIBUTION-ARCHITECTURE.md
@@ -224,9 +224,11 @@ wrapped in markers:
 <!-- END KIT-LOCAL: stack-notes -->
 ```
 
-`bootstrap-consumer.sh` fills these on first bootstrap and **preserves them
-byte-for-byte across re-bootstraps** (via `scripts/local/kit_markers.py`),
-while upstream refreshes everything *outside* the markers. This is the
+The consumer engine behind the setup door (`scripts/local/bootstrap
+--adopt`, engine `engine-consumer.sh`; KIT-0053) fills these on first
+bootstrap and **preserves them byte-for-byte across re-bootstraps** (via
+`scripts/local/kit_markers.py`), while upstream refreshes everything
+*outside* the markers. This is the
 contract that lets a consumer take a workflow-body upgrade without losing
 its localization.
 

--- a/scripts/local/kit_markers.py
+++ b/scripts/local/kit_markers.py
@@ -9,7 +9,8 @@ markers:
     ...consumer-owned content...
     <!-- END KIT-LOCAL: project-context -->
 
-`bootstrap-consumer.sh` uses this helper so that:
+The consumer engine behind the setup door (`scripts/local/bootstrap`,
+engine `engine-consumer.sh`; KIT-0053) uses this helper so that:
 
 - **Fresh bootstrap** — the upstream agent is copied, then each marker
   region is replaced with consumer-derived placeholder content (so a


### PR DESCRIPTION
## Summary

PR 2 of the pre-approved KIT-0053 split (stacked on #81 — merge that first, then retarget/rebase this to main if needed).

- README: agent-flow step, clean-export bullet, and the consumer section now show `scripts/local/bootstrap` with shape/profile examples
- CLAUDE.md Key Scripts: door row added
- `.claude/agents/create-project.md`: Step 1 runs `bootstrap --new` (two-commit verification, exit-code diagnosis table)
- `.claude/agents/bootstrap.md`: preserve-list names the door + engines
- `docs/CROSS-REPO-PATTERN.md`: planning-repo setup uses `--new --shape planning` (the purpose-built P2 scaffold) instead of a full kit export
- `docs/DISTRIBUTION-ARCHITECTURE.md` + `scripts/local/kit_markers.py`: name the consumer engine behind the door
- The four KIT-LOCAL marker-bearing agents' structural preambles updated (distributed downstream via marker-merge)

After this, old entrance names appear only in the shims themselves, the characterization tests, and historical records (CHANGELOG/retros/ADRs) — the KIT-0054 removal task sweeps those shims at 0.9.0.

## Test plan

- [x] `test_kit_markers` / `test_bootstrap_consumer` / `test_template` green (marker-agent wiring unaffected)
- [x] Reference sweep: `grep -rn 'bootstrap-consumer.sh|scripts/local/bootstrap.sh|create-project.sh'` over README/CLAUDE.md/docs/agents returns only engine-name mentions and historical records

Task: `.kit/tasks/3-in-progress/KIT-0053-one-setup-door.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULQcU9dmD1fxxZNZ6fD1a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-instruction text only; no runtime or auth changes. Wrong commands in docs could confuse setup until corrected.
> 
> **Overview**
> This PR **retargets all user-facing setup guidance** to the single setup door **`./scripts/local/bootstrap`** (`--new` / `--adopt`, shape × profile), completing the KIT-0053 docs convergence (F4, PR 2/2).
> 
> **README** and **CLAUDE.md** now describe the door for new projects, clean export, and consumer adoption (including `--profile none` and `--shape planning` examples). **`create-project`** Step 1 runs `bootstrap --new` with `--without-evaluators` / `--without-venv`, documents exit-code troubleshooting, and expects **two commits** (export + install record) instead of one.
> 
> **Cross-repo setup** in `docs/CROSS-REPO-PATTERN.md` uses `--new --shape planning` with target pointers rather than `create-project.sh`. **Distribution** docs and **`kit_markers.py`** name **`engine-consumer.sh`** as the consumer engine behind `--adopt`, replacing references to `bootstrap-consumer.sh`.
> 
> **Bootstrap** preserve-list and the four **KIT-LOCAL** agent preambles (planner / feature-developer variants) are updated so downstream marker merges carry the new naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6718938be4b37a9ead20b230e68dc22dfc529b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->