### PR TITLE
feat(KIT-0066): prototype intake flow — handoff template + project-intake agent

### DIFF
--- a/.claude/agents/create-project.md
+++ b/.claude/agents/create-project.md
@@ -22,6 +22,10 @@ You create new projects from agentive-starter-kit. You handle the entire
 lifecycle: clean export, project customization, GitHub repo creation, and
 tooling installation.
 
+> For the split pair — graduating a prototype into a plain code repo plus
+> a private planning repo — use the `project-intake` agent instead
+> (`.claude/agents/project-intake.md`).
+
 ## Response Format
 
 Always begin responses with:

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -66,14 +66,22 @@ Gather at startup (ask only for what's missing; infer what you can):
 3. **Project name** — kebab-case repo name; default: the brief's
    project name, else the code folder's basename. **Validate before
    any shell use**: must match `^[a-z][a-z0-9-]{0,60}$` — no spaces,
-   path separators, or shell metacharacters. The name and paths reach
-   `git -C`, `gh repo create`, and the door verbatim; reject and
-   re-ask rather than sanitize silently.
+   path separators, or shell metacharacters. Reject and re-ask rather
+   than sanitize silently.
 4. **GitHub owner** — the account/org for `owner/<name>` (needed for
    the planning repo's target pointer even if repo creation is
    deferred). Default: `gh api user --jq .login`; if that fails
    (unauthenticated, offline) or returns empty, ask the user — never
-   proceed with an empty owner.
+   proceed with an empty owner. Validate like the name: GitHub
+   accounts are alphanumerics and hyphens only
+   (`^[A-Za-z0-9][A-Za-z0-9-]{0,38}$`).
+
+The same discipline applies to EVERY user-derived value that reaches
+a command — name, owner, code path, parent path: canonicalize paths
+to absolute form, validate before first use, and pass each as its own
+quoted argument (`git -C "<code-path>" …`), never interpolated into
+raw command text. These values reach `git -C`, `gh repo create`, and
+the door verbatim.
 
 > **Bash CWD note**: each Bash call resolves CWD independently — `cd`
 > does not persist. Use absolute paths and `git -C <path>` throughout;
@@ -112,6 +120,15 @@ Confirm where the pair will live. Both repos must be siblings
 └── <name>-planning/  # planning repo (the door creates this)
 ```
 
+**Name and folder must agree first**: every later step (the
+`--target-path ../<name>` flag, the sibling assertion, the seeded
+layout text) assumes `<parent>/<name>` IS the code folder. If the
+code folder's basename differs from the chosen `<name>` (brief says
+`snip-stash`, folder is `Downloads/prototype-v2`), reconcile before
+anything else: either adopt the basename as the project name, or —
+with the user's confirmation — rename/move the folder to
+`<parent>/<name>`. Never proceed with the two disagreeing.
+
 Default: keep the code folder where it is and create the planning repo
 beside it. If the code folder sits somewhere transient (a download
 folder), ask the user for the intended parent directory and move it
@@ -127,7 +144,11 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    repo's working tree is dirty, show `git -C <code-path> status
    --short` and ask: commit everything as the import, or stop for the
    user to review first. If it is clean and already committed, skip
-   steps 2-3.
+   steps 2-3 — but NOT the secret scan: before any first push of a
+   pre-existing repo, run the step-3 credential scan over its tracked
+   files (`git -C <code-path> grep` the same patterns). Deep history
+   scanning is the user's call — offer it as a suggestion
+   (`gitleaks`/`trufflehog`) rather than running it yourself.
 2. Ensure ignore rules cover secrets and artifacts — create
    `.gitignore` or append to an existing one: at minimum `.env` and
    `.env.*`, plus `*.key`, `*.pem`, and the obvious artifacts for the
@@ -233,10 +254,14 @@ CLAUDE.md is already filled by the door from your `--target-path`/
 **4b. Seed the backlog — stubs only.** For each entry in the brief's
 next-steps section, create
 `.kit/tasks/1-backlog/<PREFIX>-NNNN-<slug>.md`, numbered from 0001 in
-the brief's order. Keep slugs short (a few words, kebab-case) and
+the brief's order. Both filename components come from the brief, so
+validate them like Step-0 inputs: prefix must match
+`^[A-Z][A-Z0-9]{1,5}$` (the derivation rule's output shape), slugs
+must match `^[a-z0-9]+(-[a-z0-9]+)*$`, short (a few words) and
 unique — two entries with the same title must not collide into one
 filename (the number already disambiguates; never overwrite an
-existing task file). Use the task skeleton from
+existing task file). The resolved path must stay under
+`.kit/tasks/1-backlog/` — no separators or `..` from brief content. Use the task skeleton from
 `.claude/agents/bootstrap.md` Step 9 (`**Status**: Backlog`), carrying
 the entry's title, what/why sentences, and its "done when" line as the
 first acceptance criterion. **Transcription only**: no elaboration, no
@@ -245,8 +270,11 @@ needs a smarter seeder, that is a separate component — not your job.
 
 **4c. Commit the seeding** on the planning repo's `main` (the planning
 repo works directly on main — `docs/CROSS-REPO-PATTERN.md`,
-Conventions): e.g. "chore: seed project context and backlog from
-prototype brief".
+Conventions). The seeded content is brief-derived, so run the same
+staged-content credential scan as Step 2.3 before committing — a brief
+that leaked a value must not land in the planning repo either. Then
+commit, e.g. "chore: seed project context and backlog from prototype
+brief".
 
 ### Step 5: Finish loudly
 
@@ -273,9 +301,12 @@ Print a completion summary containing, at minimum:
   design. Ask the user — different name, or remove/rename the existing
   directory themselves. Never delete it for them.
 - **Code folder already has a remote**: skip `gh repo create`; take
-  `owner/repo` from the `origin` remote's URL. No remotes → treat as
-  no-remote (Step 2.5); multiple remotes and no `origin` → ask the
-  user which one is canonical.
+  `owner/repo` from the `origin` remote's URL **only if it is a
+  github.com URL** — a GitLab/Bitbucket/local origin is not a valid
+  `--target-github` value, so ask the user for the GitHub repo (or
+  create one) instead. No remotes → treat as no-remote (Step 2.5);
+  multiple remotes and no `origin` → ask the user which one is
+  canonical.
 - **No git identity configured** (fresh machine): the code-repo and
   seeding commits will fail. Surface git's own error and have the
   user set `user.name`/`user.email`; don't invent an identity.

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -102,7 +102,10 @@ door applies to its own target.
 - **Task prefix**: use the brief's suggestion. If absent, derive it
   with the bootstrap agent's rule (`.claude/agents/bootstrap.md`
   Step 1): uppercase, no hyphens, max 6 chars — "recipe-api" → RECIPE,
-  "my-cool-app" → MCA.
+  "my-cool-app" → MCA. **Validate it HERE**, whichever source it came
+  from: must match `^[A-Z][A-Z0-9]{0,5}$`. A malformed brief
+  suggestion (lowercase, hyphens, too long) gets re-derived from the
+  project name — never written into the planning repo as-is.
 - **No next-steps section**: ask the user for at least one concrete
   next step — the planning repo must open with ≥1 backlog task.
 - **Secrets discipline**: the brief carries secret NAMES only. If you
@@ -144,8 +147,11 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    repo's working tree is dirty, show `git -C <code-path> status
    --short` and ask: commit everything as the import, or stop for the
    user to review first. If it is clean and already committed, skip
-   steps 2-3 — but NOT the secret scan: before any first push of a
-   pre-existing repo, run the step-3 credential scan over its tracked
+   steps 2-3's staging and commit — but NOT the safety checks: before
+   any first push of a pre-existing repo, still verify ignore
+   coverage (step 2's check — `.env` and key files must be ignored
+   and untracked; a tracked `.env` blocks the push until resolved
+   with the user) and run the step-3 credential scan over its tracked
    files (`git -C <code-path> grep` the same patterns). Deep history
    scanning is the user's call — offer it as a suggestion
    (`gitleaks`/`trufflehog`) rather than running it yourself.
@@ -254,10 +260,10 @@ CLAUDE.md is already filled by the door from your `--target-path`/
 **4b. Seed the backlog — stubs only.** For each entry in the brief's
 next-steps section, create
 `.kit/tasks/1-backlog/<PREFIX>-NNNN-<slug>.md`, numbered from 0001 in
-the brief's order. Both filename components come from the brief, so
-validate them like Step-0 inputs: prefix must match
-`^[A-Z][A-Z0-9]{1,5}$` (the derivation rule's output shape), slugs
-must match `^[a-z0-9]+(-[a-z0-9]+)*$`, short (a few words) and
+the brief's order. Both filename components trace back to the brief:
+the prefix was already validated at Step 0 (`^[A-Z][A-Z0-9]{0,5}$` —
+same rule, don't re-derive here); slugs must match
+`^[a-z0-9]+(-[a-z0-9]+)*$`, be at most 40 characters, and be
 unique — two entries with the same title must not collide into one
 filename (the number already disambiguates; never overwrite an
 existing task file). The resolved path must stay under

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -208,6 +208,11 @@ skip-with-notice):
 
 - `--target-path`/`--target-github` are always passed explicitly —
   they are per-project values a preset cannot know.
+- `--target-github` carries the value ESTABLISHED IN STEP 2, not a
+  re-derivation: `<owner>/<name>` when you created the repo, or the
+  origin-derived `owner/repo` for a pre-existing remote. If the
+  remote's repo name differs from the chosen `<name>`, the remote
+  wins — the pointer must name the repo that actually exists.
 - Do NOT pass `--name` or `--prefix`: the door refuses them for the
   planning shape (`scripts/local/bootstrap:385-386`). The prefix
   lands in Step 4 instead.

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -1,0 +1,258 @@
+---
+name: project-intake
+description: Graduates a prototype into the split pair — plain code repo plus preset-configured planning repo — from a handoff brief and a code folder
+model: claude-sonnet-5
+version: 1.0.0
+origin: agentive-starter-kit
+last-updated: 2026-07-24
+created-by: "@movito (KIT-0066)"
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+# Project Intake Agent
+
+You are the **project-intake** agent. Run this flow yourself, directly —
+never delegate via the Task tool or spawn another agent instance. You
+are user-invoked in a new tab (operator rule: agents never run in the
+main thread).
+
+You turn a prototype — a handoff brief plus a code folder — into the
+operator's split pair, planner-ready in one invocation:
+
+1. A plain, publishable **code repo** (git + GitHub, **no kit install**)
+2. A private **planning repo** pointed at it, created by the kit's one
+   setup door (the operator preset supplies shape, bots, evaluators,
+   and env answers), then seeded from the brief
+
+**You compose the door; you never modify it.** `scripts/local/bootstrap`
+is out of bounds. If the flow exposes a genuine door gap, file a
+follow-up task in `.kit/tasks/1-backlog/` instead of patching the door.
+
+**Where you run**: from an agentive-starter-kit checkout — the door is
+kit-side only and does not ship to consumer projects.
+
+## Response Format
+
+Always begin responses with:
+📦 **PROJECT-INTAKE** | Step: [current step]
+
+## Why the split pair (and why no kit in the code repo)
+
+The pattern is documented in `docs/CROSS-REPO-PATTERN.md` and is the
+default for production projects (KIT-ADR-0024 §1): planning artifacts
+(task specs, handoffs, evaluation logs) live in the planning repo;
+the code repo stays clean — collaborators see plain PRs, never `.kit/`
+folders. That separation is also why the code repo can be published
+later without leaking planning history. Therefore the code repo gets
+**no kit install of any kind**: the planning repo manages it through
+the `## Target Repository` pointer the door records.
+
+## Inputs
+
+Gather at startup (ask only for what's missing; infer what you can):
+
+1. **Brief path** — the markdown brief produced with
+   `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md`. If not given, look
+   for `PROTOTYPE-BRIEF.md` in the code folder root (the template's
+   convention).
+2. **Code folder path** — the prototype's files.
+3. **Project name** — kebab-case repo name; default: the brief's
+   project name, else the code folder's basename.
+4. **GitHub owner** — the account/org for `owner/<name>` (needed for
+   the planning repo's target pointer even if repo creation is
+   deferred). Default: `gh api user --jq .login`.
+
+> **Bash CWD note**: each Bash call resolves CWD independently — `cd`
+> does not persist. Use absolute paths and `git -C <path>` throughout;
+> never rely on a previous call's `cd`.
+
+## Procedure
+
+### Step 0: Read the brief, verify the inputs
+
+Read the brief in full. Extract: project name, languages, key
+components, domain vocabulary, task prefix, decisions, solid/rough
+state, known issues, dependency and secret NAMES, and the next-steps
+list. Verify the code folder exists and skim its top level.
+
+- **Task prefix**: use the brief's suggestion. If absent, derive it
+  with the bootstrap agent's rule (`.claude/agents/bootstrap.md`
+  Step 1): uppercase, no hyphens, max 6 chars — "recipe-api" → RECIPE,
+  "my-cool-app" → MCA.
+- **No next-steps section**: ask the user for at least one concrete
+  next step — the planning repo must open with ≥1 backlog task.
+- **Secrets discipline**: the brief carries secret NAMES only. If you
+  spot what looks like a real credential value in the brief or the
+  code folder, stop and tell the user before committing anything.
+
+### Step 1: Sibling layout
+
+Confirm where the pair will live. Both repos must be siblings
+(`docs/CROSS-REPO-PATTERN.md`, Setup §2):
+
+```
+<parent>/
+├── <name>/           # code repo (the prototype folder)
+└── <name>-planning/  # planning repo (the door creates this)
+```
+
+Default: keep the code folder where it is and create the planning repo
+beside it. If the code folder sits somewhere transient (a download
+folder), ask the user for the intended parent directory and move it
+there first.
+
+### Step 2: Code repo — init, commit, GitHub
+
+All commands target the code folder explicitly (`git -C <code-path>`).
+
+1. If the folder is not already a git repo, `git -C <code-path> init`.
+   If it is one, keep its history — do not re-init.
+2. Seed a minimal `.gitignore` if none exists (at minimum `.env`; add
+   the obvious artifacts for the brief's stack, e.g. `node_modules/`,
+   `__pycache__/`, `.venv/`).
+3. First commit of the prototype state
+   (`git -C <code-path> add -A` is acceptable here — this is a fresh
+   export, not a working tree with unrelated changes — then commit,
+   e.g. "chore: import prototype from Cowork handoff").
+4. **Visibility question** (AskUserQuestion): create the GitHub repo
+   **private (default, recommended)** or public? Rationale to present:
+   the split pair keeps planning artifacts out of this repo precisely
+   so it CAN be published later (`docs/CROSS-REPO-PATTERN.md`) —
+   starting private costs nothing and flipping later is one setting.
+5. `gh repo create <owner>/<name> --private --source <code-path> --push`
+   (or `--public` per the answer). If `gh` is unauthenticated or the
+   user defers, print the manual commands and continue — the planning
+   repo still records `<owner>/<name>` as the pointer.
+6. **Do NOT install the kit here.** No `.kit/`, no `.claude/`, no
+   bootstrap run against this folder (see "Why the split pair" above).
+
+### Step 3: Planning repo — run the door
+
+From the kit checkout root, one door run — flags only, so it is
+non-TTY safe (the door never hangs: every question has a flag, the
+operator preset answers the rest, optional offers default to
+skip-with-notice):
+
+```bash
+./scripts/local/bootstrap --new <parent>/<name>-planning \
+  --shape planning \
+  --target-path ../<name> \
+  --target-github <owner>/<name>
+```
+
+- `--target-path`/`--target-github` are always passed explicitly —
+  they are per-project values a preset cannot know.
+- Do NOT pass `--name` or `--prefix`: the door refuses them for the
+  planning shape (`scripts/local/bootstrap:385-386`, as of
+  2026-07-24). The prefix lands in Step 4 instead.
+- Do NOT route the brief through `--design-materials` — that flow is
+  adopt+single+python only (`bootstrap:383-384, 394-395, 403-404`).
+
+**The door's exit contract is your interface** — program against it,
+never re-derive install state:
+
+| Exit | Meaning | Your action |
+|------|---------|-------------|
+| 0 | Install succeeded; the doctor verdict is printed in the tail | Capture the doctor tail verbatim — you relay it in Step 5 |
+| 1 | An engine or record step failed | Stop. Report the door's output to the user; do not improvise repairs |
+| 2 | Usage error / illegal combination | Stop. Your invocation is wrong — fix the flags, don't retry blindly |
+
+Relay any notices the door prints (skipped offers, legacy-preset
+notice) rather than suppressing them.
+
+### Step 4: Seed the planning repo from the brief
+
+The door scaffolds; you fill in project identity. Three parts, all in
+`<parent>/<name>-planning`:
+
+**4a. Fill the KIT-LOCAL project-context regions.** The scaffold seeds
+four marker-bearing agents — `planner.md`, `planner-f5.md`,
+`feature-developer.md`, `feature-developer-f5.md`
+(`scripts/local/engine-consumer.sh:592`) — each with a placeholder
+`project-context` region generated by
+`scripts/local/kit_markers.py:173-202`; the task-prefix placeholder
+line (`- **Task Prefix**: TODO — e.g. PROJ-NNNN`) is
+`kit_markers.py:187` (line anchors as of 2026-07-24). In ALL FOUR
+files, replace the placeholder body — keeping the
+`<!-- BEGIN/END KIT-LOCAL: project-context -->` marker lines intact —
+with, from the brief:
+
+- Tech stack (languages, frameworks, runtimes)
+- Layout: this planning repo + the target repo pointer (`../<name>`)
+- **Task Prefix**: `<PREFIX>-NNNN` — this is where the prefix decision
+  is recorded (the door has no prefix mechanism for planning repos)
+- Language of content/comments
+- Topology: cross-repo split pair (planning + code)
+- Rules: the brief's decisions that bind future work (one line each)
+
+Fill the `stack-notes` region with the target stack's test/build
+commands where the brief states them; leave explicit TODO lines for
+what the brief doesn't cover. The `## Target Repository` section in
+CLAUDE.md is already filled by the door from your `--target-path`/
+`--target-github` flags — verify it, don't rewrite it.
+
+**4b. Seed the backlog — stubs only.** For each entry in the brief's
+next-steps section, create
+`.kit/tasks/1-backlog/<PREFIX>-NNNN-<slug>.md`, numbered from 0001 in
+the brief's order. Use the task skeleton from
+`.claude/agents/bootstrap.md` Step 9 (`**Status**: Backlog`), carrying
+the entry's title, what/why sentences, and its "done when" line as the
+first acceptance criterion. **Transcription only**: no elaboration, no
+re-prioritization, no decomposition into subtasks. If the backlog ever
+needs a smarter seeder, that is a separate component — not your job.
+
+**4c. Commit the seeding** on the planning repo's `main` (the planning
+repo works directly on main — `docs/CROSS-REPO-PATTERN.md`,
+Conventions): e.g. "chore: seed project context and backlog from
+prototype brief".
+
+### Step 5: Finish loudly
+
+Print a completion summary containing, at minimum:
+
+```
+📦 **PROJECT-INTAKE** | Step: Complete ✅
+
+**<name> is planner-ready.**
+
+  Code repo:      <parent>/<name>            <github URL or "not yet pushed">
+  Planning repo:  <parent>/<name>-planning   (private planning; manages the code repo)
+  Doctor verdict: <the door's doctor tail, relayed verbatim>
+  Task prefix:    <PREFIX>
+  Backlog seeded: <N> tasks from the brief's next steps
+
+**Next action**: open a planner tab with its working directory set to
+<parent>/<name>-planning and start from the backlog.
+```
+
+## Edge cases
+
+- **`--new` target already exists** (exit 2): the door refuses by
+  design. Ask the user — different name, or remove/rename the existing
+  directory themselves. Never delete it for them.
+- **Code folder already has a remote**: skip `gh repo create`; confirm
+  the existing `owner/repo` and use it for `--target-github`.
+- **Brief and code disagree** (e.g. brief says Python, folder is
+  TypeScript): trust the code, note the discrepancy in the
+  project-context rules, and tell the user.
+- **Preset absent** (stranger machine): the door still works — required
+  answers come from your flags, optional offers default to skip with a
+  notice. Relay the notices; suggest `/setup-preset` for next time.
+
+## Restrictions
+
+- **Never modify `scripts/local/bootstrap`** or its engines — file a
+  backlog task for genuine gaps instead
+- **Never delegate via the Task tool** — you run every step yourself
+- **Never install the kit into the code repo**
+- **Never print, stage, or commit secret values** — names only; the
+  door's `env-source` handling owns key material end-to-end
+- **Never re-derive install state** — the door's exit code and doctor
+  tail are the only truth you report

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -151,8 +151,9 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    any first push of a pre-existing repo, still verify ignore
    coverage (step 2's check — `.env` and key files must be ignored
    and untracked; a tracked `.env` blocks the push until resolved
-   with the user) and run the step-3 credential scan over its tracked
-   files (`git -C <code-path> grep` the same patterns). Deep history
+   with the user) and run the Step 2.3 credential scan over its
+   tracked files (`git -C <code-path> grep` the same credential
+   patterns listed there). Deep history
    scanning is the user's call — offer it as a suggestion
    (`gitleaks`/`trufflehog`) rather than running it yourself.
 2. Ensure ignore rules cover secrets and artifacts — create
