### PR TITLE
feat(KIT-0067): factory front door — STARTING-A-PROJECT, /new-project, seeded self-direction (PR 1/2)

### DIFF
--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -51,9 +51,10 @@ kit clone — never hunt for the door elsewhere.
    its help output) and let the preset answer the rest.
 
 4. **Secrets never transit the chat.** If the user pastes anything
-   that looks like key material, REFUSE it. Secrets reach a new
-   project only by reference, through the preset's secrets-file key
-   (authored via `/setup-preset`, edited in the user's own editor).
+   that looks like key material (API keys, tokens, passwords),
+   REFUSE it. Secrets reach a new project only by reference, through
+   the preset's secrets-file key (authored via `/setup-preset`,
+   edited in the user's own editor).
 
 ## Step 1: route the flow
 
@@ -77,6 +78,10 @@ The intake agent needs two inputs; collect what's missing:
    into the conversation that built the prototype, save the filled
    result as a markdown file, and come back.
 2. **The code folder.** The path to the prototype's code.
+
+Verify both paths actually exist (a quick `ls`) before handing off —
+a dangling path should be caught here, not by the intake agent one
+tab later.
 
 Then hand off — agents run in a **new tab**, never in this session.
 Print the invocation for the user:

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -79,9 +79,9 @@ The intake agent needs two inputs; collect what's missing:
    result as a markdown file, and come back.
 2. **The code folder.** The path to the prototype's code.
 
-Verify both paths actually exist (a quick `ls`) before handing off —
-a dangling path should be caught here, not by the intake agent one
-tab later.
+Before handing off, confirm the brief is a readable, non-empty file
+and the code path is a directory — a dangling or wrong-kind path
+should be caught here, not by the intake agent one tab later.
 
 Then hand off — agents run in a **new tab**, never in this session.
 Print the invocation for the user:

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -1,0 +1,128 @@
+---
+description: Interview the user and create their new project through the setup door or the intake agent
+version: 1.0.0
+origin: agentive-starter-kit
+last-updated: 2026-07-28
+created-by: "@movito with feature-developer-f5 (KIT-0067)"
+---
+
+# New Project
+
+Create a new project from this kit — the front door to the factory
+flow described in `docs/STARTING-A-PROJECT.md`. Interview the user in
+plain language, one question at a time, route them to the right
+creation path, run it, and finish by printing the LAUNCH line for the
+created project.
+
+This command runs **from an agentive-starter-kit checkout** (the setup
+door is kit-side only). If `./scripts/local/bootstrap` does not exist
+in the current repo, STOP and tell the user to open a session in their
+kit clone — never hunt for the door elsewhere.
+
+## Binding rules — read before anything else
+
+1. **Derive, never hardcode.** Your FIRST action is:
+
+   ```bash
+   ./scripts/local/bootstrap --help
+   ```
+
+   Build the entire interview from what that prints: the creation
+   modes, the shape × profile legality matrix, the offer flags, and
+   the preset/resolution-chain semantics. This command deliberately
+   contains **no flag list or shape matrix of its own** — if it named
+   them, it would drift from the door (runtime-read, per ADR-0025).
+   If this file and the door's help ever appear to disagree, the help
+   output wins. If the help does not answer something the flow needs,
+   STOP and say so to the user — never guess or improvise an answer.
+
+2. **Public surfaces only.** You interact with the door exclusively
+   through its CLI flags, and with the `project-intake` agent
+   exclusively through its documented inputs (a handoff brief and a
+   code folder — see `.claude/agents/project-intake.md`). Never
+   re-implement, patch, or partially reproduce what either of them
+   does; you compose them.
+
+3. **Plain language, one question at a time.** Never dump options on
+   the user. For each question, explain what it decides and what each
+   choice costs or unlocks in ordinary words. Offer an **expert
+   shortcut** up front: a user who says "just use my preset/defaults"
+   skips the interview — pass only what the door cannot default (per
+   its help output) and let the preset answer the rest.
+
+4. **Secrets never transit the chat.** If the user pastes anything
+   that looks like key material, REFUSE it. Secrets reach a new
+   project only by reference, through the preset's secrets-file key
+   (authored via `/setup-preset`, edited in the user's own editor).
+
+## Step 1: route the flow
+
+Ask the routing question first, in plain words: **does a prototype
+already exist** (code from a Claude/Cowork conversation, or a folder
+of working code), or is this a fresh start?
+
+- **Prototype exists → the intake route (Step 2a).**
+- **Fresh start → the door route (Step 2b).** The door's help output
+  defines the available shapes; present them as plain-language
+  choices (roughly: a split planning+code pair for production work,
+  or a single repo for smaller things — but derive the actual set
+  from the help).
+
+## Step 2a: prototype route (project-intake)
+
+The intake agent needs two inputs; collect what's missing:
+
+1. **The handoff brief.** If the user doesn't have one yet, point
+   them at `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md`: paste it
+   into the conversation that built the prototype, save the filled
+   result as a markdown file, and come back.
+2. **The code folder.** The path to the prototype's code.
+
+Then hand off — agents run in a **new tab**, never in this session.
+Print the invocation for the user:
+
+```
+⚠️ LAUNCH
+Open a new tab in this kit checkout and invoke the project-intake
+agent with:
+  Brief: <path-to-brief.md>
+  Code:  <path-to-code-folder>
+```
+
+The intake agent runs the door itself and prints the final LAUNCH
+line for the planning repo when it finishes. Your job ends at this
+handoff — do not run the door yourself on this route.
+
+## Step 2b: fresh-start route (the door)
+
+1. Interview for what the door needs (rule 1: derived from
+   `--help`; rule 3: one question at a time). Typically that is the
+   target directory, the shape, and — where no preset or default
+   answers them — the door's offers. Tell the user when their preset
+   is answering questions for them (the door announces the preset
+   path it loaded; a `--no-preset` run is available if they want to
+   be asked everything).
+2. Run the door with exactly the flags the interview produced, e.g.:
+
+   ```bash
+   ./scripts/local/bootstrap --new <target-dir> <flags-from-interview>
+   ```
+
+3. Show the user the door's output — especially the doctor verdict it
+   ends with. If the door exits non-zero, report the failure honestly
+   and stop; do not retry with guessed flags.
+
+## Step 3: finish loudly
+
+End with the LAUNCH line for wherever work continues (the door route:
+the created project; on a planning shape, that's the planning repo):
+
+```
+⚠️ LAUNCH
+Open a new tab with working directory <absolute-path-to-created-project>
+```
+
+Then state the first-session instruction in one line: in that new
+tab, invoke the `planner` agent — it triages the backlog and
+recommends what to start (the project's seeded `CLAUDE.md` says the
+same thing).

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -86,7 +86,7 @@ should be caught here, not by the intake agent one tab later.
 Then hand off — agents run in a **new tab**, never in this session.
 Print the invocation for the user:
 
-```
+```text
 ⚠️ LAUNCH
 Open a new tab in this kit checkout and invoke the project-intake
 agent with:
@@ -122,12 +122,12 @@ handoff — do not run the door yourself on this route.
 End with the LAUNCH line for wherever work continues (the door route:
 the created project; on a planning shape, that's the planning repo):
 
-```
+```text
 ⚠️ LAUNCH
 Open a new tab with working directory <absolute-path-to-created-project>
 ```
 
-Then state the first-session instruction in one line: in that new
-tab, invoke the `planner` agent — it triages the backlog and
-recommends what to start (the project's seeded `CLAUDE.md` says the
-same thing).
+Then state the first-session instruction in one line: open that tab
+as a planner session (`claude --agent .claude/agents/planner.md`) —
+the planner triages the backlog and recommends what to start (the
+project's seeded `CLAUDE.md` says the same thing).

--- a/.kit/context/KIT-0067-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0067-HANDOFF-feature-developer.md
@@ -1,6 +1,6 @@
 # KIT-0067 Handoff — feature-developer
 
-**Task**: `.kit/tasks/2-todo/KIT-0067-factory-front-door-and-structural-cleanup.md`
+**Task**: `.kit/tasks/3-in-progress/KIT-0067-factory-front-door-and-structural-cleanup.md`
 **Target Codebase**: This repo — NOT a target repo (single-repo mode)
 **Prepared**: 2026-07-27 (planner-f5)
 **Estimated effort**: 1-1.5 days

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0067",
     "task_started": null,
     "brief_note": "KIT-0071 closed out 2026-07-27 (PR #96 merged 8e695bb; retro processed: displayed_commands_are_contracts pattern, WORKTREE-WORKFLOW bookkeeping+pull-verify section, KIT-0062 third-face evidence). CLOSEOUT INCIDENT self-caught: pull printed Updating-but-aborted on mirrored files -> stale-tree bookkeeping + old-helper worktree; recovered, rule codified (verify rev-parse HEAD==origin/main after every pull). KIT-0067 worktree is the FIRST with a real per-worktree venv (3.14). CHAIN FINAL LINK: KIT-0067 assigned. Then cut 0.9.0 (KIT-0047+0054+0059).",
-    "details_link": ".kit/tasks/2-todo/KIT-0067-factory-front-door-and-structural-cleanup.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0067-factory-front-door-and-structural-cleanup.md",
     "handoff_file": ".kit/context/KIT-0067-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0067",
     "task_started": null,
     "brief_note": "KIT-0067 ready: factory front door (STARTING-A-PROJECT + /new-project + seeded self-direction) + execute approved D1-D5 (retire launchers/onboarding, archive dead docs, prune serena, gate dispatch, adr fix). Jointly-owned files enumerated in handoff. Worktree: ../ask-worktrees/KIT-0067 (real venv, pull --ff-only first).",
-    "details_link": ".kit/tasks/2-todo/KIT-0067-factory-front-door-and-structural-cleanup.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0067-factory-front-door-and-structural-cleanup.md",
     "handoff_file": ".kit/context/KIT-0067-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/reviews/KIT-0067-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0067-evaluator-review.md
@@ -1,0 +1,55 @@
+# KIT-0067 — Evaluator Review Record
+
+Ordering rule honored (KIT-0035/0046): local tests green → trio →
+PR open. Mixed code+doc diff → normal trio ordering (NOT the
+prose-sweep exception). Runs used the standing robust pattern
+`echo y | ADVERSARIAL_UNATTENDED=1 adversarial …` from the worktree
+venv; `git status` verified clean after every run.
+
+## PR 1 — factory front door (F1 STARTING-A-PROJECT, F2 /new-project, F3 seeded self-direction)
+
+Input: `.adversarial/inputs/KIT-0067-code-review-input.md`
+(prepare-review-input.sh, `--format full`, diff vs main), regenerated
+per round.
+
+### Round 1 — code-reviewer-fast (gemini-2.5-flash): FAIL
+
+| Finding | Disposition |
+|---|---|
+| `first-session` region survives a `--no-kit` re-bootstrap while the planner is pruned | **REAL — fixed** (`366f5ac`/`be6663b`): region removed with the same active-prune symmetry as the agent `rm -f`; test pinned |
+| Ambiguous "key material" detection in /new-project | **Accepted minimally**: examples named (API keys, tokens, passwords) — same wording as the shipped /setup-preset |
+| No path validation on the prototype route | **Accepted**: readable non-empty brief file + directory code path checked before the intake handoff |
+| "Fragile `--help` parsing" | **DECLINED — premise error**, same family the task evaluation dispositioned: an agent-read command reads help prose the way a human does (ADR-0025 runtime-derivation; design validated in /setup-preset) |
+| Region content not updated on re-bootstrap | **DECLINED — documented contract**: append-if-absent / consumer-owned KIT-LOCAL semantics, identical to project-rules |
+
+### Round 2 — code-reviewer-fast: FAIL
+
+| Finding | Disposition |
+|---|---|
+| Unconditional removal deletes a CUSTOMIZED first-session body | **REAL — fixed** (`366f5ac`): removal only when body is byte-identical to the kit seed; customized bodies stay with a notice; test pinned |
+| Malformed BEGIN-without-END → awk deletes to EOF | **REAL — fixed** (`366f5ac`): body read via `kit_markers extract` (balanced-pair regex) first; malformed file fails loud before any awk runs; the evaluator's clean-verify round confirmed |
+| `ls` too superficial for path checks | **Accepted**: wording tightened (readable non-empty file / directory) |
+| Static links could rot later | **DECLINED — generic doc-rot**: all links verified against the tree at ship time; the retirement PR's grep sweep is the evidence |
+
+### Round 3 — full trio on the fixed diff
+
+- **code-reviewer-fast: CONCERNS** — residuals target pre-existing
+  engine semantics outside this diff (Target-Repository conflict
+  handling, general malformed-marker behavior). Fail-loud is the
+  designed behavior there (KIT-0050/0053 review lineage). No action.
+- **code-reviewer (o3): CONCERNS** — all latent/out-of-diff:
+  - CRLF checkouts defeat exact-line awk matching → removal silently
+    skips. Shared, pre-existing semantics of every region reader in
+    this engine (grep -qx, replace_region); engine-written files are
+    LF by construction. Declined as out-of-diff class.
+  - Stale `REGIONS_OUT` snapshot — reviewer concedes current flow
+    ordering is correct; future-proofing note only.
+  - Duplicate BEGIN markers — kit_markers dedups by design
+    (documented in find_regions docstring).
+  - Explicitly verified clean: correct removal, customized-body
+    preservation, normal seeding, malformed-pair fail-loud.
+- **claude-code (security): APPROVED** — no findings.
+
+Verdict-vocabulary note: the trio spans PASS/CONCERNS/FAIL and
+APPROVED/REJECT vocabularies — logs read and interpreted, not
+token-grepped.

--- a/.kit/tasks/3-in-progress/KIT-0067-factory-front-door-and-structural-cleanup.md
+++ b/.kit/tasks/3-in-progress/KIT-0067-factory-front-door-and-structural-cleanup.md
@@ -1,6 +1,6 @@
 # KIT-0067: The factory front door + structural cleanup
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: high
 **Assigned To**: unassigned
 **Estimated Effort**: 1-1.5 days

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Using agents to build software works better if you add a bit of structure. Anthr
 
 When we start a new project, we clone this repo and complete the onboarding. This gives us tests, tasks, documentation, and token-efficient tools, all in about ten minutes. You can tweak things as you wish, including how the agents work, and what models you use.
 
+**Starting a project?** Read **[docs/STARTING-A-PROJECT.md](docs/STARTING-A-PROJECT.md)** — the operator flow from a permanent kit clone to a planner-ready project, including the `/new-project` command and the prototype-graduation path.
+
 ----
 ## What's inside?
 
@@ -397,6 +399,7 @@ pytest tests/ --cov=your_project --cov-report=term-missing
 
 ## Documentation
 
+- **Starting a Project** (the operator flow): `docs/STARTING-A-PROJECT.md`
 - **Agentive Development Guide** (archived): `docs/archive/agentive-development/README.md`
 - **Agent Template**: `.kit/templates/AGENT-TEMPLATE.md`
 - **Task Template**: `.kit/tasks/9-reference/templates/task-template.md`

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -17,7 +17,7 @@ never build product code inside it. Every project you create is a
 **sibling folder** next to it — stamped out by the kit's one setup
 door (`scripts/local/bootstrap`) and then independent of the factory.
 
-```
+```text
 ~/Github/
 ├── agentive-starter-kit/    ← the factory: one permanent clone
 ├── agentive-config/         ← your operator preset (private, optional)
@@ -96,7 +96,7 @@ private planning repo that manages it (why this split: see
    clone and invoke the `project-intake` agent, giving it the brief
    and the code folder:
 
-   ```
+   ```text
    Use the project-intake agent. Brief: ~/Downloads/my-prototype-brief.md
    Code: ~/Downloads/my-prototype/
    ```
@@ -134,7 +134,7 @@ Kit tooling never asks you to `cd` around inside one long session.
 When a step finishes somewhere else — a project got created, a task
 got assigned — the tool prints a **LAUNCH block**:
 
-```
+```text
 ⚠️ LAUNCH
 Open a new tab with working directory /Users/you/Github/my-product-planning
 ```
@@ -152,9 +152,10 @@ make this work:
 
 ## Your first session in a new planning repo
 
-Open the tab the LAUNCH line named, then **invoke the `planner`
-agent** (in a new tab, per the convention above). The planner triages
-the backlog — in a graduated prototype it has the seeded tasks from
+Open the tab the LAUNCH line named **as a planner session** — start it
+with `claude --agent .claude/agents/planner.md`, or open the tab and
+ask for the planner agent by name. (That tab *is* the agent's tab; no
+further hop needed.) The planner triages the backlog — in a graduated prototype it has the seeded tasks from
 your brief; in a blank pair it helps you write the first tasks — and
 recommends what to start. The seeded `CLAUDE.md` in every new project
 carries this same first-session instruction, so an agent opening the

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -1,0 +1,188 @@
+# Starting a Project
+
+How to go from "I have an idea" (or a prototype) to a working,
+planner-ready project — using one permanent clone of this kit as your
+project factory.
+
+This guide is written for someone who has never seen the kit before.
+It covers the mental model, the three ways to create a project, and
+what to do in your first session.
+
+---
+
+## The factory model
+
+You clone **agentive-starter-kit once**, keep that clone forever, and
+never build product code inside it. Every project you create is a
+**sibling folder** next to it — stamped out by the kit's one setup
+door (`scripts/local/bootstrap`) and then independent of the factory.
+
+```
+~/Github/
+├── agentive-starter-kit/    ← the factory: one permanent clone
+├── agentive-config/         ← your operator preset (private, optional)
+├── my-product/              ← a code repo the factory created
+├── my-product-planning/     ← its planning repo (the split pair)
+└── my-notes/                ← a single-repo project
+```
+
+Three things follow from this model:
+
+- **The kit clone is where creation happens.** You open a Claude Code
+  session in `agentive-starter-kit/` to create projects (the
+  `/new-project` command, the `project-intake` agent, the setup door
+  itself). You do everything else in the created project's own folder.
+- **Projects never contain the factory.** A created project gets the
+  agents, scripts, and workflow it needs — not the kit's git history,
+  its internal tasks, or the door.
+- **Navigation is by tabs, not `cd`.** When a tool finishes creating
+  something, it prints where to go next; you open a new tab there
+  (see [Tab handoffs](#tab-handoffs-the-launch-convention) below).
+
+Set up the factory once:
+
+```bash
+cd ~/Github  # or wherever your projects live
+git clone https://github.com/movito/agentive-starter-kit.git
+```
+
+## The one setup door
+
+Every creation flow below ends up running the same script —
+`scripts/local/bootstrap`, "the door". It asks the install questions
+(or reads them from your preset), validates the answers, and runs the
+engines that write the project. You never need a second setup path,
+and this guide deliberately does not duplicate the door's option
+matrix — the authoritative, always-current reference is:
+
+```bash
+cd ~/Github/agentive-starter-kit && ./scripts/local/bootstrap --help
+```
+
+If anything here and that help output ever disagree, the help output
+wins.
+
+### The operator preset (answer the questions once)
+
+The door resolves every question as **CLI flag → preset → kit default
+→ interactive prompt**. A preset file at
+`<kit-parent>/agentive-config/preset` — a visible sibling of the kit
+clone — pre-answers the door's questions (project shape, review bots,
+evaluator install, secrets file, and so on), so with a filled preset,
+creating a project is genuinely one command with zero questions.
+
+Author yours conversationally: open a Claude Code session in the kit
+clone and run `/setup-preset`. It interviews you in plain language and
+writes the file. This is worth doing before your first real project —
+most of the door's questions then never come up again.
+
+---
+
+## Three ways to create a project
+
+### 1. Graduate a prototype (you already have code)
+
+You prototyped something in a Claude (Cowork) conversation, or you
+have a folder of working code, and now it deserves a real home. The
+result is the **split pair**: a plain, publishable code repo plus a
+private planning repo that manages it (why this split: see
+`docs/CROSS-REPO-PATTERN.md`).
+
+1. **Produce the handoff brief.** In the conversation that built the
+   prototype, paste the contents of
+   `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` and let it fill the
+   template in. Save the result as a markdown file.
+2. **Hand it to the intake agent.** Open a **new tab** in the kit
+   clone and invoke the `project-intake` agent, giving it the brief
+   and the code folder:
+
+   ```
+   Use the project-intake agent. Brief: ~/Downloads/my-prototype-brief.md
+   Code: ~/Downloads/my-prototype/
+   ```
+
+3. The agent composes the door into both repos (your preset supplies
+   the answers), seeds the planning repo's backlog from the brief, and
+   finishes by printing a LAUNCH line for the planning repo.
+
+### 2. Blank split pair (production default, no code yet)
+
+The same two-repo shape, started empty. Open a Claude Code session in
+the kit clone and run `/new-project` — it asks what you're making, in
+plain language, and drives the door for you.
+
+Direct door use (no interview) works too; see `--shape planning` and
+the target-pointer flags in `bootstrap --help`.
+
+### 3. Single repo (small tools, notes, experiments)
+
+Everything — planning and code — in one repo. This is the door's
+default shape. `/new-project` offers it, or run the door directly:
+
+```bash
+cd ~/Github/agentive-starter-kit && ./scripts/local/bootstrap --new ~/Github/my-tool
+```
+
+Docs-only repos (no Python toolchain) are a profile choice within this
+shape — again, `bootstrap --help` is the reference.
+
+---
+
+## Tab handoffs: the LAUNCH convention
+
+Kit tooling never asks you to `cd` around inside one long session.
+When a step finishes somewhere else — a project got created, a task
+got assigned — the tool prints a **LAUNCH block**:
+
+```
+⚠️ LAUNCH
+Open a new tab with working directory /Users/you/Github/my-product-planning
+```
+
+That printed path **is** the navigation mechanism: open a new Claude
+Code tab (or terminal) at that path and continue there. Two habits
+make this work:
+
+- **Agents run in new tabs, never in your main thread.** The main
+  session is for coordination; an agent invocation gets its own tab so
+  its context stays clean and yours stays yours.
+- **One tab per working directory.** A planning repo tab plans; a code
+  repo tab codes. The printed LAUNCH path always tells you which one
+  you're opening.
+
+## Your first session in a new planning repo
+
+Open the tab the LAUNCH line named, then **invoke the `planner`
+agent** (in a new tab, per the convention above). The planner triages
+the backlog — in a graduated prototype it has the seeded tasks from
+your brief; in a blank pair it helps you write the first tasks — and
+recommends what to start. The seeded `CLAUDE.md` in every new project
+carries this same first-session instruction, so an agent opening the
+project cold knows it too.
+
+After that, the working loop is the kit's normal one: the planner
+prepares and assigns tasks, feature developers implement them in their
+own tabs, and completion gates (`/preflight`, review bots, evaluators)
+keep the work honest.
+
+## Checking your environment
+
+Whenever something seems off — missing tools, keys, or config — run
+the health surface from inside any created project:
+
+```bash
+./scripts/core/project doctor  # incident-mapped environment checks
+```
+
+---
+
+## Where things are
+
+| You want | Where |
+|----------|-------|
+| The door's full option reference | `./scripts/local/bootstrap --help` (in the kit clone) |
+| A guided interview instead of flags | `/new-project` (in the kit clone) |
+| Your preset, authored conversationally | `/setup-preset` (in the kit clone) |
+| The split-pair pattern explained | `docs/CROSS-REPO-PATTERN.md` |
+| The prototype handoff template | `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` |
+| Health checks in a created project | `./scripts/core/project doctor` |

--- a/scripts/local/engine-consumer.sh
+++ b/scripts/local/engine-consumer.sh
@@ -768,14 +768,18 @@ append_region_if_absent() {
 # export carried the kit's python Project Rules next to profile: none).
 # Body passes via the environment — awk -v would mangle backslashes.
 replace_region() {
+    # mktemp, not a predictable suffix: a pre-planted symlink at a
+    # fixed tmp name could redirect the write (CodeRabbit, this PR —
+    # same class as remove_region_if_unmodified below)
+    RESEED_TMP="$(mktemp "$CLAUDE_MD.kit-reseed.XXXXXX")"
     REGION_BODY="$2" awk -v region="$1" '
         $0 == "<!-- BEGIN KIT-LOCAL: " region " -->" {
             print; print ENVIRON["REGION_BODY"]; skip=1; next
         }
         $0 == "<!-- END KIT-LOCAL: " region " -->" { skip=0 }
         !skip { print }
-    ' "$CLAUDE_MD" > "$CLAUDE_MD.kit-reseed.tmp"
-    mv "$CLAUDE_MD.kit-reseed.tmp" "$CLAUDE_MD"
+    ' "$CLAUDE_MD" > "$RESEED_TMP"
+    mv "$RESEED_TMP" "$CLAUDE_MD"
     echo "  $1 region reseeded ($3)"
 }
 
@@ -897,12 +901,15 @@ remove_region_if_unmodified() {
         echo "  $1 region customized — left in place (consumer-owned)"
         return 0
     fi
+    # mktemp, not a predictable suffix (CodeRabbit, this PR): a
+    # pre-planted symlink at a fixed tmp name could redirect the write
+    REMOVE_TMP="$(mktemp "$CLAUDE_MD.kit-remove.XXXXXX")"
     awk -v region="$1" '
         $0 == "<!-- BEGIN KIT-LOCAL: " region " -->" { skip=1; next }
         $0 == "<!-- END KIT-LOCAL: " region " -->" { skip=0; next }
         !skip { print }
-    ' "$CLAUDE_MD" > "$CLAUDE_MD.kit-remove.tmp"
-    mv "$CLAUDE_MD.kit-remove.tmp" "$CLAUDE_MD"
+    ' "$CLAUDE_MD" > "$REMOVE_TMP"
+    mv "$REMOVE_TMP" "$CLAUDE_MD"
     echo "  $1 region removed ($3)"
 }
 

--- a/scripts/local/engine-consumer.sh
+++ b/scripts/local/engine-consumer.sh
@@ -875,6 +875,15 @@ RULES
     fi
     seed_region project-rules "$RULES_BODY" "profile: $PROFILE"
 fi
+
+# First-session self-direction (KIT-0067 F3): the seeded CLAUDE.md
+# closes by telling a cold-open session what to do first. Only where
+# the planner actually ships (--no-kit prunes the kit agents).
+if [ "$KIT_ENABLED" -eq 1 ]; then
+    seed_region first-session \
+"First session in this repo: invoke the \`planner\` agent (in a new tab) — it triages the backlog and recommends what to start." \
+        "planner self-direction"
+fi
 echo
 
 # ─────────────────────────────────────────

--- a/scripts/local/engine-consumer.sh
+++ b/scripts/local/engine-consumer.sh
@@ -876,14 +876,25 @@ RULES
     seed_region project-rules "$RULES_BODY" "profile: $PROFILE"
 fi
 
-# Drop a KIT-LOCAL region, markers included. Only for regions an
-# install MODE invalidates: --no-kit prunes the planner agents above,
-# so a first-session region from an earlier kit-enabled install must
-# go with them (same active-prune symmetry as the rm -f of the
-# agents; fast-gate evaluator, KIT-0067). Consumer-owned regions are
-# otherwise never removed.
-remove_region() {
+# Drop a KIT-LOCAL region, markers included — but ONLY if its body is
+# still byte-identical to what the kit seeded ($2). A customized body
+# is consumer-owned and stays (with a notice), same KIT-LOCAL
+# semantics as everywhere else. The body is read via kit_markers
+# extract, whose regex requires a BALANCED marker pair — so a
+# malformed file (BEGIN without END) fails loud here instead of
+# letting the awk below eat everything to EOF (fast-gate evaluator
+# round 2, KIT-0067). Only for regions an install MODE invalidates.
+remove_region_if_unmodified() {
     if ! printf '%s\n' "$REGIONS_OUT" | grep -qx "$1"; then
+        return 0
+    fi
+    if ! REGION_BODY_NOW="$(python3 "$KIT_MARKERS" extract "$CLAUDE_MD" "$1" 2>&1)"; then
+        echo "Error: kit_markers extract $1 failed on $CLAUDE_MD:"
+        echo "       $REGION_BODY_NOW"
+        exit 1
+    fi
+    if [ "$REGION_BODY_NOW" != "$2" ]; then
+        echo "  $1 region customized — left in place (consumer-owned)"
         return 0
     fi
     awk -v region="$1" '
@@ -892,19 +903,19 @@ remove_region() {
         !skip { print }
     ' "$CLAUDE_MD" > "$CLAUDE_MD.kit-remove.tmp"
     mv "$CLAUDE_MD.kit-remove.tmp" "$CLAUDE_MD"
-    echo "  $1 region removed ($2)"
+    echo "  $1 region removed ($3)"
 }
 
 # First-session self-direction (KIT-0067 F3): the seeded CLAUDE.md
 # closes by telling a cold-open session what to do first. Only where
 # the planner actually ships (--no-kit prunes the kit agents — and
-# removes a stale region from an earlier kit-enabled install).
+# removes an unmodified region left by an earlier kit-enabled install).
+FIRST_SESSION_BODY="First session in this repo: invoke the \`planner\` agent (in a new tab) — it triages the backlog and recommends what to start."
 if [ "$KIT_ENABLED" -eq 1 ]; then
-    seed_region first-session \
-"First session in this repo: invoke the \`planner\` agent (in a new tab) — it triages the backlog and recommends what to start." \
-        "planner self-direction"
+    seed_region first-session "$FIRST_SESSION_BODY" "planner self-direction"
 else
-    remove_region first-session "--no-kit: planner not shipped"
+    remove_region_if_unmodified first-session "$FIRST_SESSION_BODY" \
+        "--no-kit: planner not shipped"
 fi
 echo
 

--- a/scripts/local/engine-consumer.sh
+++ b/scripts/local/engine-consumer.sh
@@ -876,13 +876,35 @@ RULES
     seed_region project-rules "$RULES_BODY" "profile: $PROFILE"
 fi
 
+# Drop a KIT-LOCAL region, markers included. Only for regions an
+# install MODE invalidates: --no-kit prunes the planner agents above,
+# so a first-session region from an earlier kit-enabled install must
+# go with them (same active-prune symmetry as the rm -f of the
+# agents; fast-gate evaluator, KIT-0067). Consumer-owned regions are
+# otherwise never removed.
+remove_region() {
+    if ! printf '%s\n' "$REGIONS_OUT" | grep -qx "$1"; then
+        return 0
+    fi
+    awk -v region="$1" '
+        $0 == "<!-- BEGIN KIT-LOCAL: " region " -->" { skip=1; next }
+        $0 == "<!-- END KIT-LOCAL: " region " -->" { skip=0; next }
+        !skip { print }
+    ' "$CLAUDE_MD" > "$CLAUDE_MD.kit-remove.tmp"
+    mv "$CLAUDE_MD.kit-remove.tmp" "$CLAUDE_MD"
+    echo "  $1 region removed ($2)"
+}
+
 # First-session self-direction (KIT-0067 F3): the seeded CLAUDE.md
 # closes by telling a cold-open session what to do first. Only where
-# the planner actually ships (--no-kit prunes the kit agents).
+# the planner actually ships (--no-kit prunes the kit agents — and
+# removes a stale region from an earlier kit-enabled install).
 if [ "$KIT_ENABLED" -eq 1 ]; then
     seed_region first-session \
 "First session in this repo: invoke the \`planner\` agent (in a new tab) — it triages the backlog and recommends what to start." \
         "planner self-direction"
+else
+    remove_region first-session "--no-kit: planner not shipped"
 fi
 echo
 

--- a/tests/test_bootstrap_shapes.py
+++ b/tests/test_bootstrap_shapes.py
@@ -431,7 +431,21 @@ class TestProfiles:
         assert (target / "scripts" / "core" / "ci-check.sh").is_file()
         assert (target / "scripts" / "local" / "checks.sh").is_file()
         assert not (target / ".claude" / "agents" / "planner.md").exists()
-        assert "profile: python" in (target / "CLAUDE.md").read_text(encoding="utf-8")
+        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "profile: python" in claude
+        # KIT-0067 F3: no planner shipped -> no planner self-direction
+        assert "first-session" not in claude
+
+    def test_first_session_region_seeded_with_kit(self, tmp_path):
+        # KIT-0067 F3: the seeded CLAUDE.md closes with the planner
+        # self-direction region wherever the kit workflow (and thus
+        # the planner agent) ships
+        target = make_consumer_dir(tmp_path, "firstsession")
+        result = run_bootstrap(target)
+        assert result.returncode == 0, result.stderr + result.stdout
+        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "<!-- BEGIN KIT-LOCAL: first-session -->" in claude
+        assert "invoke the `planner` agent" in claude
 
     def test_equals_form_flags_parse(self, tmp_path):
         # o3 review gap: the --flag=value forms had no functional run

--- a/tests/test_bootstrap_shapes.py
+++ b/tests/test_bootstrap_shapes.py
@@ -450,6 +450,28 @@ class TestProfiles:
         claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
         assert "first-session" not in claude
 
+    def test_no_kit_rebootstrap_keeps_customized_first_session(self, tmp_path):
+        # fast-gate evaluator round 2 (KIT-0067): a CUSTOMIZED region
+        # body is consumer-owned — --no-kit removes only the kit's own
+        # unmodified seed, never consumer edits
+        target = make_consumer_dir(tmp_path, "customized")
+        assert run_bootstrap(target).returncode == 0
+        claude_path = target / "CLAUDE.md"
+        custom_line = "My own first-session ritual: read the runbook."
+        claude_path.write_text(
+            claude_path.read_text(encoding="utf-8").replace(
+                "First session in this repo: invoke the `planner` agent"
+                " (in a new tab) — it triages the backlog and recommends"
+                " what to start.",
+                custom_line,
+            ),
+            encoding="utf-8",
+        )
+        result = run_bootstrap(target, "--no-kit")
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "first-session region customized — left in place" in result.stdout
+        assert custom_line in claude_path.read_text(encoding="utf-8")
+
     def test_first_session_region_seeded_with_kit(self, tmp_path):
         # KIT-0067 F3: the seeded CLAUDE.md closes with the planner
         # self-direction region wherever the kit workflow (and thus

--- a/tests/test_bootstrap_shapes.py
+++ b/tests/test_bootstrap_shapes.py
@@ -472,6 +472,26 @@ class TestProfiles:
         assert "first-session region customized — left in place" in result.stdout
         assert custom_line in claude_path.read_text(encoding="utf-8")
 
+    def test_no_kit_malformed_marker_fails_loud_without_data_loss(self, tmp_path):
+        # CodeRabbit (this PR): a first-session BEGIN marker whose END
+        # marker is missing must abort the --no-kit re-bootstrap loudly
+        # — never let the removal awk eat the file to EOF
+        target = make_consumer_dir(tmp_path, "malformed")
+        assert run_bootstrap(target).returncode == 0
+        claude_path = target / "CLAUDE.md"
+        before = claude_path.read_text(encoding="utf-8")
+        claude_path.write_text(
+            before.replace("<!-- END KIT-LOCAL: first-session -->\n", ""),
+            encoding="utf-8",
+        )
+        mangled = claude_path.read_text(encoding="utf-8")
+        result = run_bootstrap(target, "--no-kit")
+        assert result.returncode == 1
+        assert "kit_markers extract first-session failed" in (
+            result.stdout + result.stderr
+        )
+        assert claude_path.read_text(encoding="utf-8") == mangled
+
     def test_first_session_region_seeded_with_kit(self, tmp_path):
         # KIT-0067 F3: the seeded CLAUDE.md closes with the planner
         # self-direction region wherever the kit workflow (and thus

--- a/tests/test_bootstrap_shapes.py
+++ b/tests/test_bootstrap_shapes.py
@@ -436,6 +436,20 @@ class TestProfiles:
         # KIT-0067 F3: no planner shipped -> no planner self-direction
         assert "first-session" not in claude
 
+    def test_no_kit_rebootstrap_removes_first_session_region(self, tmp_path):
+        # fast-gate evaluator (KIT-0067): --no-kit prunes the planner,
+        # so a first-session region from an earlier kit-enabled install
+        # must go with it — never a stale instruction to invoke an
+        # agent that no longer ships
+        target = make_consumer_dir(tmp_path, "downgrade")
+        assert run_bootstrap(target).returncode == 0
+        assert "first-session" in (target / "CLAUDE.md").read_text(encoding="utf-8")
+        result = run_bootstrap(target, "--no-kit")
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "first-session region removed" in result.stdout
+        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "first-session" not in claude
+
     def test_first_session_region_seeded_with_kit(self, tmp_path):
         # KIT-0067 F3: the seeded CLAUDE.md closes with the planner
         # self-direction region wherever the kit workflow (and thus


### PR DESCRIPTION
## Summary

PR 1 of 2 for KIT-0067 (the factory front door). PR 2 (retirements
D1–D5, stacked on this branch) follows with the audit A-number
dispositions.

- **F1 — `docs/STARTING-A-PROJECT.md`**: the operator flow for a
  newcomer — factory model (one permanent clone, siblings diagram),
  the three creation flows (prototype graduation via project-intake,
  blank split pair, single repo), the LAUNCH tab-handoff convention,
  and first-session self-direction. README links it prominently. No
  hardcoded shape×profile matrix — `bootstrap --help` is cited as the
  authoritative reference throughout.
- **F2 — `/new-project`** (`.claude/commands/new-project.md`), in the
  /setup-preset structural style: derives the interview from
  `./scripts/local/bootstrap --help` at runtime, one question at a
  time, routes to project-intake (prototype exists) or a direct door
  run (fresh start), public-surfaces-only, stop-and-say-so on help
  gaps, finishes by printing the LAUNCH line. Kit-side command — not
  in any sync tier (same as /setup-preset).
- **F3 — seeded self-direction**: the consumer engine seeds a
  `first-session` KIT-LOCAL region ("invoke the planner agent — it
  triages the backlog") wherever the kit workflow ships. Skipped
  under `--no-kit`; a `--no-kit` re-bootstrap removes the region only
  if it is still byte-identical to the kit seed (customized bodies
  are consumer-owned and stay).

## Evaluator trio (before PR open, per ordering rule)

3 rounds; 2 real findings fixed (stale region on --no-kit downgrade;
customization/malformed-marker safety of the removal). Final:
fast CONCERNS (out-of-diff residuals) / o3 CONCERNS (latent,
out-of-diff) / claude-code APPROVED. Full dispositions:
`.kit/context/reviews/KIT-0067-evaluator-review.md`.

## Route transcripts (/new-project executed per the command file)

**Route A — fresh start (blank), single shape.** Derivation step ran
`./scripts/local/bootstrap --help`; interview answers → target dir +
defaults; door invoked exactly as the command prescribes
(`--no-preset` stranger mode for reproducibility):

```
$ ./scripts/local/bootstrap --new /tmp/kit0067-demo/demo-single --no-preset
...
Recording install (shape: single, profile: python) in CLAUDE.md...
  kit-install region written (shape: single, profile: python)
  project-rules region reseeded (profile: python)
  first-session region written (planner self-direction)
...
Doctor verdict: FAILURES (see above) — install still succeeded; fix before working
Install complete: shape=single profile=python → /tmp/kit0067-demo/demo-single

⚠️ LAUNCH
Open a new tab with working directory /tmp/kit0067-demo/demo-single
```

**Route A' — fresh start, planning shape** (the blank split pair's
planning half, target pointer supplied by the interview):

```
$ ./scripts/local/bootstrap --new /tmp/kit0067-demo/demo-planning \
    --shape planning --target-path ../demo-product \
    --target-github example/demo-product --no-preset
...
Install complete: shape=planning profile=none → /tmp/kit0067-demo/demo-planning
```

**Route B — prototype exists.** The command's job ends at the intake
handoff (it never runs the door on this route); after path
verification it prints:

```
⚠️ LAUNCH
Open a new tab in this kit checkout and invoke the project-intake
agent with:
  Brief: <path-to-brief.md>
  Code:  <path-to-code-folder>
```

Full door outputs: `/tmp/kit0067-demo/route-blank-single.txt`,
`/tmp/kit0067-demo/route-blank-planning.txt` (operator sweep list:
`/tmp/kit0067-demo/`).

## Seed evidence (F3 acceptance)

Fresh-export (`--new`) CLAUDE.md tail, both shapes:

```
<!-- BEGIN KIT-LOCAL: first-session -->
First session in this repo: invoke the `planner` agent (in a new tab) — it triages the backlog and recommends what to start.
<!-- END KIT-LOCAL: first-session -->
```

Re-adopt on the same target: `first-session region already present
(preserved)` — idempotent. Pinned by 4 tests in
`tests/test_bootstrap_shapes.py`.

## Test plan

- [x] Full suite in the worktree venv (py3.14): 830 passed, 12 skipped
- [x] New tests: seeded-with-kit, absent-under---no-kit,
      removed-on---no-kit-re-bootstrap, customized-body-preserved
- [x] Live door runs: `--new` single, `--new` planning, re-adopt
      (idempotency), `--no-kit` downgrade
- [x] Evaluator trio run pre-PR; real findings fixed (see record)

Task: `.kit/tasks/3-in-progress/KIT-0067-factory-front-door-and-structural-cleanup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation and bootstrap seeding behavior with new characterization tests; consumer impact is limited to new projects and explicit `--no-kit` re-bootstrap paths.
> 
> **Overview**
> **Factory front door (PR 1/2)** — documents the one-clone-as-factory model and wires a kit-side entry path so operators can create projects without memorizing bootstrap flags.
> 
> **`docs/STARTING-A-PROJECT.md`** explains the sibling-folder layout, the three creation paths (prototype → `project-intake`, blank split pair, single repo), LAUNCH tab handoffs, and first planner session. **README** points newcomers there.
> 
> **`/new-project`** interviews one question at a time, derives choices from `./scripts/local/bootstrap --help` (no duplicated matrix), routes prototypes to `project-intake` with brief/code validation, or runs the door for fresh starts, and ends with a LAUNCH block.
> 
> **Bootstrap consumer engine** seeds a `first-session` KIT-LOCAL region when the kit workflow ships; **`--no-kit` re-bootstrap** drops it only if still byte-identical to the seed (customized bodies stay). Region removal uses **`kit_markers extract`** before awk so malformed markers fail loud; temp writes use **`mktemp`** instead of predictable suffixes.
> 
> **Tests** cover seeding, `--no-kit` removal, customized preservation, and malformed-marker abort. Task/handoff bookkeeping moves KIT-0067 to in-progress; evaluator review record added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccbf95a585db660d925911ab29b343c2a8357925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->