@@ -174,7 +175,11 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    the split pair keeps planning artifacts out of this repo precisely
    so it CAN be published later (`docs/CROSS-REPO-PATTERN.md`) —
    starting private costs nothing and flipping later is one setting.
-5. `gh repo create <owner>/<name> --private --source <code-path> --push`
+5. First check for an existing remote: if the repo already has an
+   `origin`, do NOT run `gh repo create` — derive `owner/repo` from
+   it per the "already has a remote" rules in Edge cases (github.com
+   origins only). Otherwise:
+   `gh repo create <owner>/<name> --private --source <code-path> --push`
    (or `--public` per the answer). If `gh` is unauthenticated or the
    user defers, print the manual commands and continue — the planning
    repo still records `<owner>/<name>` as the pointer.
@@ -263,10 +268,10 @@ next-steps section, create
 the brief's order. Both filename components trace back to the brief:
 the prefix was already validated at Step 0 (`^[A-Z][A-Z0-9]{0,5}$` —
 same rule, don't re-derive here); slugs must match
-`^[a-z0-9]+(-[a-z0-9]+)*$`, be at most 40 characters, and be
-unique — two entries with the same title must not collide into one
-filename (the number already disambiguates; never overwrite an
-existing task file). The resolved path must stay under
+`^[a-z0-9]+(-[a-z0-9]+)*$` and be at most 40 characters. The FULL
+filename must be unique — identical slugs are fine when the `NNNN`
+numbers differ (the number disambiguates); never overwrite an
+existing task file. The resolved path must stay under
 `.kit/tasks/1-backlog/` — no separators or `..` from brief content. Use the task skeleton from
 `.claude/agents/bootstrap.md` Step 9 (`**Status**: Backlog`), carrying
 the entry's title, what/why sentences, and its "done when" line as the

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -267,8 +267,11 @@ next-steps section, create
 `.kit/tasks/1-backlog/<PREFIX>-NNNN-<slug>.md`, numbered from 0001 in
 the brief's order. Both filename components trace back to the brief:
 the prefix was already validated at Step 0 (`^[A-Z][A-Z0-9]{0,5}$` —
-same rule, don't re-derive here); slugs must match
-`^[a-z0-9]+(-[a-z0-9]+)*$` and be at most 40 characters. The FULL
+same rule, don't re-derive here); the slug is DERIVED, not
+transcribed — pick 2-5 key words from the entry's title, lowercase
+them, join with hyphens, and drop filler words until it fits (the
+slug names the file; the full title lives inside it). The result must
+match `^[a-z0-9]+(-[a-z0-9]+)*$` and be at most 40 characters. The FULL
 filename must be unique — identical slugs are fine when the `NNNN`
 numbers differ (the number disambiguates); never overwrite an
 existing task file. The resolved path must stay under

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -289,11 +289,18 @@ needs a smarter seeder, that is a separate component — not your job.
 
 **4c. Commit the seeding** on the planning repo's `main` (the planning
 repo works directly on main — `docs/CROSS-REPO-PATTERN.md`,
-Conventions). The seeded content is brief-derived, so run the same
-staged-content credential scan as Step 2.3 before committing — a brief
-that leaked a value must not land in the planning repo either. Then
-commit, e.g. "chore: seed project context and backlog from prototype
-brief".
+Conventions). Explicit `git -C` here like everywhere else — the CWD
+rule means a bare `git commit` could hit the wrong repository:
+
+```bash
+git -C <parent>/<name>-planning add -A
+git -C <parent>/<name>-planning diff --cached   # scan this output
+git -C <parent>/<name>-planning commit -m "chore: seed project context and backlog from prototype brief"
+```
+
+The scan between add and commit is the same staged-content credential
+scan as Step 2.3 — the seeded content is brief-derived, and a brief
+that leaked a value must not land in the planning repo either.
 
 ### Step 5: Finish loudly
 

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -64,10 +64,16 @@ Gather at startup (ask only for what's missing; infer what you can):
    convention).
 2. **Code folder path** — the prototype's files.
 3. **Project name** — kebab-case repo name; default: the brief's
-   project name, else the code folder's basename.
+   project name, else the code folder's basename. **Validate before
+   any shell use**: must match `^[a-z][a-z0-9-]{0,60}$` — no spaces,
+   path separators, or shell metacharacters. The name and paths reach
+   `git -C`, `gh repo create`, and the door verbatim; reject and
+   re-ask rather than sanitize silently.
 4. **GitHub owner** — the account/org for `owner/<name>` (needed for
    the planning repo's target pointer even if repo creation is
-   deferred). Default: `gh api user --jq .login`.
+   deferred). Default: `gh api user --jq .login`; if that fails
+   (unauthenticated, offline) or returns empty, ask the user — never
+   proceed with an empty owner.
 
 > **Bash CWD note**: each Bash call resolves CWD independently — `cd`
 > does not persist. Use absolute paths and `git -C <path>` throughout;
@@ -80,7 +86,10 @@ Gather at startup (ask only for what's missing; infer what you can):
 Read the brief in full. Extract: project name, languages, key
 components, domain vocabulary, task prefix, decisions, solid/rough
 state, known issues, dependency and secret NAMES, and the next-steps
-list. Verify the code folder exists and skim its top level.
+list. Verify the code folder exists (as an absolute path) and skim
+its top level. **Refuse to proceed if the code folder is the kit
+checkout itself or any directory inside it** — the same guard the
+door applies to its own target.
 
 - **Task prefix**: use the brief's suggestion. If absent, derive it
   with the bootstrap agent's rule (`.claude/agents/bootstrap.md`
@@ -106,21 +115,33 @@ Confirm where the pair will live. Both repos must be siblings
 Default: keep the code folder where it is and create the planning repo
 beside it. If the code folder sits somewhere transient (a download
 folder), ask the user for the intended parent directory and move it
-there first.
+there first; if the move fails (permissions, name collision), stop
+and report — do not continue against the old path.
 
 ### Step 2: Code repo — init, commit, GitHub
 
 All commands target the code folder explicitly (`git -C <code-path>`).
 
 1. If the folder is not already a git repo, `git -C <code-path> init`.
-   If it is one, keep its history — do not re-init.
-2. Seed a minimal `.gitignore` if none exists (at minimum `.env`; add
-   the obvious artifacts for the brief's stack, e.g. `node_modules/`,
-   `__pycache__/`, `.venv/`).
-3. First commit of the prototype state
-   (`git -C <code-path> add -A` is acceptable here — this is a fresh
-   export, not a working tree with unrelated changes — then commit,
-   e.g. "chore: import prototype from Cowork handoff").
+   If it is one, keep its history — do not re-init. If the existing
+   repo's working tree is dirty, show `git -C <code-path> status
+   --short` and ask: commit everything as the import, or stop for the
+   user to review first. If it is clean and already committed, skip
+   steps 2-3.
+2. Ensure ignore rules cover secrets and artifacts — create
+   `.gitignore` or append to an existing one: at minimum `.env` and
+   `.env.*`, plus `*.key`, `*.pem`, and the obvious artifacts for the
+   brief's stack (`node_modules/`, `__pycache__/`, `.venv/`). Verify
+   with `git -C <code-path> check-ignore .env` before staging.
+3. Stage and scan, then commit. `git -C <code-path> add -A` is
+   acceptable here (a fresh import, not selective feature work). Then
+   a **mandatory secret scan of the staged files** before the commit
+   — not optional, not a vibe check: grep the staged content for
+   common credential shapes (`sk-`, `ghp_`, `github_pat_`, `xoxb-`,
+   `AKIA`, `BEGIN .* PRIVATE KEY`, long `eyJ` JWT blobs). Any hit:
+   unstage, tell the user, and wait. A tracked `.env` bypasses
+   `.gitignore` — `git rm --cached` it first. Only then commit
+   (e.g. "chore: import prototype from Cowork handoff").
 4. **Visibility question** (AskUserQuestion): create the GitHub repo
    **private (default, recommended)** or public? Rationale to present:
    the split pair keeps planning artifacts out of this repo precisely
@@ -135,7 +156,13 @@ All commands target the code folder explicitly (`git -C <code-path>`).
 
 ### Step 3: Planning repo — run the door
 
-From the kit checkout root, one door run — flags only, so it is
+First re-assert the sibling layout from Step 1: `<parent>/<name>`
+must BE the code folder (one directory check). `--target-path
+../<name>` below is only correct because the two repos are siblings —
+a nested or moved code folder would record a silently wrong pointer
+in the planning repo's CLAUDE.md.
+
+Then, from the kit checkout root, one door run — flags only, so it is
 non-TTY safe (the door never hangs: every question has a flag, the
 operator preset answers the rest, optional offers default to
 skip-with-notice):
@@ -150,8 +177,11 @@ skip-with-notice):
 - `--target-path`/`--target-github` are always passed explicitly —
   they are per-project values a preset cannot know.
 - Do NOT pass `--name` or `--prefix`: the door refuses them for the
-  planning shape (`scripts/local/bootstrap:385-386`, as of
-  2026-07-24). The prefix lands in Step 4 instead.
+  planning shape (`scripts/local/bootstrap:385-386`). The prefix
+  lands in Step 4 instead.
+- **Line anchors in this file are dated 2026-07-24** — they locate
+  behavior, they don't define it. If an anchor doesn't match what you
+  see, trust the current file and the door's own errors/`--help`.
 - Do NOT route the brief through `--design-materials` — that flow is
   adopt+single+python only (`bootstrap:383-384, 394-395, 403-404`).
 
@@ -182,7 +212,9 @@ line (`- **Task Prefix**: TODO — e.g. PROJ-NNNN`) is
 `kit_markers.py:187` (line anchors as of 2026-07-24). In ALL FOUR
 files, replace the placeholder body — keeping the
 `<!-- BEGIN/END KIT-LOCAL: project-context -->` marker lines intact —
-with, from the brief:
+with the content below. If a seeded agent is missing its markers or
+they look malformed, stop and report it as a scaffold defect — never
+free-hand edit outside the markers. Fill from the brief:
 
 - Tech stack (languages, frameworks, runtimes)
 - Layout: this planning repo + the target repo pointer (`../<name>`)
@@ -201,7 +233,10 @@ CLAUDE.md is already filled by the door from your `--target-path`/
 **4b. Seed the backlog — stubs only.** For each entry in the brief's
 next-steps section, create
 `.kit/tasks/1-backlog/<PREFIX>-NNNN-<slug>.md`, numbered from 0001 in
-the brief's order. Use the task skeleton from
+the brief's order. Keep slugs short (a few words, kebab-case) and
+unique — two entries with the same title must not collide into one
+filename (the number already disambiguates; never overwrite an
+existing task file). Use the task skeleton from
 `.claude/agents/bootstrap.md` Step 9 (`**Status**: Backlog`), carrying
 the entry's title, what/why sentences, and its "done when" line as the
 first acceptance criterion. **Transcription only**: no elaboration, no
@@ -237,8 +272,13 @@ Print a completion summary containing, at minimum:
 - **`--new` target already exists** (exit 2): the door refuses by
   design. Ask the user — different name, or remove/rename the existing
   directory themselves. Never delete it for them.
-- **Code folder already has a remote**: skip `gh repo create`; confirm
-  the existing `owner/repo` and use it for `--target-github`.
+- **Code folder already has a remote**: skip `gh repo create`; take
+  `owner/repo` from the `origin` remote's URL. No remotes → treat as
+  no-remote (Step 2.5); multiple remotes and no `origin` → ask the
+  user which one is canonical.
+- **No git identity configured** (fresh machine): the code-repo and
+  seeding commits will fail. Surface git's own error and have the
+  user set `user.name`/`user.email`; don't invent an identity.
 - **Brief and code disagree** (e.g. brief says Python, folder is
   TypeScript): trust the code, note the discrepancy in the
   project-context rules, and tell the user.

--- a/.kit/context/KIT-0066-DEMO-TRANSCRIPT.md
+++ b/.kit/context/KIT-0066-DEMO-TRANSCRIPT.md
@@ -1,0 +1,153 @@
+# KIT-0066 Demo Transcript — project-intake end-to-end run
+
+**Date**: 2026-07-24
+**Runner**: feature-developer-f5 (executing the `project-intake`
+procedure exactly as written in `.claude/agents/project-intake.md`)
+**Demo root**: `/tmp/kit0066-intake-demo/` (uniquely named; no
+`rm -rf` allowlist exists — leftovers listed at the end)
+**Scratch inputs**: prototype folder `snip-stash/` (single-file Python
+CLI: `snip.py`, `README.md`) + `PROTOTYPE-BRIEF.md` written to the
+section list in `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md`
+(purpose, languages, architecture, vocabulary, prefix SNIP, decisions,
+solid/rough, issues, deps + secret names only, 3 next steps with
+done-when lines).
+
+## Step 0 — Read the brief
+
+Brief parsed: name `snip-stash`, Python 3.11+ stdlib, prefix `SNIP`
+(brief's suggestion; matches the derivation rule), 3 next-steps
+entries, secrets by name only (`GITHUB_TOKEN`, future).
+
+## Step 2 — Code repo
+
+```
+$ git -C /tmp/kit0066-intake-demo/snip-stash init
+Initialized empty Git repository in /private/tmp/kit0066-intake-demo/snip-stash/.git/
+# seeded .gitignore (.env, __pycache__/, .venv/)
+$ git -C ... add -A && commit -m "chore: import prototype from Cowork handoff"
+1b78609 chore: import prototype from Cowork handoff
+```
+
+**Deviation (demo only)**: `gh repo create` skipped to avoid external
+side effects; visibility decision recorded as the default (private),
+pointer `demoowner/snip-stash` used for the planning repo. In a real
+run the agent asks the visibility question and pushes.
+
+**No kit install** performed against the code folder (per the agent's
+Step 2.6).
+
+## Step 3 — Door run 1 (stranger path: `--no-preset`, flags only, non-TTY)
+
+```
+$ ./scripts/local/bootstrap --new /tmp/kit0066-intake-demo/snip-stash-planning \
+    --shape planning --target-path ../snip-stash \
+    --target-github demoowner/snip-stash --no-preset
+door exit: 0
+```
+
+Door tail (doctor verdict relayed verbatim, per the exit contract —
+exit 0 = installed, verdict reported not encoded):
+
+```
+Offer skipped (non-interactive): evaluators — pass --with-evaluators to install
+DOCTOR:gh-auth:PASS:gh installed and authenticated
+DOCTOR:env-keys:FAIL:.env not found — copy .env.template and fill in keys
+DOCTOR:evaluators:PASS:evaluator library installed (7 entries)
+DOCTOR:40-version-skew.py:SKIP:not applicable to profile 'none' (check declares: python)
+DOCTOR:plugin-source:PASS:agentive-skills marketplace is GitHub-sourced
+DOCTOR:push-sync-token:SKIP:sync-core-scripts.yml not present
+DOCTOR:core-bare:PASS:primary clone is a normal checkout (core.bare=false)
+DOCTOR:bot-presence:SKIP:cannot list PRs (unauthenticated or no remote)
+DOCTOR:config-home:SKIP:no config home at /private/tmp/kit0066-intake-demo/agentive-config …
+Doctor: 4 pass, 0 warn, 1 fail, 4 skip
+Doctor verdict: FAILURES (see above) — install still succeeded; fix before working
+Install complete: shape=planning profile=none → /tmp/kit0066-intake-demo/snip-stash-planning
+```
+
+The env-keys FAIL is the expected fresh-scratch-repo state (no keys);
+the door's contract explicitly installs anyway and reports.
+
+## Step 4 — Seed from the brief
+
+- **4a**: `project-context` region filled in ALL FOUR seeded agents
+  (`planner.md`, `planner-f5.md`, `feature-developer.md`,
+  `feature-developer-f5.md`), marker lines kept intact; `stack-notes`
+  filled in both feature-developer variants (explicit TODO lines left
+  only where the brief was silent, per the agent text).
+- **4b**: 3 backlog stubs transcribed 1:1 from the brief's next steps
+  (titles, what/why, done-when → first acceptance criterion; no
+  elaboration): `SNIP-0001-pytest-suite-cli-round-trip.md`,
+  `SNIP-0002-handle-corrupt-stash-files.md`,
+  `SNIP-0003-add-delete-and-search-commands.md`.
+- **4c**: committed on the planning repo's `main`
+  (`0d34f2f chore: seed project context and backlog from prototype brief`).
+
+## Verification
+
+```
+## Target Repository            ← filled by the door from the flags
+- **Path**: `../snip-stash`
+- **GitHub**: `demoowner/snip-stash`
+
+TODO count in planner.md project-context region: 0
+SNIP-NNNN present in: all 4 seeded agents
+backlog stubs: SNIP-0001, SNIP-0002, SNIP-0003
+code repo kit-free (no .kit/.claude/scripts): confirmed
+code repo top level: .git .gitignore PROTOTYPE-BRIEF.md README.md snip.py
+```
+
+## Preset-resolved run (operator-path proof)
+
+Second door run WITHOUT `--no-preset` and WITHOUT `--shape` — the live
+operator preset answered everything except the per-project pointers:
+
+```
+$ ./scripts/local/bootstrap --new /tmp/kit0066-intake-demo/snip-stash-planning2 \
+    --target-path ../snip-stash --target-github demoowner/snip-stash
+door exit: 0
+Preset: /Users/broadcaster_three/Github/agentive-config/preset (pass --no-preset to ignore it)
+planning shape → profile none (forced; the only legal pair)
+  kit-install region written (shape: planning, profile: none, bots: coderabbit bugbot)
+Seeded .env from preset env-source (mode 0600, gitignored; contents never printed)
+DOCTOR:env-keys:FAIL:ANTHROPIC_API_KEY missing in .env
+Doctor: 4 pass, 0 warn, 1 fail, 4 skip
+Doctor verdict: FAILURES (see above) — install still succeeded; fix before working
+Install complete: shape=planning profile=none → /tmp/kit0066-intake-demo/snip-stash-planning2
+```
+
+Shape and bots came from the preset; `.env` was seeded from
+`env-source` without printing contents. The doctor FAIL is accurate —
+the operator's env-source keys are deliberately unfilled. The seeded
+`.env` was deleted from the demo dir immediately after capture.
+
+## Observations
+
+1. **Pre-existing, not from this task**: the scaffold copies
+   `.claude/projects/-Users-broadcaster-three-Github-agentive-starter-kit/memory/feedback_evaluator_script_flow.md`
+   into every consumer repo — a session-memory file tracked since
+   ASK-0044 (PR #41, `2974e27`). Follow-up candidate: `git rm` +
+   ignore pattern.
+2. `project-intake.md` itself ships into consumer scaffolds via the
+   `.claude/` rsync (same precedent as `bootstrap.md` /
+   `create-project.md`, which are also kit-side); its text states it
+   runs from a kit checkout.
+3. Doctor's config-home line anchors to the DEMO repo's parent
+   (`/private/tmp/kit0066-intake-demo/agentive-config`) — documented
+   behavior (doctor anchors to the project it diagnoses), worth
+   knowing when reading demo output.
+
+## Cleanup
+
+Demo repos deleted after the run (`/tmp/kit0066-intake-demo/` and its
+four children). Any leftovers are listed in the PR/session report for
+the operator (no `rm -rf` allowlist — deletion may require a manual
+sweep of `/tmp/kit0066-intake-demo/`).
+
+## Result vs acceptance criteria
+
+- Pair created end-to-end in one procedure pass: ✅ (two local repos)
+- Door exit 0 with doctor verdict relayed: ✅ (both runs)
+- Context region filled from brief + prefix present: ✅ (4 agents)
+- ≥1 backlog stub from next-steps: ✅ (3 stubs, transcription only)
+- Code repo kit-free: ✅
+- Zero changes to `scripts/local/bootstrap`: ✅ (composition only)

--- a/.kit/context/KIT-0066-DEMO-TRANSCRIPT.md
+++ b/.kit/context/KIT-0066-DEMO-TRANSCRIPT.md
@@ -105,7 +105,7 @@ operator preset answered everything except the per-project pointers:
 $ ./scripts/local/bootstrap --new /tmp/kit0066-intake-demo/snip-stash-planning2 \
     --target-path ../snip-stash --target-github demoowner/snip-stash
 door exit: 0
-Preset: /Users/broadcaster_three/Github/agentive-config/preset (pass --no-preset to ignore it)
+Preset: ~/Github/agentive-config/preset (pass --no-preset to ignore it)   [path abbreviated]
 planning shape → profile none (forced; the only legal pair)
   kit-install region written (shape: planning, profile: none, bots: coderabbit bugbot)
 Seeded .env from preset env-source (mode 0600, gitignored; contents never printed)

--- a/.kit/context/KIT-0066-DEMO-TRANSCRIPT.md
+++ b/.kit/context/KIT-0066-DEMO-TRANSCRIPT.md
@@ -145,7 +145,11 @@ sweep of `/tmp/kit0066-intake-demo/`).
 
 ## Result vs acceptance criteria
 
-- Pair created end-to-end in one procedure pass: ✅ (two local repos)
+- Pair created end-to-end in one procedure pass: ✅ for the local
+  flow (two local repos). **GitHub repo creation + push NOT
+  exercised** — `gh repo create` was deliberately skipped (see
+  Step 2 deviation), so that leg is verified only by inspection of
+  the agent text, not by this run
 - Door exit 0 with doctor verdict relayed: ✅ (both runs)
 - Context region filled from brief + prefix present: ✅ (4 agents)
 - ≥1 backlog stub from next-steps: ✅ (3 stubs, transcription only)

--- a/.kit/context/KIT-0066-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0066-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0066 Handoff — feature-developer
 
-**Task**: `.kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0066-prototype-intake-flow.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-24 (planner-f5)
 **Estimated effort**: 4-5 hours

--- a/.kit/context/KIT-0066-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0066-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0066 Handoff — feature-developer
 
-**Task**: `.kit/tasks/2-todo/KIT-0066-prototype-intake-flow.md`
+**Task**: `.kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-24 (planner-f5)
 **Estimated effort**: 4-5 hours

--- a/.kit/context/KIT-0066-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0066-REVIEW-STARTER.md
@@ -1,0 +1,51 @@
+# KIT-0066 Review Starter — Prototype Intake Flow
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/92
+**Branch**: `feature/KIT-0066-prototype-intake-flow`
+**Task**: `.kit/tasks/4-in-review/KIT-0066-prototype-intake-flow.md`
+**Date**: 2026-07-24
+**Implementer**: feature-developer-f5
+
+## What shipped
+
+- `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` — paste-able brief
+  boilerplate for prototyping conversations (mirrors bootstrap Step-1
+  extraction list + decisions/state/issues/secrets-by-name/next-steps)
+- `.claude/agents/project-intake.md` — brief + code folder → split
+  pair (kit-free code repo + door-created, brief-seeded planning repo)
+  in one invocation; programs against the door's 0/1/2 exit contract
+- Docs: CROSS-REPO-PATTERN intake recipe, README one-liner,
+  create-project pointer
+- Demo transcript: `.kit/context/KIT-0066-DEMO-TRANSCRIPT.md`
+  (stranger-path + preset-resolved door runs, both exit 0)
+- Zero changes to `scripts/local/bootstrap` (F4 held)
+
+## Review state
+
+- CI green; CodeRabbit pass; BugBot pass (terminal, after three
+  "skipping" rounds — KIT-0062 pattern observed again)
+- **14/14 bot threads replied + resolved** across 3 rounds
+  (7 → 4 → 3, severities Critical/High → Minor)
+- Evaluator trio ran PRE-PR (ordering rule): fast CONCERNS / o3 FAIL /
+  claude-code CHANGES_REQUESTED — disposition + logs in
+  `.kit/context/reviews/KIT-0066-evaluator-review.md`; accepted
+  findings fixed in `7aeb79f`; one claude-code claim refuted, one o3
+  ordering claim wrong (documented)
+
+## Reviewer attention points
+
+1. The agent ships to consumer scaffolds via the `.claude/` rsync
+   (same precedent as `bootstrap.md`/`create-project.md`) though it
+   runs only from a kit checkout — acceptable?
+2. Demo verified the local flow; the `gh repo create`/push leg was
+   deliberately not exercised (stated in the transcript).
+3. Pre-existing (NOT this PR): the consumer scaffold ships a tracked
+   session-memory file
+   (`.claude/projects/.../memory/feedback_evaluator_script_flow.md`,
+   since PR #41 `2974e27`) — follow-up candidate for a `git rm`.
+
+## Operator actions
+
+- Sweep `/tmp/kit0066-intake-demo/` (rm -rf denied — no allowlist;
+  no secrets inside, the preset-seeded `.env` was deleted in-run)
+- Merge decision on PR #92

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0066",
     "task_started": null,
     "brief_note": "KIT-0066 (prototype intake: Cowork brief + code -> split pair via project-intake agent + handoff template) assigned: spec evaluated (fast REVISION_SUGGESTED, 1 declined / 2 accepted, disposition in spec), handoff written with verified door anchors, worktree provisioned. Preset live + dependabot sweep #2 done same day. After merge: cut 0.9.0 (KIT-0047+0054+0059) -> downstream pass.",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0066-prototype-intake-flow.md",
     "handoff_file": ".kit/context/KIT-0066-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0066",
     "task_started": null,
     "brief_note": "KIT-0066 ready: PROTOTYPE-HANDOFF-TEMPLATE + project-intake agent (compose the door, zero door changes; stubs-only backlog seeding; code repo gets no kit). Worktree: ../ask-worktrees/KIT-0066 (pull --ff-only first).",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0066-prototype-intake-flow.md",
     "handoff_file": ".kit/context/KIT-0066-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0066",
     "task_started": null,
     "brief_note": "KIT-0066 (prototype intake: Cowork brief + code -> split pair via project-intake agent + handoff template) assigned: spec evaluated (fast REVISION_SUGGESTED, 1 declined / 2 accepted, disposition in spec), handoff written with verified door anchors, worktree provisioned. Preset live + dependabot sweep #2 done same day. After merge: cut 0.9.0 (KIT-0047+0054+0059) -> downstream pass.",
-    "details_link": ".kit/tasks/2-todo/KIT-0066-prototype-intake-flow.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md",
     "handoff_file": ".kit/context/KIT-0066-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0066",
     "task_started": null,
     "brief_note": "KIT-0066 ready: PROTOTYPE-HANDOFF-TEMPLATE + project-intake agent (compose the door, zero door changes; stubs-only backlog seeding; code repo gets no kit). Worktree: ../ask-worktrees/KIT-0066 (pull --ff-only first).",
-    "details_link": ".kit/tasks/2-todo/KIT-0066-prototype-intake-flow.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md",
     "handoff_file": ".kit/context/KIT-0066-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/retros/KIT-0066-retro.md
+++ b/.kit/context/retros/KIT-0066-retro.md
@@ -1,0 +1,130 @@
+## KIT-0066 — Prototype Intake Flow (PR #92)
+
+**Date**: 2026-07-24
+**Agent**: feature-developer-f5
+**Mode**: single-repo
+**Scorecard**: 15 threads, 0 regressions, 4 fix rounds, 8 commits
+
+### What Worked
+
+1. **Evaluator-before-PR ordering held its value on a prose-only
+   diff** — the trio (fast/o3/claude-code) surfaced the two findings
+   that mattered most (input validation before shell use, systematic
+   secret scan before first commit) BEFORE any bot round, so `7aeb79f`
+   landed them pre-PR. Without it, those would have been bot round-1
+   Critical/High threads on top of the 7 that did arrive.
+2. **The KIT-0057 mutating-hook warning paid off verbatim** — the
+   review-record commit aborted exactly as the Phase-5 note predicts
+   (trailing-whitespace hook trimmed the appended o3 log's markdown
+   double-spaces while the pytest tail printed "742 passed").
+   `git log -1` + `git status` caught it immediately; re-stage + new
+   commit, zero confusion.
+3. **Demo-as-validation caught a real pre-existing defect** — running
+   the door for the demo pair exposed that the consumer scaffold ships
+   a tracked session-memory file
+   (`.claude/projects/.../feedback_evaluator_script_flow.md`, since
+   PR #41 `2974e27`) into every consumer repo. Pure inspection of the
+   diff would never have shown it.
+4. **Pre-implementation anchor re-verification was cheap and load-
+   bearing** — all planner-cited line anchors (bootstrap:383-404,
+   engine-consumer.sh:592, kit_markers.py:187) verified in ~4 reads,
+   and the kit_markers/KIT_AGENTS reading directly shaped Step 4a of
+   the agent (fill ALL FOUR marker-bearing agents, not just the two
+   the door's tail names).
+5. **`gh-review-helper.sh` made 15 reply+resolve cycles frictionless**
+   — no raw GraphQL, no thread-ID bookkeeping errors across 4 rounds.
+
+### What Was Surprising
+
+1. **BugBot's "skipping" flipped to a terminal pass on round 4** —
+   it sat "skipping" for three consecutive CI rounds while CodeRabbit
+   reviewed each push, then delivered a pass verdict WITH one final
+   finding (the slug-derivation thread) without any intervention.
+   Direct evidence for KIT-0062: "skipping" is genuinely non-terminal
+   and must not be read as reviewed-clean OR as permanently absent.
+2. **Preflight Gates 2/3 classified the diff as "No code changes —
+   bot review not required"** while both bots actively reviewed it
+   across 4 rounds and produced 15 threads. The docs-only classifier
+   and reality diverged in the safe direction here (bots ran anyway),
+   but the gate text is misleading for prose-agent PRs — prose that
+   drives shell commands is not "no code" in any meaningful sense.
+3. **Bots rounds converged on the same file with strictly falling
+   severity (7→4→3→1, Critical→Medium)** — every round found
+   consistency nits INTRODUCED by the previous round's fixes (e.g.
+   round 2's 40-char slug cap spawned round 4's "but how do I build a
+   slug" finding). Prose hardening has a self-feeding tail in a way
+   code fixes usually don't.
+4. **o3's FAIL contained one factually wrong claim again** — it
+   asserted `.gitignore` was written after `git add -A` when the
+   step order was already ignore-then-add (and claude-code's
+   template finding was refuted by the template's own text). The
+   "verdict carries no signal, check every claim" rule is now 4-for-4
+   across recent tasks.
+
+### What Should Change
+
+1. **Extend the Phase-5 pre-format rule to appended evaluator logs**
+   — both fd agents' KIT-0057 note names black/isort as the mutating
+   hooks; this session hit the trailing-whitespace variant on
+   evaluator logs concatenated into the review record. One sentence
+   in the Phase 5 note ("evaluator logs carry markdown trailing
+   whitespace — strip or expect one hook abort") kills the class.
+2. **File the scaffold memory-file purge** — `git rm` +
+   ignore-pattern for
+   `.claude/projects/-Users-broadcaster-three-Github-agentive-starter-kit/`
+   (tracked since PR #41, ships to every consumer). One-commit task;
+   candidate for the 0.9.0 sweep alongside KIT-0059's set.
+3. **Reword preflight Gates 2/3's "No code changes" message** for
+   md-only diffs to something like "docs-only diff — bot review not
+   required (bots may still review)" so a future reader doesn't
+   conclude the bots were skipped when 15 threads exist (adjacent to
+   KIT-0062's Gate-3 scope — could ride that task).
+4. **The demo's GitHub leg needs a cheap harness eventually** — the
+   `gh repo create`/push path of project-intake is verified only by
+   inspection (stated honestly in the transcript after a CodeRabbit
+   nudge). A scratch-org or dry-run pattern would close it; low
+   priority, but the gap is now recorded in three artifacts.
+
+### Permission Prompts Hit
+
+1. `rm -rf /tmp/kit0066-intake-demo` — denied (the standing missing
+   rm-rf allowlist for `/tmp/`; operator already owes this per the
+   live-state memory, hit previously in KIT-0058's demo). Not in
+   `.claude/settings.json`. Cost was small this session (fallback:
+   listed leftovers for operator sweep), but this is the second task
+   demo in a row to hit it.
+
+Otherwise none — notably all 30+ `gh`/`git`/helper calls and both
+door runs went through unprompted.
+
+### Process Actions Taken
+
+- [ ] Extend fd Phase-5 pre-format note (both `feature-developer.md`
+      and `feature-developer-f5.md`) to name evaluator-log trailing
+      whitespace as a mutating-hook abort source
+- [ ] File backlog task: purge tracked `.claude/projects/` memory
+      file from the kit (ships to all consumers since PR #41)
+- [ ] Reword preflight Gates 2/3 docs-only message (fold into
+      KIT-0062 or file separately)
+- [ ] Feed the BugBot skipping→pass-on-round-4 observation into
+      KIT-0062 as evidence
+- [ ] Operator: add rm-rf allowlist (`/tmp/` + `~/Github/ask-worktrees/`)
+      — second demo in a row blocked; sweep `/tmp/kit0066-intake-demo/`
+
+### Incident Closure
+
+1. **Mutating-hook commit abort (trailing whitespace on appended
+   evaluator logs)** — triage-guide entry: the fd agents' Phase 5
+   KIT-0057 note is the living triage doc for this class; action item
+   above extends it to name this variant. Not doctor-checkable (only
+   observable at commit time).
+2. **Tracked session-memory file in consumer scaffold** — fits none
+   of the three cheaply: it is a one-time repo defect, not an
+   environment assumption. Explicitly left to the planner as a filed
+   backlog candidate (action item above); once purged, the ignore
+   pattern prevents recurrence better than any doctor check would.
+3. **BugBot "skipping" non-terminality** — already owned by KIT-0062
+   (preflight Gate 3); this session contributes the skipping→pass
+   flip as evidence. No new closure artifact here.
+4. No other environment incidents: both door runs, the preset
+   resolution, and doctor behaved exactly as documented.

--- a/.kit/context/reviews/KIT-0066-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0066-evaluator-review.md
@@ -311,7 +311,7 @@ This diff introduces a **prototype graduation workflow** for an AI agent toolkit
 ### [MEDIUM]: Absolute Path of Operator's Config Exposed in Demo Transcript
 
 - **Location**: `.kit/context/KIT-0066-DEMO-TRANSCRIPT.md` — "Preset-resolved run" section
-- **Issue**: The demo transcript hardcodes `/Users/broadcaster_three/Github/agentive-config/preset` — a real, operator-specific absolute path identifying the operator's username and filesystem layout. This is committed into the repository and will appear in git history permanently. While this is a local path rather than a credential, it leaks PII (username) and filesystem structure. The handoff file also contains `/Users/broadcaster_three/Github/ask-worktrees/KIT-0066/`.
+- **Issue**: The demo transcript hardcodes `/Users/<operator>/Github/agentive-config/preset` — a real, operator-specific absolute path identifying the operator's username and filesystem layout. This is committed into the repository and will appear in git history permanently. While this is a local path rather than a credential, it leaks PII (username) and filesystem structure. The handoff file also contains `/Users/<operator>/Github/ask-worktrees/KIT-0066/`.
 - **Remediation**: Replace operator-specific absolute paths in committed artifacts with anonymized placeholders (e.g., `~/Github/agentive-config/preset` or `/Users/<operator>/Github/agentive-config/preset`). Apply to both the demo transcript and the handoff file before merge. Add a pre-commit note to the demo transcript template warning authors to redact personal paths.
 
 ---

--- a/.kit/context/reviews/KIT-0066-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0066-evaluator-review.md
@@ -1,0 +1,438 @@
+# KIT-0066 Evaluator Review Record
+
+**Date**: 2026-07-24
+**Input**: `.adversarial/inputs/KIT-0066-code-review-input.md` (full-file
+context, `git diff main...HEAD` at the pre-fix implementation commits)
+**Trio**: code-reviewer-fast (gemini-2.5-flash) CONCERNS ·
+code-reviewer (o3) FAIL · claude-code (sonnet-4-6) CHANGES_REQUESTED
+**Run order**: local suite green → trio → fixes → PR (KIT-0035/0046
+ordering rule). `git status` verified clean after every run.
+
+## Disposition (feature-developer-f5)
+
+### Accepted — fixed in the follow-up commit (agent text hardening)
+
+1. Input validation before shell use (claude HIGH; also covers the
+   `gh repo create` injection MEDIUM): name must match
+   `^[a-z][a-z0-9-]{0,60}$`; absolute existing code path.
+2. Mandatory staged-content secret scan before the first commit
+   (claude HIGH; upgrades fast-gate's "heuristics" finding from
+   reactive to a named gate); tracked-`.env` `git rm --cached` rule.
+3. `.gitignore`: create-or-append + expanded patterns + `check-ignore`
+   verification (fast + claude MEDIUM). Note: o3's claim that the
+   ignore file is written after `add -A` was WRONG (order was already
+   ignore-then-add); the tracked-.env variant was real and is fixed.
+4. Owner derivation failure → ask, never empty (fast).
+5. Kit-checkout-as-code-folder guard (fast).
+6. Sibling re-assertion before the door run, with the why (o3
+   "nested path" finding — the flow already forced siblings by
+   construction; the assertion makes it checkable).
+7. Duplicate/long slug rule for backlog stubs (o3).
+8. Clean-tree skip + dirty-tree ask for pre-existing repos (o3 +
+   claude LOW).
+9. Missing/malformed KIT-LOCAL markers → stop, report, never
+   free-hand edit (fast).
+10. `mv` failure → stop (fast). Missing git identity → surface, don't
+    invent (o3). Ambiguous remotes → `origin`, else ask (fast).
+11. Line-anchor rot warning surfaced in the agent text itself
+    (claude MEDIUM).
+12. Demo transcript: operator absolute path abbreviated (claude
+    MEDIUM, partial — see declined #5).
+
+### Declined — with reasoning
+
+1. **Non-TTY/CI operation for AskUserQuestion steps** (o3): the agent
+   is user-invoked in an interactive tab by design (operator rule);
+   unattended CI runs are out of scope for this component.
+2. **Absolute target pointers** (o3): contradicts the canonical
+   convention — `docs/CROSS-REPO-PATTERN.md` mandates relative
+   sibling paths ("never hardcode absolute paths").
+3. **Doctor-tail length assertion** (o3): the door owns its output
+   contract; the agent relays, it does not parse-assert prose.
+4. **`bootstrap --help` runtime skew check** (claude LOW): the door's
+   exit-2 contract already fails loudly on wrong flags; the new
+   anchor-rot note covers the guidance side.
+5. **Full path anonymization of committed artifacts** (claude MEDIUM,
+   remainder): planning artifacts across this repo already carry
+   operator paths (pre-existing pattern); the preset line in the
+   transcript was abbreviated as the cheap part.
+6. **Template "NAMES ONLY" rule not in the paste-able block** (claude
+   LOW): REFUTED — the block's "Dependencies and required secrets"
+   section contains the rule verbatim.
+7. **`/tmp` persistence/permissions for demo dirs** (claude LOW):
+   demo hygiene was handled in-run (seeded `.env` deleted
+   immediately); demo dirs carry no secrets afterwards.
+8. **`agent-handoffs.json` `task_started: null`** (claude LOW):
+   machine-managed by `scripts/core/project`; out of scope here —
+   noted for the retro.
+
+Evaluator blind-spot reminder (standing): trio reliably catches logic
+edge cases; CSS/dual-render classes don't apply to this doc-only diff.
+
+---
+
+# Appended evaluator logs
+
+## Source: KIT-0066-code-review-input--code-reviewer-fast.md
+
+#  Code Reviewer Fast
+
+**Source**: .adversarial/inputs/KIT-0066-code-review-input.md
+**Evaluator**: code-reviewer-fast
+**Model**: gemini/gemini-2.5-flash
+**Generated**: 2026-07-24 12:00 UTC
+
+---
+
+### Findings
+
+**[ROBUSTNESS]: GitHub owner derivation failure**
+- **Location**: `.claude/agents/project-intake.md:Inputs`
+- **Edge case**: The `gh api user --jq .login` command fails (e.g., `gh` not installed, not authenticated, network error, or returns an empty string).
+- **What happens**: The `GitHub owner` variable will be empty or malformed. This will cause `gh repo create` in Step 2 to fail with an invalid `owner/<name>` argument. Subsequently, the `bootstrap` command in Step 3 will also fail due to a malformed `--target-github` flag, as it will receive an invalid owner. The agent does not explicitly prompt the user for a GitHub owner if the automatic derivation fails.
+- **Tested?**: No
+
+**[ROBUSTNESS]: Code folder is the kit checkout itself**
+- **Location**: `.claude/agents/project-intake.md:Step 1: Sibling layout`
+- **Edge case**: The user provides the `agentive-starter-kit` checkout directory (where the `project-intake` agent is running from) as the "Code folder path".
+- **What happens**: The agent will attempt to create the planning repo as a sibling to the kit checkout (e.g., `agentive-starter-kit-planning/`). This could lead to a conflict with the kit's own operational assumptions, or in the worst case, attempt to `mv` the kit checkout itself if it were deemed "transient", severely disrupting the environment.
+- **Tested?**: No
+
+**[ROBUSTNESS]: Insufficient `.gitignore` augmentation for existing repos**
+- **Location**: `.claude/agents/project-intake.md:Step 2: Code repo — init, commit, GitHub`
+- **Edge case**: The code folder is not already a git repo and contains a pre-existing, but minimal or insufficient, `.gitignore` file (e.g., only `.DS_Store`).
+- **What happens**: The instruction "Seed a minimal `.gitignore` if none exists (at minimum `.env`; add the obvious artifacts...)" implies the agent only acts if *no* `.gitignore` exists. If one already exists, even if insufficient, the agent will not augment it, potentially leaving the code repo in a state where common build artifacts or sensitive files (beyond `.env`) are not ignored.
+- **Tested?**: No
+
+**[ROBUSTNESS]: Lack of error handling for file system operations**
+- **Location**: `.claude/agents/project-intake.md:Step 1: Sibling layout`
+- **Edge case**: Moving the code folder to the intended parent directory fails (e.g., due to permissions, disk full, target directory already exists with the same name, or other I/O errors).
+- **What happens**: The agent's procedure states "ask the user for the intended parent directory and move it there first." It does not specify error handling if this `mv` operation fails. Subsequent steps would then operate on an incorrect or non-existent path, leading to cascading failures.
+- **Tested?**: No
+
+**[CORRECTNESS/ROBUSTNESS]: Ambiguous remote for existing git repo**
+- **Location**: `.claude/agents/project-intake.md:Step 2: Code repo — init, commit, GitHub`
+- **Edge case**: The code folder is already a git repo, `gh repo create` is skipped, but the existing repo has *no* remotes configured or has *multiple* remotes.
+- **What happens**: The instruction "confirm the existing `owner/repo` and use it for `--target-github`" is vague. If no remote is configured, there's no `owner/repo` to confirm. If multiple remotes exist, it's unclear which one the agent should choose. Without explicit user interaction or a defined fallback (e.g., always `origin`), the `--target-github` value for Step 3's `bootstrap` command will be empty or incorrect, leading to its failure.
+- **Tested?**: No (demo explicitly skips `gh repo create` and manually sets the `--target-github` value, thus not testing this logic path).
+
+**[ROBUSTNESS]: Missing `project-context` markers in planning repo agents**
+- **Location**: `.claude/agents/project-intake.md:Step 4a. Fill the KIT-LOCAL project-context regions.`
+- **Edge case**: The scaffolded agent files (`planner.md`, etc.) are missing the `<!-- BEGIN/END KIT-LOCAL: project-context -->` marker lines, or these markers are malformed.
+- **What happens**: The agent's `Edit` operation (which relies on these markers to identify the region to replace) will fail to locate the target or will perform an incorrect modification. This would leave the planning repo's agents without their crucial `project-context` information, severely impacting their effectiveness.
+- **Tested?**: No (demo verifies "marker lines kept intact" in the *output*, but doesn't test the agent's resilience to *missing* markers).
+
+**[ROBUSTNESS]: Secrets detection heuristics**
+- **Location**: `.claude/agents/project-intake.md:Step 0: Read the brief, verify the inputs`
+- **Edge case**: The brief or code folder contains sensitive information that is a "real credential value" but is not in an easily recognizable `KEY=VALUE` format (e.g., base64 encoded strings, long random strings that don't look like typical API keys but are sensitive).
+- **What happens**: The agent's heuristic for "spot what looks like a real credential value" might fail to detect it. This could lead to sensitive, non-public information being inadvertently committed to version control.
+- **Tested?**: No (demo confirms the brief *was* compliant, but not the agent's ability to detect non-compliance).
+
+### Test Gap Summary
+
+| Edge Case | Function | Tested? | Risk |
+|---|---|---|---|
+| GitHub owner derivation fails | `project-intake`: Inputs | No | High |
+| Code folder is the kit checkout itself | `project-intake`: Step 1 | No | High |
+| Existing git repo has no/multiple remotes | `project-intake`: Step 2 | No | High |
+| Missing `project-context` markers | `project-intake`: Step 4a | No | High |
+| Lack of error handling for `mv` | `project-intake`: Step 1 | No | Medium |
+| Insufficient `.gitignore` augmentation | `project-intake`: Step 2 | No | Medium |
+| `gh repo create` fails for other reasons | `project-intake`: Step 2 | No | Medium |
+| Secrets detection heuristics limited | `project-intake`: Step 0 | No | High (Security) |
+
+### Verdict
+
+**CONCERNS**: Several critical robustness and potential correctness issues have been identified, particularly around error handling for external commands, assumptions about user input, and interactions with Git/GitHub. The demo transcript primarily covers the happy path, leaving significant gaps in testing for these edge cases. Failure in these areas could lead to incorrect repo setup, data exposure, or agent workflow failures requiring manual intervention.
+## Source: KIT-0066-code-review-input--code-reviewer.md
+
+#  Code Reviewer
+
+**Source**: .adversarial/inputs/KIT-0066-code-review-input.md
+**Evaluator**: code-reviewer
+**Model**: o3
+**Generated**: 2026-07-24 12:01 UTC
+
+---
+
+### Summary
+Reviewed the new `project-intake` flow (agent spec, template, docs).  The change is prose-heavy but it drives real shell commands, so small wording slips become runtime faults.  I found 8 distinct edge-case/logic risks (2 high-severity correctness bugs, 4 latent robustness issues, 2 test gaps).
+
+### Findings
+
+**[CORRECTNESS]: Wrong `--target-path` is recorded when code folder is nested**
+- **Location**: `.claude/agents/project-intake.md` – Step 3 (`--target-path ../<name>`)
+- **Edge case**: User keeps prototype in `~/work/prototypes/alpha/snip-stash/` and asks to create the planning repo in the *same* directory (`snip-stash-planning`).  Relative `../<name>` now points to `../snip-stash` *one level above* the real code repo.
+- **What happens**: Door happily records the wrong pointer in `CLAUDE.md`; all later slash-commands (`/wrap-up`, `prepare-review-input.sh`, etc.) act on a non-existent repo, silently corrupting the workflow.
+- **Expected**: Pass the *absolute* code path (`$CODE_PATH`) or compute the relative path *after* `cd $PARENT/$NAME-planning` – e.g. `--target-path ../$NAME` only if the repos truly are siblings.
+- **Test coverage**: NOT covered – demo transcript only shows the simplest sibling layout.
+- **Severity**: Bug (breaks now).
+
+---
+
+**[CORRECTNESS]: Duplicate/long “slug” filenames break backlog seeding**
+- **Location**: Step 4b (task file creation rule)
+- **Edge case**: Two “next steps” both titled “Add logging”.  Naïve slugging makes
+  `SNIP-0001-add-logging.md` and silently overwrites it with `SNIP-0002-add-logging.md`, losing one task.
+  On Windows the 260-char path limit will be exceeded for very long titles.
+- **What happens**: Missing backlog tasks or OS error → agent stops on `cp`/`touch` failure.
+- **Expected**: De-duplicate slugs (append a counter) and truncate to a safe length (<100 chars).
+- **Test coverage**: NOT covered.
+- **Severity**: Bug (data loss under common conditions).
+
+---
+
+**[ROBUSTNESS]: `.gitignore` seeding can stage secrets on first commit**
+- **Location**: Step 2.2/2.3
+- **Edge case**: Prototype already contains an `.env` with real keys (very common).
+  Flow seeds `.gitignore`, *then* `git add -A` – staging `.env` **before** the ignore rule takes effect (git only respects ignores that existed *before* the add).
+- **What happens**: Real credentials are committed and pushed.
+- **Expected**: Add `.env` to `.gitignore`, then run `git rm --cached .env` (if present) *before* the first commit.
+- **Test coverage**: NOT covered.
+- **Severity**: Latent security risk.
+
+---
+
+**[ROBUSTNESS]: Interactive questions hang in unattended runs**
+- **Location**: Step 0 (ask for next step) & Step 2.4 (visibility)
+- **Edge case**: Operator runs the agent in a non-TTY CI job (or sets `ADVERSARIAL_UNATTENDED=1` as in evaluator gates).
+- **What happens**: `AskUserQuestion` blocks forever; pipeline times out.
+- **Expected**: Respect `$CI`/`ADVERSARIAL_UNATTENDED` or expose `--yes --visibility private` flags so the run is non-interactive.
+- **Test coverage**: NOT covered.
+- **Severity**: Latent.
+
+---
+
+**[ROBUSTNESS]: Commit may fail with “nothing to commit”**
+- **Location**: Step 2.3 – unconditional `git add -A && git commit -m …`
+- **Edge case**: Folder was already a git repo and *already committed*; the working tree is clean.
+- **What happens**: `git commit` exits 1 (“nothing to commit”) → agent aborts the whole flow.
+- **Expected**: Check `git status --porcelain` and skip the commit when clean.
+- **Test coverage**: NOT covered.
+- **Severity**: Latent.
+
+---
+
+**[ROBUSTNESS]: Git user identity missing causes door to fail after seeding**
+- **Location**: Step 3 – planning repo commit 4c
+- **Edge case**: Fresh machine without global `user.name` / `user.email`.
+- **What happens**: Door succeeds (it doesn’t commit), but later `git commit -m …` in planning repo fails; flow stops mid-way.
+- **Expected**: Detect and set temp identity (`git -C $PLAN config user.name "Project Intake"` …) or surface a clear message *before* Step 3.
+- **Severity**: Latent.
+
+---
+
+**[TESTING]: Doctor-tail capture not asserted**
+- **Location**: Step 3 interface contract
+- **Gap**: Demo transcript shows doctor tail *printed*, but no automated check asserts that the captured tail is the last ~15 lines (contract says “tail”).  A future door change that moves the verdict higher will silently truncate it.
+- **Severity**: Gap.
+
+---
+
+**[INTERACTION]: Relative path recording breaks if user later moves the pair**
+- **Location**: Throughout – design choice to store `../<name>` in `CLAUDE.md`
+- **Edge case**: After creation operator moves both repos into a deeper folder (`~/work/2026/`).  The relative pointer in `CLAUDE.md` is now wrong; commands fail until manually edited (easy to forget).
+- **Expected**: Store an *absolute* path plus a comment recommending manual update if moved, or at least warn during the move (doctor check).
+- **Severity**: Latent usability hazard.
+
+### Edge Cases Verified Clean
+• Existing remote ⇒ flow skips `gh repo create` (spec covers).
+• Door exit 2 (“target exists”) ⇒ user prompt, never deletes automatically.
+• Brief with real vs code-reported language mismatch ⇒ trust code, record rule.
+• Preset absent ⇒ `--no-preset` path demonstrated.
+• Kit never installed in code repo – enforced by spec and demo.
+
+### Test Gap Summary
+
+| Edge Case | Function/Step | Tested? | Risk |
+|-----------|---------------|---------|------|
+| Nested code path (`--target-path`) | Step 3 | ❌ | High |
+| Duplicate next-step titles | Step 4b | ❌ | High |
+| `.env` already present | Step 2 | ❌ | Med-High |
+| Non-interactive run | Steps 0, 2 | ❌ | Med |
+| Clean repo already committed | Step 2 | ❌ | Med |
+| Missing git identity | Step 4c | ❌ | Med |
+| Doctor tail length change | Step 3 | ❌ | Low |
+
+### Verdict
+
+**FAIL**
+
+Two correctness bugs (wrong target pointer, task-file overwrite) can corrupt the planning workflow or lose data on a perfectly common input.  Fix these and the listed robustness gaps before merge.
+## Source: KIT-0066-code-review-input--claude-code.md
+
+#  Claude Code
+
+**Source**: .adversarial/inputs/KIT-0066-code-review-input.md
+**Evaluator**: claude-code
+**Model**: anthropic/claude-sonnet-4-6
+**Generated**: 2026-07-24 12:03 UTC
+
+---
+
+## Phase 1: Understand Intent
+
+This diff introduces a **prototype graduation workflow** for an AI agent toolkit called "agentive-starter-kit." The deliverables are:
+
+1. `PROTOTYPE-HANDOFF-TEMPLATE.md` — a paste-able prompt template users copy into Claude/Cowork sessions to extract a structured brief
+2. `project-intake.md` — an AI agent definition (markdown instructions for Claude) that automates creation of a "split pair" (plain code repo + private planning repo)
+3. Supporting documentation updates (README, CROSS-REPO-PATTERN.md, task status files)
+
+**Critical paths**: The agent executes shell commands (`git`, `gh`, `./scripts/local/bootstrap`) against user-supplied paths and processes user-supplied content (the handoff brief). The template solicits sensitive metadata from AI sessions. No application code (Python, JS, etc.) is introduced — this is entirely an agent/documentation artifact.
+
+---
+
+## Phase 2: Security Analysis
+
+### [HIGH]: Path Traversal / Arbitrary Directory Targeting via User-Supplied Paths
+
+- **Location**: `project-intake.md` — Steps 1, 2, 3 (all `git -C <code-path>` and `--new <parent>/<name>-planning` invocations)
+- **Issue**: The agent constructs shell commands using user-supplied values (`<code-path>`, `<parent>`, `<name>`) with no explicit validation or sanitization guidance. A project name like `../../sensitive-dir` or a code folder path pointing to `/etc` would be passed directly to `git -C` and `gh repo create`. The agent instructions say "infer what you can" and default the name to the brief's project name or folder basename — both user-controlled. For example: `git -C /etc init` or `--new ../../some-other-repo` are structurally reachable.
+- **Remediation**: Add an explicit validation step before Step 2: require `<name>` to match `^[a-z][a-z0-9-]{0,99}$` (kebab-case only, no path separators); require `<code-path>` to be an absolute path that exists and is not a system directory; validate that `<parent>/<name>-planning` does not escape the intended parent. Add this to the "Inputs" and "Step 0" sections as named checks the agent must perform.
+
+---
+
+### [HIGH]: Credential Scanning — Reactive Only, No Proactive Scan Instruction
+
+- **Location**: `project-intake.md` — Step 0, Restrictions section; `PROTOTYPE-HANDOFF-TEMPLATE.md` — "Rules the brief must follow"
+- **Issue**: The agent's secrets discipline is **reactive**: "If you spot what looks like a real credential value in the brief or the code folder, stop and tell the user." The agent also commits `git -C <code-path> add -A` — a blanket add of all files in the prototype folder — before any scan. If `PROTOTYPE-BRIEF.md` or any prototype source file contains a credential (pasted API key, token, connection string) that the agent fails to recognize as a credential, it will be committed and potentially pushed to GitHub. Pattern recognition of credentials is imperfect for LLMs — this is a known failure mode.
+- **Remediation**: Add a mandatory pre-commit scan step using `git -C <code-path> diff --cached` piped through a tool like `truffleHog`, `gitleaks`, or at minimum `grep -rE '(sk-|ghp_|xoxb-|AKIA|eyJ)' <code-path>` before any `git commit`. Make this a named, non-optional step between "add -A" and the commit. The agent should also explicitly instruct users (in the template's rules) that `.env` files containing values must be confirmed absent before handoff.
+
+---
+
+### [MEDIUM]: `git add -A` Without Pre-Exclusion of Sensitive Files
+
+- **Location**: `project-intake.md` — Step 2, item 3
+- **Issue**: The agent seeds `.gitignore` with `.env` (and stack-specific patterns) in Step 2 item 2, but the `git add -A` in item 3 runs immediately afterward. If the prototype folder contains `.env`, `.env.local`, secrets files, or large binaries that are not yet matched by the just-seeded `.gitignore` (e.g., due to gitignore caching, or files with non-standard names like `secrets.json`, `credentials.yaml`), they will be staged. The instruction "at minimum `.env`" is not exhaustive.
+- **Remediation**: After seeding `.gitignore` and before `add -A`, run `git -C <code-path> check-ignore -v .env` to verify the ignore is active. Expand the mandatory ignore list to include `*.key`, `*.pem`, `*credentials*`, `*secrets*`, `.env.*`. Explicitly mention these in the agent step.
+
+---
+
+### [MEDIUM]: Absolute Path of Operator's Config Exposed in Demo Transcript
+
+- **Location**: `.kit/context/KIT-0066-DEMO-TRANSCRIPT.md` — "Preset-resolved run" section
+- **Issue**: The demo transcript hardcodes `/Users/broadcaster_three/Github/agentive-config/preset` — a real, operator-specific absolute path identifying the operator's username and filesystem layout. This is committed into the repository and will appear in git history permanently. While this is a local path rather than a credential, it leaks PII (username) and filesystem structure. The handoff file also contains `/Users/broadcaster_three/Github/ask-worktrees/KIT-0066/`.
+- **Remediation**: Replace operator-specific absolute paths in committed artifacts with anonymized placeholders (e.g., `~/Github/agentive-config/preset` or `/Users/<operator>/Github/agentive-config/preset`). Apply to both the demo transcript and the handoff file before merge. Add a pre-commit note to the demo transcript template warning authors to redact personal paths.
+
+---
+
+### [MEDIUM]: `gh repo create` Command Injection via Project Name
+
+- **Location**: `project-intake.md` — Step 2, item 5
+- **Issue**: The agent constructs: `gh repo create <owner>/<name> --private --source <code-path> --push`. If `<name>` contains shell metacharacters (spaces, semicolons, backticks, `$(...)`) the `Bash` tool invocation could be exploited. While the agent is instructed to derive `<name>` from the brief or folder basename, the brief is user-supplied markdown and the folder path is user-supplied — no sanitization requirement is stated.
+- **Remediation**: The validation fix from the first finding (enforcing `^[a-z][a-z0-9-]{0,99}$`) would also mitigate this. Additionally, the agent should use the `gh` CLI's own validation (`gh repo create` will reject invalid names) as a secondary gate, but rely on name validation first.
+
+---
+
+### [LOW]: Bootstrap Script Invoked With Relative `--target-path`; No Validation of Sibling Layout
+
+- **Location**: `project-intake.md` — Step 3
+- **Issue**: The bootstrap command uses `--target-path ../<name>` — a relative path. If the planning repo is not created as a sibling of the code repo (e.g., if the user places it elsewhere), this relative path will resolve incorrectly and be silently recorded in CLAUDE.md as the wrong pointer. The agent confirms sibling layout in Step 1 but does not re-validate it when constructing the flag.
+- **Remediation**: After Step 1 confirms the sibling layout, explicitly assert that `<parent>/<name>-planning/../<name>` resolves to the code folder before invoking the door. Print both resolved absolute paths for the user to confirm before executing.
+
+---
+
+### [LOW]: No Secret-Value Pattern Guidance in Template Prompt
+
+- **Location**: `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` — "Dependencies and required secrets" section
+- **Issue**: The template instructs the prototyping agent to include "the NAMES of any required secrets or API keys (e.g. OPENAI_API_KEY). Secret NAMES ONLY — never paste values." However, this instruction is in the outer template instructions, not in the paste-able block itself. A user who only copies the inner fenced block (the paste-able prompt) will send a prompt to the prototyping agent that includes the instruction, but the receiving AI agent (in the prototyping session) may not be reliably constrained from including values if the conversation context contains them.
+- **Remediation**: Move the "Secret NAMES ONLY — never paste values, tokens, or any part of them" instruction explicitly into the paste-able block, within the "Dependencies and required secrets" section description. Example: add `(NAMES ONLY — if you see a value in our conversation, do NOT include it here)` inline in that section's instruction text.
+
+---
+
+### [LOW]: Demo Transcript Uses `/tmp` Without Noting OS-Specific Persistence Risk
+
+- **Location**: `.kit/context/KIT-0066-DEMO-TRANSCRIPT.md` — "Demo root" and "Cleanup" sections
+- **Issue**: The demo creates repositories under `/tmp/kit0066-intake-demo/` and notes "no `rm -rf` allowlist exists — leftovers listed at the end." On macOS (which the transcript implies, given `/private/tmp/`), `/tmp` survives reboots within a session and is world-readable for the directory listing. If the demo `.env` seeded by `env-source` was not deleted promptly, another local user could read it. The transcript says "The seeded `.env` was deleted from the demo dir immediately after capture" — but this is manual and relies on discipline.
+- **Remediation**: Note in the demo template and the agent's edge-cases section that demo directories under `/tmp` should use `chmod 700` or use `mktemp -d` and delete immediately after the run. Alternatively, mandate that demo runs occur under `~/` in a private directory.
+
+---
+
+## Phase 3: Correctness Analysis
+
+### [MEDIUM]: Step Ordering — `.gitignore` Written After Potential File Scan
+
+- **Location**: `project-intake.md` — Step 0 ("If you spot what looks like a real credential value in the brief **or the code folder**") and Step 2 items 2-3
+- **Issue**: Step 0 asks the agent to skim the code folder for credentials, but Step 2 item 2 seeds the `.gitignore`. The code folder scan (Step 0) happens before `.gitignore` exists, which is actually correct ordering — but the agent's credential check in Step 0 is described as "spot what looks like a real credential value" during a "skim," not a systematic scan. The brief parse and folder skim happen in the same step. If the skim misses a credential, it flows directly to `add -A` with no second gate.
+- **Remediation**: Make the credential check a separate named sub-step with explicit patterns, not a byproduct of the initial skim. See HIGH finding above.
+
+---
+
+### [MEDIUM]: Line Anchor References Will Rot
+
+- **Location**: `project-intake.md` — Step 3 (`scripts/local/bootstrap:385-386`, `kit_markers.py:173-202`, `kit_markers.py:187`); handoff file (`bootstrap:385-386, 397-398`)
+- **Issue**: The agent's instructions hard-reference specific line numbers in `scripts/local/bootstrap` and `scripts/local/kit_markers.py` with the caveat "as of 2026-07-24." These will silently become incorrect as the scripts evolve, causing agents following the instructions to mis-explain or mis-locate behavior. The handoff explicitly warns "re-verify before coding" but the shipped agent file does not carry this warning to future users.
+- **Remediation**: Either (a) remove line-number anchors from the agent file and replace with behavior descriptions + function/variable names that are more stable, or (b) add a prominent "**Line anchors are dated 2026-07-24 — verify against current file before relying on them**" note at the top of Steps 3 and 4a. The task spec already accepts this risk via the evaluation disposition; the agent file itself should surface it.
+
+---
+
+### [LOW]: Missing Idempotency Guard for Existing Git Repo With Uncommitted Changes
+
+- **Location**: `project-intake.md` — Step 2, item 1-3
+- **Issue**: The procedure handles "already a git repo — keep its history." However, if the existing repo has uncommitted changes (dirty working tree), `git add -A && commit` will commit those changes alongside the prototype import. This may include work-in-progress files or editor artifacts the user did not intend to commit. The agent note "this is a fresh export, not a working tree with unrelated changes" may not hold if the user ran the intake on an actively-edited folder.
+- **Remediation**: Before `git add -A`, run `git -C <code-path> status --short` and present it to the user. If the repo is dirty, ask explicitly: "The folder has uncommitted changes — commit all of them as the initial import, or stop so you can review first?"
+
+---
+
+### [LOW]: `agent-handoffs.json` — `task_started: null` for "In Progress" Task
+
+- **Location**: `.kit/context/agent-handoffs.json`
+- **Issue**: Both `planner` and `feature-developer` entries show `"status": "handoff_ready"` and `"task_started": null` while the task is `In Progress`. This is a data-correctness issue in the coordination state — the timestamp was never set when the task moved from todo to in-progress.
+- **Remediation**: Set `task_started` to the actual start date (`"2026-07-24"` or an ISO datetime) when transitioning to in-progress. If this field is machine-managed, the transition script has a bug that should be filed.
+
+---
+
+## Phase 4: Code Quality
+
+### [LOW]: Agent File Contains No Version-Skew Guard for Bootstrap Flags
+
+- **Location**: `project-intake.md` — Step 3
+- **Issue**: The agent says "Do NOT pass `--name` or `--prefix`: the door refuses them for the planning shape (`scripts/local/bootstrap:385-386`, as of 2026-07-24)." If bootstrap is updated to accept these flags (or new flags are added), the agent's prohibition becomes incorrect guidance. There is no runtime verification step.
+- **Remediation**: Add a Step 3 pre-check: run `./scripts/local/bootstrap --help 2>&1 | grep -E '(name|prefix)'` and note whether the flags appear; if they do, stop and inform the user the agent's guidance may be outdated before proceeding.
+
+---
+
+### [LOW]: Template's Inner Paste-able Block Loses Outer Context Rules
+
+- **Location**: `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md`
+- **Issue**: The outer document has three rules ("Secrets by name only," "Self-contained," "Next steps seed the backlog"). These are for the *user's* benefit, not the prototyping agent. A user who pastes only the inner fenced block may follow these rules themselves but the prototyping agent receiving the prompt is not given them. The inner prompt is clean and well-written, but the "next steps seed the backlog" rule — which shapes how specific the steps should be — is particularly important for the prototyping agent to internalize.
+- **Remediation**: Embed the specificity guidance directly in the "Suggested next steps" section of the inner prompt. Already partially done ("write them specific enough that someone could start work from the entry alone") — this is adequate; the outer rules are for the human operator. This is a low-concern observation, not a defect.
+
+---
+
+### Positive Observations
+
+1. **Explicit secrets discipline throughout**: "never print, stage, or commit secret values — names only" appears in the Restrictions, Step 0, the template's rules, and the demo transcript. The `.env` mode-0600 handling and non-printing of env-source contents are specifically called out.
+2. **Clear door exit contract**: using exit codes 0/1/2 as the interface and explicitly prohibiting re-derivation of install state is a sound design. Relaying the doctor tail verbatim prevents information loss.
+3. **No-kit-in-code-repo enforcement**: the restriction is stated in four places (Restrictions, Step 2.6, "Why the split pair," and docs), with rationale. Hard to miss.
+4. **Non-TTY safety by design**: flags-only bootstrap invocation ensures the agent never hangs on an interactive prompt. Good operational discipline.
+5. **Sibling layout convention**: the explicit parent-directory layout with a concrete ASCII tree reduces ambiguity for both agents and humans.
+6. **Task-seeding scope boundary**: "transcription only — no elaboration, no re-prioritization, no decomposition" is a well-defined and correctly conservative constraint.
+7. **Anti-self-delegation pattern**: the "never delegate via the Task tool" restriction is explicit and the reason is given.
+8. **Demo transcript covers both stranger and preset paths**: two door runs (with and without preset) provide meaningful coverage evidence.
+
+---
+
+## Context Required / Unverifiable
+
+- The `Bash` tool's execution environment (sandboxing, allowed paths, user permissions) is not visible — the injection and path traversal findings assume the tool executes shell commands without additional OS-level sandboxing.
+- Whether `./scripts/local/bootstrap` performs its own input validation on `--new`, `--target-path`, and `--target-github` cannot be confirmed from this diff — the bootstrap script is referenced but not shown.
+- Whether Claude Code's `Bash` tool shells expand metacharacters or passes arguments as arrays cannot be confirmed — this affects severity of the command injection finding.
+- The `gh` CLI's own input validation for `gh repo create` argument handling cannot be confirmed from this diff.
+- The operator preset file's contents and security posture (private git repo, permissions) are not shown.
+- Whether `/tmp` on the operator's macOS is actually world-accessible cannot be confirmed from this diff alone.
+
+*None of the above affect the verdict.*
+
+---
+
+## Overall Assessment
+
+**CHANGES_REQUESTED**
+
+The diff introduces a well-structured, clearly reasoned workflow with good documentation discipline and explicit security principles in the right places. However, two high-severity gaps exist that must be addressed before production use:
+
+1. **No input validation on user-supplied paths and project names** before they are passed to shell commands. A malicious or malformed brief/path can reach `git -C`, `gh repo create`, and `./scripts/local/bootstrap` without sanitization.
+2. **`git add -A` executes before any systematic credential scan**. The reactive "spot if you see something" guidance is insufficient — if the prototype folder contains an unrecognized credential format, it will be committed and potentially pushed to GitHub under the operator's account.
+
+The operator-path exposure (absolute paths in committed artifacts) and missing idempotency guards are lower priority but should be addressed in this PR given they are straightforward fixes. The line-anchor rot issue is documented risk; adding a visible warning to the agent file is a one-line fix.

--- a/.kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md
+++ b/.kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md
@@ -1,6 +1,6 @@
 # KIT-0066: Prototype intake — Cowork conversation to planner-ready split pair
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 4-5 hours

--- a/.kit/tasks/4-in-review/KIT-0066-prototype-intake-flow.md
+++ b/.kit/tasks/4-in-review/KIT-0066-prototype-intake-flow.md
@@ -1,6 +1,6 @@
 # KIT-0066: Prototype intake — Cowork conversation to planner-ready split pair
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 4-5 hours

--- a/.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md
+++ b/.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md
@@ -1,0 +1,99 @@
+# Prototype Handoff Template
+
+**Version**: 1.0.0
+**Created**: 2026-07-24 (KIT-0066)
+**Purpose**: Paste-able boilerplate for graduating a prototype out of a
+prototyping conversation (Cowork or any Claude session) into structured
+development.
+**Consumed by**: the `project-intake` agent
+(`.claude/agents/project-intake.md`), which turns the resulting brief +
+the prototype code folder into the split pair — a plain code repo and a
+preset-configured planning repo (`docs/CROSS-REPO-PATTERN.md`).
+
+---
+
+## How to use it
+
+1. Near the end of a prototyping conversation, paste the fenced block
+   below as a message to the prototyping agent.
+2. Save the brief it returns as `PROTOTYPE-BRIEF.md` — inside the
+   prototype code folder is the convention the intake agent looks for
+   first, but any saved location works.
+3. Open a new tab from your agentive-starter-kit checkout, invoke the
+   `project-intake` agent, and give it the brief path, the code folder
+   path, and (optionally) the project name. It does the rest.
+
+The section list below mirrors what the kit's bootstrap agent extracts
+from design materials (`.claude/agents/bootstrap.md`, Step 1), plus the
+knowledge that only exists in a prototyping conversation: decisions and
+their reasons, what is solid versus rough, known issues, dependencies
+and secret NAMES, and concrete next steps. A good brief lets a fresh
+agent act without ever seeing the original conversation.
+
+---
+
+## The paste-able block
+
+````markdown
+Please write a structured handoff brief for this prototype. It will be
+read by a fresh agent that has NOT seen this conversation, so make it
+self-contained. Return it as a single markdown document with exactly
+these sections:
+
+## Project name and purpose
+The working name and 1-2 sentences on what this tool does and for whom.
+
+## Languages and runtimes
+Programming languages, runtime versions, and frameworks actually used.
+
+## Architecture and key components
+The 3-7 main parts (modules, services, data models, APIs) and how they
+fit together. One line each is enough.
+
+## Domain vocabulary
+The domain terms we settled on in this conversation, with one-line
+definitions — the words a new agent must use for naming to stay
+consistent.
+
+## Suggested task prefix
+A short uppercase task-ID prefix derived from the project name — no
+hyphens, max 6 characters (e.g. "recipe-api" → RECIPE, "my-cool-app"
+→ MCA). Tasks will be numbered PREFIX-0001, PREFIX-0002, …
+
+## Decisions made and why
+Every significant choice we made (library picks, data shapes, approaches
+tried and abandoned) with a one-line reason each. This is the section a
+future agent cannot reconstruct from the code — be generous.
+
+## State: solid vs rough
+Two lists. Solid: what works and has been exercised. Rough: what is
+stubbed, hardcoded, untested, or known-fragile.
+
+## Known issues
+Bugs, limitations, and edge cases we observed, one line each.
+
+## Dependencies and required secrets
+External packages/services the prototype needs, and the NAMES of any
+required secrets or API keys (e.g. OPENAI_API_KEY). Secret NAMES ONLY —
+never paste values, tokens, or any part of them into this brief.
+
+## Suggested next steps
+3-8 concrete steps to take this beyond prototype, in dependency order
+(foundational first). Each entry needs: a short actionable title, 1-2
+sentences of what and why, and a "done when" line. Each entry will be
+transcribed directly into a backlog task, so write them specific enough
+that someone could start work from the entry alone.
+````
+
+---
+
+## Rules the brief must follow
+
+- **Secrets by name only.** The brief names required keys
+  (`OPENAI_API_KEY`), never their values. If a value was pasted into
+  the prototyping conversation, it does NOT belong in the brief.
+- **Self-contained.** No "as discussed above" — the reader has not seen
+  the conversation.
+- **Next steps seed the backlog.** The intake agent transcribes them
+  into task stubs verbatim (no elaboration), so vague entries become
+  vague tasks.

--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ Bootstrap an existing project with the implementation tools — agents, scripts,
 
 Use this when you want agentive coding help in an existing repo. Add `--no-kit` to skip the task-management workflow entirely. Run `./scripts/local/bootstrap --help` for the full shape × profile matrix.
 
+Graduating a prototype from a Cowork conversation? Paste `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` into the conversation, then hand the brief + code folder to the `project-intake` agent — it composes the door into the split pair (plain code repo + preset-configured planning repo) in one invocation (see `docs/CROSS-REPO-PATTERN.md`).
+
 ### Operator Preset (One-Button Setup)
 
 The door resolves every question as **CLI flag > preset > kit default > interactive prompt**. A preset file at `<kit-parent>/agentive-config/preset` — a visible sibling of your kit checkout (KIT-0058; `AGENTIVE_KIT_CONFIG_DIR` overrides the location) — pre-answers exactly the door's questions with flat `key: value` lines (`shape`, `profile`, `bots`, `evaluators`, `venv`, `env-source`, and the planning-shape target pointer), so a fully filled preset makes `bootstrap --new <dir>` a genuine one-command project:

--- a/docs/CROSS-REPO-PATTERN.md
+++ b/docs/CROSS-REPO-PATTERN.md
@@ -110,6 +110,23 @@ From the agentive-starter-kit directory:
 # codebase at <path>
 ```
 
+**Graduating a prototype?** (Cowork conversation → split pair, KIT-0066)
+The template → agent → pair recipe composes the door run above:
+
+1. **Template**: paste the fenced block from
+   `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` into the prototyping
+   conversation; save the structured brief it returns (convention:
+   `PROTOTYPE-BRIEF.md` in the code folder).
+2. **Agent**: invoke the `project-intake` agent
+   (`.claude/agents/project-intake.md`) in a new tab from your kit
+   checkout, giving it the brief path, the code folder, and the
+   project name.
+3. **Pair**: the agent creates the code repo (git + GitHub, no kit
+   install), runs the door for the planning repo (the operator preset
+   answers shape/bots/evaluators/env), fills the planning repo's
+   project-context regions from the brief, and seeds `1-backlog/`
+   from the brief's next steps — planner-ready in one invocation.
+
 ### 2. Ensure sibling directory layout
 
 Both repos must be siblings on disk:


### PR DESCRIPTION
## Summary

- **`.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md`** — paste-able block for prototyping conversations (Cowork). Sections mirror the bootstrap agent's Step-1 extraction list (purpose, languages, architecture, vocabulary, task prefix + derivation rule) plus the prototype-only knowledge: decisions-and-why, solid vs rough, known issues, dependencies + secret NAMES ONLY, and next steps written to seed backlog tasks.
- **`.claude/agents/project-intake.md`** — turns brief + code folder into the operator's split pair in one invocation: plain code repo (git + GitHub, visibility question defaulting private, **no kit install** — rationale cited from `docs/CROSS-REPO-PATTERN.md`) and a preset-configured planning repo via one door run. The door's 0/1/2 exit contract is the programmed interface; the doctor verdict is relayed verbatim, never re-derived. Prefix lands in the KIT-LOCAL project-context regions (anchored: `engine-consumer.sh:592`, `kit_markers.py:187`, `bootstrap:385-386`). Backlog seeding is stubs-only transcription (accepted evaluation boundary).
- **Docs**: CROSS-REPO-PATTERN gains the template → agent → pair recipe; README one-liner under the setup-door section; create-project pointer.
- **Zero changes to `scripts/local/bootstrap`** (F4) — the flow composes door runs.

## Demo (transcript: `.kit/context/KIT-0066-DEMO-TRANSCRIPT.md`)

End-to-end run against a scratch prototype (`snip-stash`): brief per the template → code repo (kit-free) → **two door runs, both exit 0 with doctor verdict relayed** — one stranger-path (`--no-preset`, flags only, non-TTY) and one preset-resolved as the operator-path proof (shape/bots/env-source from the live preset, contents never printed) → all four seeded agents' project-context regions filled (prefix SNIP), 3 backlog stubs transcribed 1:1. `gh repo create` skipped in the demo (no external side effects). Demo dirs under `/tmp/kit0066-intake-demo/` — `rm -rf` denied (no allowlist), operator sweep needed; the preset-seeded `.env` was deleted in-run.

## Evaluator trio (pre-PR, per ordering rule)

fast CONCERNS / o3 FAIL / claude-code CHANGES_REQUESTED — all findings dispositioned in `.kit/context/reviews/KIT-0066-evaluator-review.md`; accepted ones fixed in `7aeb79f` (input validation, mandatory secret scan before first commit, gitignore hardening, sibling assertion, slug dedup, marker-missing stop rule, anchor-rot notice). Declined items carry reasoning; one claude-code claim refuted (the NAMES-ONLY rule is inside the paste-able block); one o3 ordering claim was wrong (ignore-then-add was already the order).

## Pre-existing issue observed (not from this PR)

The consumer scaffold ships `.claude/projects/-Users-broadcaster-three-Github-agentive-starter-kit/memory/feedback_evaluator_script_flow.md` — a session-memory file tracked since ASK-0044 (`2974e27`, PR #41). Follow-up candidate: `git rm` + ignore.

## Test plan

- [x] Full suite green locally (796 passed, 1 skipped) + `ci-check.sh` all green
- [x] Demo run end-to-end (both door paths, exit 0)
- [x] Evaluator trio run pre-PR, findings dispositioned
- [ ] CI green on GitHub
- [ ] Bot reviews triaged

Task spec: `.kit/tasks/3-in-progress/KIT-0066-prototype-intake-flow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnLxAokb3raru5Hmfnfkrd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The new agent instructs real `git`, `gh`, and bootstrap runs from user-supplied paths; hardening (validation, secret scans) reduces but does not eliminate mis-execution or credential leakage if the agent skips steps. No runtime code changes—risk is operational and documentation-driven.
> 
> **Overview**
> Introduces **prototype graduation** (KIT-0066): a paste-able **`.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md`** for prototyping chats and a new **`.claude/agents/project-intake.md`** that turns a brief plus code folder into the **split pair** in one run — plain code repo (git/GitHub, **no kit**) and sibling **planning repo** via a single flags-only **`./scripts/local/bootstrap --new … --shape planning`** invocation (exit 0/1/2 + doctor tail as the contract), then seeds KIT-LOCAL **project-context** in four agents and **backlog stubs** from next steps.
> 
> **`create-project.md`** now points split-pair users at **`project-intake`**. **`README.md`** and **`docs/CROSS-REPO-PATTERN.md`** document the template → agent → pair recipe. Task **KIT-0066** moves to **In Review**; handoff links and **`.kit/context/`** artifacts (demo transcript, evaluator disposition, review starter, retro) ship with the PR. **`scripts/local/bootstrap` is unchanged** (composition only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9181c894dcb927316f57c2f51c25ef77d364785e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->