### PR TITLE
feat(KIT-0084): new projects start with a working .env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -72,13 +72,19 @@ LINEAR_TEAM_ID=
 # ============================================================================
 # PROJECT CONFIGURATION
 # ============================================================================
-# These are set during the planner onboarding process
+# On `bootstrap --new` the setup door seeds .env and fills these:
+# PROJECT_NAME from the target folder; TASK_PREFIX from the export
+# engine's derived prefix (single shape) or left empty until intake
+# decides it (planning shape). API keys are carried over by the
+# OPERATOR — via the preset's env-source or by hand; agents never move
+# key material (the permission classifier blocks it).
 
 # Your project name (used in configurations)
 PROJECT_NAME=
 
 # Project ID prefix for tasks (e.g., "PROJ" creates PROJ-0001, PROJ-0002, etc.)
-TASK_PREFIX=TASK
+# Empty until set — `project doctor` warns while it is empty or "TASK".
+TASK_PREFIX=
 
 # ============================================================================
 # LOGGING CONFIGURATION

--- a/.kit/context/KIT-0084-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0084-HANDOFF-feature-developer.md
@@ -5,7 +5,7 @@
 **Date**: 2026-08-04
 **From**: planner-f5
 **To**: feature-developer
-**Task**: `.kit/tasks/2-todo/KIT-0084-working-env-from-day-one.md`
+**Task**: `.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md`
 **Status**: Ready for implementation
 **Evaluation**: arch-review-fast APPROVED (first pass) —
 `.adversarial/logs/KIT-0084-working-env-from-day-one--arch-review-fast.md`
@@ -101,6 +101,6 @@ in help/docs (F3), and don't let the template default regress.
 
 ---
 
-**Task File**: `.kit/tasks/2-todo/KIT-0084-working-env-from-day-one.md`
+**Task File**: `.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md`
 **Evaluation Log**: `.adversarial/logs/KIT-0084-working-env-from-day-one--arch-review-fast.md`
 **Source Issue**: movito/agentive-starter-kit#104 — comment there when the PR opens

--- a/.kit/context/KIT-0084-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0084-HANDOFF-feature-developer.md
@@ -6,7 +6,7 @@
 **From**: planner-f5
 **To**: feature-developer
 **Task**: `.kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md`
-**Status**: Ready for implementation
+**Status**: In Review (implementation done — PR #105; this handoff is historical)
 **Evaluation**: arch-review-fast APPROVED (first pass) —
 `.adversarial/logs/KIT-0084-working-env-from-day-one--arch-review-fast.md`
 

--- a/.kit/context/KIT-0084-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0084-HANDOFF-feature-developer.md
@@ -5,7 +5,7 @@
 **Date**: 2026-08-04
 **From**: planner-f5
 **To**: feature-developer
-**Task**: `.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md`
 **Status**: Ready for implementation
 **Evaluation**: arch-review-fast APPROVED (first pass) —
 `.adversarial/logs/KIT-0084-working-env-from-day-one--arch-review-fast.md`
@@ -101,6 +101,6 @@ in help/docs (F3), and don't let the template default regress.
 
 ---
 
-**Task File**: `.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md`
+**Task File**: `.kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md`
 **Evaluation Log**: `.adversarial/logs/KIT-0084-working-env-from-day-one--arch-review-fast.md`
 **Source Issue**: movito/agentive-starter-kit#104 — comment there when the PR opens

--- a/.kit/context/KIT-0084-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0084-REVIEW-STARTER.md
@@ -1,0 +1,61 @@
+# KIT-0084 — Review Starter
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/105
+**Branch**: `feature/KIT-0084-working-env-from-day-one`
+**Task**: `.kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md`
+**Source issue**: #104 (commented with the PR link)
+**Status**: All gates green — ready for human review
+
+## What shipped (F1–F5)
+
+- **F1**: `bootstrap --new` (both shapes) seeds `.env` — preset
+  `env-source` when configured, else the target's own `.env.template`;
+  discipline shared in `copy_env_into_target` (gitignore refusal,
+  born-0600 umask-first write, contents never printed).
+- **F2**: `PROJECT_NAME` filled from the target basename; `TASK_PREFIX`
+  from the export engine's recorded prefix (single shape, via
+  `current-state.json`) or written empty (planning shape). Template
+  default is now `TASK_PREFIX=` (empty); doctor env-keys WARNs while
+  it is missing, empty, or `TASK` (last-assignment-wins value read).
+- **F3**: key carry-over is operator-consented and operator-executed —
+  TTY consent question naming the whole file, or a printed
+  `install -m 600` command (non-TTY). Agent/classifier constraint
+  documented in the door header and `docs/STARTING-A-PROJECT.md`.
+- **F4**: consumer `first-session` region gains the doctor/env-keys
+  line, with a legacy-body parameter on `remove_region_if_unmodified`
+  so pre-change consumers' `--no-kit` re-bootstraps stay clean.
+- **F5**: `.env.template` comments describe the real mechanism.
+
+## Review gates already passed
+
+- **Evaluator trio (pre-PR, per KIT-0035)**: fast-v2 CONCERNS→actioned;
+  o3 FAIL→2 actioned / 4 rejected with reasoning; claude-code security
+  **APPROVED**. Full triage + embedded logs:
+  `.kit/context/reviews/KIT-0084-evaluator-review.md`.
+- **Bot threads**: 9 total (CodeRabbit round 1: 7, round 2: 2), every
+  one replied and resolved — 8 fixed (last-wins doctor value, dedup
+  incl. export/indented forms, quote-aware `#` parsing, atomic
+  temp-in-.git rewrite, quoted/`install -m 600` printed command,
+  bookkeeping), 1 declined with reasoning (allowlist merge for
+  carry-over — contradicts spec F3's wholesale-cp remedy; consent
+  wording tightened instead). BugBot: pass on all three rounds.
+- **CI**: green on every head — dispatched Tests runs 30945602946,
+  30947609291, 30949363925 (lint + Python 3.10/3.12/3.14). ⚠️ Note:
+  the `pull_request` event never fired for this PR (other PRs today
+  triggered normally); each run above was started with
+  `gh workflow run test.yml --ref <branch>` on the same head SHA.
+  Worth a planner follow-up if it recurs on the next PR.
+- **Local caveat**: the 8 `test_doctor.py`/4 `test_setup_door.py`
+  local failures are the known KIT-0080 Apple-git-2.30.1 class,
+  verified identical on clean `main`; commits used `SKIP_TESTS=1`
+  for that reason only, with all KIT-0084 tests run green directly.
+
+## Suggested review focus
+
+- The operator/agent key-material boundary (F3) — wording and
+  mechanism both.
+- `fill_env_identity`'s awk rewrite (dedup, quoting, atomic replace).
+- The declined CodeRabbit allowlist thread — confirm the disagree
+  rationale holds for you.
+- Doctor `key_value` last-wins vs `key_state` first-non-empty presence
+  scan — the divergence is deliberate and documented.

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0084",
     "task_started": null,
     "brief_note": "2026-08-04: ev-fast-charging-loads intake surfaced issues #103/#104 -> KIT-0083/KIT-0084 (both arch-review-fast APPROVED). KIT-0084 (working .env from day one) now in 3-in-progress with feature-developer (PR #105); KIT-0083 next in 2-todo (pin-home decision coordinates with #60/KIT-0079). KIT-0078 remains in todo, queue-jumped by operator direction. Milestone framing: 0.9.1 ships-working-scaffolds (KIT-0075/0079/0080/0081/0082/0083/0084).",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md",
     "handoff_file": ".kit/context/KIT-0084-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0084",
     "task_started": null,
     "brief_note": "KIT-0084 ready: door seeds .env (extend apply_env_source fallback), fill PROJECT_NAME/TASK_PREFIX, doctor WARN on TASK default, operator-only key carry-over, first-session doctor line. Anchors in handoff. Worktree: ../ask-worktrees/KIT-0084 via plain git worktree (helper broken on this machine, KIT-0080). KIT-0078 handoff still pending in todo.",
-    "details_link": ".kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md",
+    "details_link": ".kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md",
     "handoff_file": ".kit/context/KIT-0084-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -4,7 +4,7 @@
     "current_task": "KIT-0084",
     "task_started": null,
     "brief_note": "2026-08-04: ev-fast-charging-loads intake surfaced issues #103/#104 -> KIT-0083/KIT-0084 (both arch-review-fast APPROVED, in 2-todo). Operator prioritized KIT-0084 (working .env from day one) first; KIT-0083 next (pin-home decision coordinates with #60/KIT-0079). KIT-0078 remains in todo, queue-jumped by operator direction. Milestone framing: 0.9.1 ships-working-scaffolds (KIT-0075/0079/0080/0081/0082/0083/0084).",
-    "details_link": ".kit/tasks/2-todo/KIT-0084-working-env-from-day-one.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md",
     "handoff_file": ".kit/context/KIT-0084-HANDOFF-feature-developer.md"
   },
   "feature-developer": {
@@ -12,7 +12,7 @@
     "current_task": "KIT-0084",
     "task_started": null,
     "brief_note": "KIT-0084 ready: door seeds .env (extend apply_env_source fallback), fill PROJECT_NAME/TASK_PREFIX, doctor WARN on TASK default, operator-only key carry-over, first-session doctor line. Anchors in handoff. Worktree: ../ask-worktrees/KIT-0084 via plain git worktree (helper broken on this machine, KIT-0080). KIT-0078 handoff still pending in todo.",
-    "details_link": ".kit/tasks/2-todo/KIT-0084-working-env-from-day-one.md",
+    "details_link": ".kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md",
     "handoff_file": ".kit/context/KIT-0084-HANDOFF-feature-developer.md"
   },
   "code-reviewer": {

--- a/.kit/context/agent-handoffs.json
+++ b/.kit/context/agent-handoffs.json
@@ -3,7 +3,7 @@
     "status": "handoff_ready",
     "current_task": "KIT-0084",
     "task_started": null,
-    "brief_note": "2026-08-04: ev-fast-charging-loads intake surfaced issues #103/#104 -> KIT-0083/KIT-0084 (both arch-review-fast APPROVED, in 2-todo). Operator prioritized KIT-0084 (working .env from day one) first; KIT-0083 next (pin-home decision coordinates with #60/KIT-0079). KIT-0078 remains in todo, queue-jumped by operator direction. Milestone framing: 0.9.1 ships-working-scaffolds (KIT-0075/0079/0080/0081/0082/0083/0084).",
+    "brief_note": "2026-08-04: ev-fast-charging-loads intake surfaced issues #103/#104 -> KIT-0083/KIT-0084 (both arch-review-fast APPROVED). KIT-0084 (working .env from day one) now in 3-in-progress with feature-developer (PR #105); KIT-0083 next in 2-todo (pin-home decision coordinates with #60/KIT-0079). KIT-0078 remains in todo, queue-jumped by operator direction. Milestone framing: 0.9.1 ships-working-scaffolds (KIT-0075/0079/0080/0081/0082/0083/0084).",
     "details_link": ".kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md",
     "handoff_file": ".kit/context/KIT-0084-HANDOFF-feature-developer.md"
   },

--- a/.kit/context/reviews/KIT-0084-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0084-evaluator-review.md
@@ -1,7 +1,7 @@
 # KIT-0084 — Evaluator Review Record
 
 **Date**: 2026-08-04
-**Task**: `.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md`
 **Diff**: `main...feature/KIT-0084-working-env-from-day-one` (full-file context input)
 **Ordering**: trio run BEFORE PR open (KIT-0035/KIT-0046 rule)
 

--- a/.kit/context/reviews/KIT-0084-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0084-evaluator-review.md
@@ -1,0 +1,469 @@
+# KIT-0084 — Evaluator Review Record
+
+**Date**: 2026-08-04
+**Task**: `.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md`
+**Diff**: `main...feature/KIT-0084-working-env-from-day-one` (full-file context input)
+**Ordering**: trio run BEFORE PR open (KIT-0035/KIT-0046 rule)
+
+## Runs
+
+| Evaluator | Model | Verdict | Log |
+|-----------|-------|---------|-----|
+| code-reviewer-fast-v2 (round 1) | gemini-3-flash | CONCERNS | superseded by round 2 (same file) |
+| code-reviewer (deep) | o3 | FAIL | `.adversarial/logs/KIT-0084-code-review-input--code-reviewer.md` |
+| claude-code (security) | claude-sonnet-4-6 | **APPROVED** | `.adversarial/logs/KIT-0084-code-review-input--claude-code.md` |
+| code-reviewer-fast-v2 (round 2, post-fix) | gemini-3-flash | CONCERNS | `.adversarial/logs/KIT-0084-code-review-input--code-reviewer-fast-v2.md` |
+
+## Findings actioned (commit `4bc3b02` + indent follow-up)
+
+- **JSON null → literal "None"** (fast-v2 r1): the current-state.json
+  reader now prints only `isinstance(value, str)` values; test
+  `test_null_recorded_prefix_writes_empty_never_none` pins it.
+- **Duplicate identity lines survive** (fast-v2 r1, o3): `fill_env_identity`
+  rewrites the first assignment and DROPS later duplicates (dotenv
+  parsers are last-assignment-wins); indented assignments match too
+  (fast-v2 r2). Test: `test_duplicate_identity_lines_deduplicated`.
+- **`#` inside quoted values truncated** (fast-v2 r1): `_effective_value`
+  is quote-aware — quotes first, comment-split only for unquoted
+  values. Tests: `test_quoted_value_with_hash_not_truncated`,
+  `test_quoted_key_with_hash_is_present`. (Also fixed an
+  empty-string `value[:1] in "\"'"` → IndexError caught by the
+  existing empty-key test.)
+- **Newline injection via name/prefix** (o3): CR/LF stripped from
+  identity values before the rewrite (operator-owned input; hardening,
+  not a trust boundary).
+- **Printed cp command unquoted / kit .env mode unchecked** (claude-code):
+  paths quoted; the kit `.env` gets the same 0600 courtesy warning as
+  the preset env-source.
+- **Test `split()` fragility** (claude-code): `maxsplit=1` in the
+  legacy-body test.
+
+## Findings rejected, with reasoning
+
+- **o3: "door aborts when repo isn't initialised"** — unreachable: on
+  `--new` both engines git-init before the env step runs, and the
+  check-ignore failure branch exits with its own message (an `if !`
+  condition, not a `set -e` abort).
+- **o3: "carry-over nukes template lines"** — by design: the file being
+  replaced is the template seeded seconds earlier with no operator
+  content, and the spec's own non-TTY remedy is the identical wholesale
+  `cp`; identity fields are refilled after.
+- **o3: allow opting out of the `TASK` WARN** — contradicts the task
+  spec, which mandates WARN on empty-or-`TASK`; doctor WARNs are
+  non-fatal.
+- **o3: ".env exists on re-run"** — `--new` refuses existing targets
+  outright; the path does not exist.
+- **fast-v2 r2: doctor is first-non-empty-wins, parsers are last-wins** —
+  `key_state`'s whole-file first-NON-EMPTY scan is pre-existing,
+  previously-litigated behavior (the copy-template-then-append layout
+  depends on it); `key_value` mirrors it deliberately, and the door now
+  dedupes seeded files so the divergence needs a hand-broken `.env`.
+- **fast-v2 r2: `.strip()` inside quotes** — mirrors the pre-existing
+  normalization; for this check a whitespace-only quoted prefix is
+  unusable anyway, so WARN is correct.
+- **fast-v2 r1: `basename /`** — `--new` rejects existing targets (`/`
+  exists) and empty targets die at argument validation.
+
+## Residual notes for reviewers
+
+- claude-code MEDIUM (acknowledged trade-off): `.env` contents pass
+  through a shell variable during the identity rewrite — chosen over a
+  temp file because a leaked temp beside `.env` would not be
+  gitignored; short-lived operator-owned process.
+- The doctor/parser semantics divergence above is documented in code
+  comments; revisit only if a real `.env` shape hits it.
+
+---
+
+## Appended evaluator logs (verbatim, whitespace-stripped; .adversarial/logs/ is untracked by policy)
+
+### Log: code-reviewer-fast-v2
+
+#  Code Reviewer Fast V2
+
+**Source**: /Users/broadcaster_one/Github/ask-worktrees/KIT-0084/.adversarial/inputs/KIT-0084-code-review-input.md
+**Evaluator**: code-reviewer-fast-v2
+**Model**: gemini/gemini-3-flash-preview
+**Generated**: 2026-08-04 19:44 UTC
+
+---
+
+### Findings
+
+**[CORRECTNESS]: Discrepancy between Doctor's key-parsing and standard `.env` behavior (First-wins vs Last-wins)**
+- **Location**: `scripts/core/doctor.d/20-env-keys.py:key_value` and `key_state`
+- **Edge case**: Multiple assignments of the same key in `.env` (e.g., `TASK_PREFIX=OLD` followed by `TASK_PREFIX=NEW`).
+- **What happens**: Standard `.env` parsers (and shell sourcing) are "last-assignment-wins". However, the `key_value` and `key_state` functions return the first uncommented assignment they encounter. This means the `doctor` may report a "PASS" or "WARN" based on a value that is actually being overridden and ignored by the application.
+- **Tested?**: No. Tests only cover single assignments or commented-then-uncommented.
+
+**[CORRECTNESS]: `_effective_value` incorrectly strips internal spaces from quoted strings**
+- **Location**: `scripts/core/doctor.d/20-env-keys.py:_effective_value`
+- **Edge case**: Quoted values with intentional leading/trailing whitespace (e.g., `TASK_PREFIX=" PROJ "`).
+- **What happens**: The function calls `.strip()` on the content *inside* the quotes (`value[1:closing].strip()`). In standard `.env` parsing, quotes are used specifically to preserve such whitespace. This discrepancy causes the `doctor` to validate a "normalized" value that does not match what the application actually loads.
+- **Tested?**: No. Existing tests use trimmed values like `"PROJ#1"`.
+
+**[ROBUSTNESS]: `fill_env_identity` fails to deduplicate indented assignments**
+- **Location**: `scripts/local/bootstrap:fill_env_identity`
+- **Edge case**: An existing `.env` (from an `env-source` or manual edit) has indented assignments (e.g., `  PROJECT_NAME=OLD`).
+- **What happens**: The `awk` script uses anchors `^PROJECT_NAME=`. It will fail to match indented lines. Consequently:
+    1. It won't replace the indented line.
+    2. The `END` block will append a new `PROJECT_NAME=NEW` at the end of the file.
+    While a last-wins parser will technically use the new value, the file remains cluttered with duplicates, and the `doctor` (which is first-wins) will incorrectly report the `OLD` value.
+- **Tested?**: Partial. `test_duplicate_identity_lines_deduplicated` tests duplicates but they are not indented.
+
+**[CORRECTNESS]: Potential for malformed `.env` if template keys are commented**
+- **Location**: `scripts/local/bootstrap:fill_env_identity`
+- **Edge case**: The `.env.template` or `env-source` has `PROJECT_NAME` commented out (e.g., `# PROJECT_NAME=`).
+- **What happens**: The `awk` script only matches `^PROJECT_NAME=`. If the line is commented, it is ignored by the matching logic and handled by the default `{ print }` block. Then, the `END` block appends a new assignment. Result:
+    ```
+    # PROJECT_NAME=
+    ...
+    PROJECT_NAME=NEW_NAME
+    ```
+    This is safe, but if the user also had an uncommented indented assignment (see above), you end up with three variations, confusing both the operator and the `doctor`.
+- **Tested?**: Yes, `test_missing_lines_appended_commented_left_alone` confirms this behavior.
+
+### Test Gap Summary
+| Edge Case | Function | Tested? | Risk |
+|-----------|----------|---------|------|
+| Duplicate keys (First vs Last wins) | `key_value` | No | Med: Doctor reports/validates wrong data |
+| Internal whitespace in quotes | `_effective_value` | No | Low: Minor identity mismatch |
+| Indented key replacement | `fill_env_identity` | No | Low: File clutter/Doctor confusion |
+| Missing closing quote in `.env` | `_effective_value` | No | Low: Falls back to split logic safely |
+
+### Trace: `_effective_value` missing quote
+If `raw` is `"value`:
+1. `value` = `"value`
+2. `value[0]` is `"`
+3. `closing` = `value.find("\"", 1)` -> `-1`
+4. Returns `value.split("#", 1)[0].strip()` -> `"value`
+This is handled correctly as a fallback.
+
+### Trace: `fill_env_identity` JSON Null
+If `current-state.json` has `"task_prefix": null`:
+1. Python block sets `value = None`.
+2. `isinstance(value, str)` is False.
+3. Python prints nothing.
+4. Shell `prefix` is `""`.
+5. `fill_env_identity` writes `TASK_PREFIX=` (empty).
+This is handled correctly (checked by `test_null_recorded_prefix_writes_empty_never_none`).
+
+### Verdict
+
+**CONCERNS**
+
+The logic for `doctor` and `bootstrap` is slightly inconsistent regarding how it handles `.env` files that aren't perfectly formatted (specifically duplicates and indentation). While it works for standard "happy path" seeding, a user who manually edits their `.env` with indentation or duplicates will see the `doctor` and the `bootstrap` tool disagreeing on the project's identity. The most significant gap is the `first-wins` logic in `doctor.d/20-env-keys.py`, which is the opposite of how environment variables actually behave in Linux/Python.
+### Log: code-reviewer
+
+#  Code Reviewer
+
+**Source**: /Users/broadcaster_one/Github/ask-worktrees/KIT-0084/.adversarial/inputs/KIT-0084-code-review-input.md
+**Evaluator**: code-reviewer
+**Model**: o3
+**Generated**: 2026-08-04 19:33 UTC
+
+---
+
+### Summary
+Reviewed changes around `.env` seeding (KIT-0084), doctor checks and bootstrap logic.
+Found 6 non-trivial edge-case/logic problems (2 immediate correctness bugs, 3 latent, 1 test gap).
+
+### Findings
+
+**[CORRECTNESS]: bootstrap fails when repo isn’t initialised yet**
+- **Location**: `scripts/local/bootstrap:copy_env_into_target` (line ~560)
+- **Edge case**: `bootstrap --new` targets whose export engine does NOT create a `.git` (custom export engine, or a future refactor).
+- **What happens**: `git -C "$TARGET" check-ignore -q .env` is called before `git init` has happened ⇒ exit-status 128, bash `-e` terminates the whole door. User sees “.env is not gitignored” even though the ignore file would be created later.
+- **Expected**: Door should defer the ignore check until after a repo exists, or fall back to “no repo yet – assume future .gitignore will ignore `.env`”.
+- **Test coverage**: NOT covered – all current tests run default export path which already contains a repo.
+- **Severity**: Bug
+
+---
+
+**[CORRECTNESS]: Operator carry-over silently nukes earlier template lines**
+- **Location**: `scripts/local/bootstrap:offer_env_carryover` (line ~630)
+- **Edge case**: No `env-source`; template seeded first, then operator answers “yes” to key copy.
+- **What happens**: `copy_env_into_target` overwrites the file wholesale with the kit’s `.env`, discarding the earlier template comments and any non-key variables that template had added. Only `PROJECT_NAME` / `TASK_PREFIX` get re-added afterwards.
+- **Expected**: Keys should be *merged*; content not related to secrets should survive.
+- **Test coverage**: NOT covered (tests only hit the “no”/non-TTY path).
+- **Severity**: Latent – data loss once an operator answers “yes”.
+
+---
+
+**[ROBUSTNESS]: Duplicate PROJECT_NAME / TASK_PREFIX lines remain stale**
+- **Location**: `scripts/local/bootstrap:fill_env_identity` (line ~680)
+- **Edge case**: `env-source` already contains `PROJECT_NAME=` / `TASK_PREFIX=`.
+- **What happens**: Function rewrites the *first* matching line but leaves the old one further down. Libraries that read “last assignment wins” (python-dotenv, Node dotenv) will still see the stale value.
+- **Expected**: Either de-duplicate (delete later matches) or always rewrite *all* occurrences.
+- **Test coverage**: NOT covered (tests assert only first value).
+- **Severity**: Latent – wrong identity under common dotenv parsers.
+
+---
+
+**[SECURITY/ROBUSTNESS]: New-line / shell token injection in ENV_PREFIX / ENV_NAME**
+- **Location**: `fill_env_identity` awk substitution
+- **Edge case**: Operator passes `--prefix 'FOO\nMALICIOUS=1'` or project folder name contains back-ticks/newlines.  Value is pushed into `.env` unescaped.
+- **What happens**: Results in multi-line injection: extra environment variables, potentially used by later tooling, with no validation.  Not remote-code-exec but breaks invariants and could smuggle secrets into logs.
+- **Expected**: Validate `[A-Z0-9_-]+` for prefixes and names, or at least reject control characters.
+- **Test coverage**: NOT covered.
+- **Severity**: Latent / security hardening.
+
+---
+
+**[ROBUSTNESS]: `.env` placeholder “TASK” treated as always wrong**
+- **Location**: `scripts/core/doctor.d/20-env-keys.py` (line ~90)
+- **Edge case**: Legitimate legacy projects that *do* use prefix `TASK`.
+- **What happens**: Doctor always WARNs, cannot be silenced.
+- **Expected**: Allow opt-out (e.g. `TASK_PREFIX_FORCE=1`) or warn only when the project was created by the new door (has a creation marker).
+- **Test coverage**: Explicitly asserts the constant behaviour; no test for legitimate TASK prefix.
+- **Severity**: Gap / potential annoyance.
+
+---
+
+**[TESTING]: `copy_env_into_target` path where `.env` already exists is untested**
+- **Location**: multiple call-sites
+- **Edge case**: Re-running `bootstrap --new` after manual edits, or operator accidentally copies twice.
+- **What happens**: File is overwritten with no confirmation.  Behaviour is undefined if file is a symlink.
+- **Expected**: Unit or e2e test that existing non-symlink file is refused or merged.
+- **Test coverage**: Not present.
+- **Severity**: Gap
+
+### Edge Cases Verified Clean
+- Template missing → door prints warning and continues without crash.
+- Mixed “export ” prefixes, quoted empty values – env-keys check flags them.
+- Legacy first-session body removal path works for both new and legacy texts.
+
+### Test Gap Summary
+
+| Edge Case | Function | Tested? | Risk |
+|-----------|----------|---------|------|
+| Repo not yet initialised when `.env` copied | copy_env_into_target | No | Door aborts on custom exporters |
+| Operator carry-over overwrite | offer_env_carryover | No | Silent data loss |
+| Duplicate PROJECT_NAME/PREFIX lines | fill_env_identity | No | Identity drift under dotenv parsers |
+| Control chars in prefix/name | fill_env_identity | No | Env poisoning |
+| Legitimate TASK prefix | env-keys doctor | No | Permanent false WARN |
+| Existing `.env` file on re-run | copy_env_into_target | No | Overwrite without notice |
+
+### Verdict
+**FAIL** – The new door flow contains two concrete correctness bugs that can abort an install or silently clobber `.env`, plus several latent robustness issues.  Fix at least the git-init ordering and the carry-over overwrite before merging.
+### Log: claude-code
+
+#  Claude Code
+
+**Source**: /Users/broadcaster_one/Github/ask-worktrees/KIT-0084/.adversarial/inputs/KIT-0084-code-review-input.md
+**Evaluator**: claude-code
+**Model**: anthropic/claude-sonnet-4-6
+**Generated**: 2026-08-04 19:35 UTC
+
+---
+
+# Code Review: KIT-0084
+
+## Phase 1: Understand Intent
+
+This PR implements "working `.env` from day one" for new projects created via `bootstrap --new`. Key goals:
+1. **F1**: Seed `.env` (0600, gitignored) from preset env-source or `.env.template`
+2. **F2**: Fill `PROJECT_NAME`/`TASK_PREFIX` identity fields; doctor warns on placeholder values
+3. **F3**: Operator-consented API key carry-over (TTY prompt or printed command; never agent-executed)
+4. **F4**: First-session CLAUDE.md region updated with doctor env-keys note
+5. **F5**: `.env.template` comments updated to reflect actual mechanism
+
+Critical paths: `copy_env_into_target()` (secret handling), `fill_env_identity()` (awk-based in-memory rewrite), `offer_env_carryover()` (consent boundary), `key_value()` in the doctor check.
+
+---
+
+## Phase 2: Security Analysis
+
+### [MEDIUM]: In-memory `.env` Rewrite Exposes Content via Shell Variable
+
+- **Location**: `scripts/local/bootstrap`, `fill_env_identity()`, around the `content="$(…)"` assignment
+- **Issue**: The entire `.env` contents (including any API keys already seeded by `copy_env_into_target`) are captured into a shell variable `content` and then written back via `printf '%s\n' "$content"`. Shell variables holding secret material are visible in `/proc/<pid>/environ` on Linux and can appear in crash dumps or tracing tools. The comment says "no temp file" to avoid a gitignore gap, but the chosen alternative moves the exposure from filesystem to process memory/environment in a less controlled way.
+
+  The risk is low in practice (short-lived process, operator-owned machine), but it's worth documenting. A more robust alternative would be a temp file written inside the target directory (which IS gitignored for `.env`) with a `.env.kit-tmp.XXXXX` name that also matches the gitignore pattern, followed by atomic rename — though the current approach is acceptable given the deployment context.
+
+- **Remediation**: Add a comment explicitly acknowledging this trade-off. If hardening is desired, use a temp file with a name that matches the gitignore glob (e.g., `.env.tmp.*` added to `.gitignore` during bootstrap) and use `mktemp` + `mv` (the TEMP-THEN-COMMIT pattern used elsewhere).
+
+---
+
+### [LOW]: `offer_env_carryover` Prints Absolute Paths to Kit `.env` Without Checking Mode
+
+- **Location**: `scripts/local/bootstrap`, `offer_env_carryover()`, the non-TTY branch
+- **Issue**: The printed `cp` command includes the absolute path to the kit clone's `.env`. If the operator runs this in a logging environment (e.g., CI with captured output), the path is exposed in logs — though not the content. More importantly, the function does not check `$kit_env`'s file mode before printing it as a copy source. The `apply_env_source()` function warns when the source is not 0600; `offer_env_carryover()` silently proceeds regardless of the kit `.env`'s mode.
+- **Remediation**: Add a mode check (similar to the one in `apply_env_source`) before suggesting the copy command:
+  ```bash
+  mode="$(stat -f '%Lp' "$kit_env" 2>/dev/null || stat -c '%a' "$kit_env" 2>/dev/null || echo unknown)"
+  if [ "$mode" != "600" ]; then
+      echo "Warning: $kit_env is mode $mode (expected 0600) — tighten it before copying" >&2
+  fi
+  ```
+
+---
+
+### [LOW]: `key_value()` — Commented-Out Assignment Returns `value_seen = ""`
+
+- **Location**: `scripts/core/doctor.d/20-env-keys.py`, `key_value()`, lines handling the `TASK_PREFIX=` case
+- **Issue**: When `TASK_PREFIX=` appears uncommented but empty, `value_seen` is set to `""`. When the function returns `value_seen` (which is `""`), the caller checks `prefix == ""` and correctly warns. However, if `TASK_PREFIX=` appears multiple times (e.g., a commented template line followed by an empty live line), the function exits early on the first non-empty value via `return value`. The scan logic mirrors `key_state()` in structure but does not handle the "whole file scan" semantic the same way for the case where a later uncommented line has a non-empty value after an earlier empty one. Specifically: the first NON-EMPTY assignment wins (per the docstring), but `value_seen = ""` is set on the first EMPTY assignment and never updated if a later line has a non-empty value. This means if the file has:
+  ```
+  TASK_PREFIX=
+  TASK_PREFIX=MYPROJECT
+  ```
+  The function returns `""` (warns) instead of `"MYPROJECT"` (passes). This is the inverse of the `key_state()` "present wins" semantic.
+- **Remediation**: Fix the scan to continue past empty assignments:
+  ```python
+  if value:
+      return value
+  value_seen = ""  # record that an empty assignment exists; keep scanning
+  # do NOT return here — a later non-empty line should win
+  ```
+  Actually, looking at the code again, this IS what the code does — `value_seen = ""` and then `continue` (via the loop). But the issue is that `return value` only fires when `value` is truthy, so an empty value falls through to `value_seen = ""` and continues. A subsequent non-empty value would correctly `return value`. The logic is actually correct. **Retracting this finding** — the code is correct for this case.
+
+---
+
+### [LOW]: `fill_env_identity` Writes `.env` Without Verifying Gitignore First
+
+- **Location**: `scripts/local/bootstrap`, `fill_env_identity()`
+- **Issue**: `fill_env_identity()` rewrites `$TARGET/.env` using `printf '%s\n' "$content" > "$TARGET/.env"` but does NOT call `git check-ignore` first (unlike `copy_env_into_target`). The function is called after `copy_env_into_target` has already verified gitignore, so in the normal flow this is fine. However, if `fill_env_identity()` were ever called independently (e.g., sourced in a test with only `TARGET` set and no prior gitignore check), it would write without the guard.
+- **Remediation**: This is a defense-in-depth concern given the current call sites. Document explicitly in the function that callers must ensure `.env` is gitignored before calling (or add the check). The test `TestFillEnvIdentityUnits` does not set up gitignore, which confirms the function skips this check.
+
+---
+
+### [POSITIVE]: No Hardcoded Credentials
+
+No API keys, tokens, or secrets appear anywhere in the changed code. Test fixtures use clearly labeled dummy strings (`KIT0056-FIXTURE-SECRET-NEVER-PRINT`, `sk-test-*`).
+
+### [POSITIVE]: Values Passed via Environment to awk, Never Interpolated
+
+The `fill_env_identity` function passes `PROJECT_NAME` and `TASK_PREFIX` values via `ENV_NAME`/`ENV_PREFIX` environment variables to `awk` using `ENVIRON[]`, never via `-v` or string interpolation into the awk program. This correctly prevents injection through operator-supplied project names containing special characters.
+
+### [POSITIVE]: umask-First File Creation
+
+`copy_env_into_target()` uses `(umask 077; cat "$1" > "$TARGET/.env")` followed by `chmod 600`, ensuring the file is born at mode 0600 with no window at looser permissions.
+
+### [POSITIVE]: Gitignore Check Before Any Secret Write
+
+`copy_env_into_target()` calls `git check-ignore -q .env` before writing, refusing to proceed if `.env` is not gitignored.
+
+### [POSITIVE]: Secret Values Never Echoed
+
+All seeding functions explicitly state and demonstrate that contents are never printed. The test suite asserts this (`assert SECRET not in result.stdout + result.stderr`).
+
+---
+
+## Phase 3: Correctness Analysis
+
+### [MEDIUM]: `fill_env_identity` — Trailing Newline Behavior with `printf '%s\n'`
+
+- **Location**: `scripts/local/bootstrap`, `fill_env_identity()`
+- **Issue**: The content is captured via command substitution: `content="$(… awk … "$TARGET/.env")"`. Command substitution strips trailing newlines. If the original `.env` ends with content followed by a newline (standard), the captured string loses that trailing newline. Then `printf '%s\n' "$content"` adds exactly one newline back. This means:
+  - A file ending in `\n` → captured without `\n` → written with `\n` ✓
+  - A file ending in `\n\n` (blank line at end) → captured without both trailing `\n`s → written with one `\n` — the blank line is lost.
+  - A file NOT ending in `\n` (non-standard) → written with `\n` added — this changes the file.
+
+  In practice, `.env.template` ends with a final newline, so the seeded `.env` will too, and this is correct behavior. The edge case of trailing blank lines being stripped is cosmetic for `.env` files.
+
+- **Remediation**: Acceptable for this use case. A comment noting the trailing-newline behavior would help future maintainers.
+
+---
+
+### [LOW]: `key_value()` Does Not Handle Multi-Line Values or Continuation
+
+- **Location**: `scripts/core/doctor.d/20-env-keys.py`, `key_value()`
+- **Issue**: Like `key_state()`, this function processes one line at a time and doesn't handle quoted values spanning multiple lines or backslash continuations. This is consistent with the existing `key_state()` behavior and appropriate for a `.env` parser that explicitly documents "strict `KEY=value` format."
+- **Remediation**: No change needed; the existing behavior is consistent and documented.
+
+---
+
+### [LOW]: `remove_region_if_unmodified` — Legacy Body Comparison Is Exact String Match
+
+- **Location**: `scripts/local/engine-consumer.sh`, `remove_region_if_unmodified()`
+- **Issue**: The `$4` legacy body parameter is compared with `[ "$REGION_BODY_NOW" != "$4" ]`. This works correctly for exact matches. However, if a consumer has the legacy body with a trailing newline difference (e.g., their editor added a trailing newline after the region content), it would not match as "unmodified" and would be incorrectly preserved as "customized." This is an edge case in existing pre-KIT-0084 consumers.
+- **Remediation**: Low risk. The `kit_markers extract` output is deterministic, so trailing newline differences are unlikely. No change needed.
+
+---
+
+### [MEDIUM]: `offer_env_carryover` — TTY Path Calls `copy_env_into_target` Which Calls `exit 1`
+
+- **Location**: `scripts/local/bootstrap`, `offer_env_carryover()` and `copy_env_into_target()`
+- **Issue**: When the operator answers "yes" to the consent prompt, `copy_env_into_target` is called with the kit's `.env` as source. If the gitignore check fails (`git check-ignore -q .env` returns non-zero), `copy_env_into_target` calls `exit 1`. This is correct behavior — but in the TTY path, the operator has just been prompted and consented, and then the process exits with "refusing to seed secrets." The error message is accurate but the UX is slightly jarring (consent granted, then immediate exit). This is acceptable since the gitignore check should pass (it was already verified during `seed_env_from_template`), but if the `.env` somehow got un-gitignored between those two calls, the error is correct.
+- **Remediation**: Not a bug; the defense-in-depth check is correct. No change needed.
+
+---
+
+### [LOW]: `test_no_kit_rebootstrap_removes_legacy_first_session_body` — Fragile String Splitting
+
+- **Location**: `tests/test_bootstrap_shapes.py`, `test_no_kit_rebootstrap_removes_legacy_first_session_body()`
+- **Issue**: The test uses `.split(begin)` and `.split(end)` to manipulate CLAUDE.md content. If `begin` or `end` appear more than once in the file (e.g., the file already has two first-session regions due to a bug being tested), `split()` with no maxsplit would produce more than 2 parts and the unpacking `head, rest = seeded.split(begin)` would raise `ValueError`. This is a test-only concern.
+- **Remediation**: Use `split(begin, 1)` and `split(end, 1)` for robustness:
+  ```python
+  head, rest = seeded.split(begin, 1)
+  _, tail = rest.split(end, 1)
+  ```
+
+---
+
+## Phase 4: Code Quality
+
+### [LOW]: `fill_env_identity` — Python Heredoc Uses BASH-Style PYEOF but Runs in Subshell
+
+- **Location**: `scripts/local/bootstrap`, `fill_env_identity()`
+- **Issue**: The `python3 - "$TARGET/.kit/context/current-state.json" 2>/dev/null <<'PYEOF' ... PYEOF` construct is correct and works properly. The `2>/dev/null` suppresses errors (e.g., missing JSON file), and the `|| prefix=""` handles Python exit failures. The `[ -n "$prefix" ] || prefix="$PREFIX"` fallback to the CLI-supplied `$PREFIX` is a good defensive measure.
+
+  One subtle issue: if `python3` is not available on `PATH`, the command substitution itself might fail. Under `set -e`, this would exit the script. The `2>/dev/null` only suppresses stderr, not the exit code. The `|| prefix=""` handles this correctly since it catches any non-zero exit.
+- **Remediation**: No change needed; the error handling is correct.
+
+---
+
+### [LOW]: Inconsistent Quoting in `offer_env_carryover` Printed Command
+
+- **Location**: `scripts/local/bootstrap`, `offer_env_carryover()`, non-TTY branch
+- **Issue**: The printed copy command `cp $kit_env $TARGET/.env && chmod 600 $TARGET/.env` is printed without quoting the paths. If `$kit_env` or `$TARGET` contain spaces or special characters, the printed command would be incorrect when copy-pasted.
+- **Remediation**: Quote the paths in the printed command:
+  ```bash
+  echo "    cp \"$kit_env\" \"$TARGET/.env\" && chmod 600 \"$TARGET/.env\""
+  ```
+  This is a UX issue, not a security issue (the values are not being executed here, only printed).
+
+---
+
+### [POSITIVE]: Comprehensive Test Coverage
+
+The PR adds well-structured tests:
+- `TestTaskPrefixWarn` covers all three warn cases (empty, missing, placeholder) plus combined warnings and commented-line behavior
+- `TestEnvSeedingE2E` covers single/planning shapes, preset env-source path, and the non-TTY carry-over message
+- `TestFillEnvIdentityUnits` tests the in-memory rewrite in isolation via `sourced()`
+- The legacy body upgrade path test is well-designed and tests the exact scenario it was built for
+
+### [POSITIVE]: Security Boundary Clearly Documented
+
+The operator/agent boundary is explicitly documented in multiple places (bootstrap header comment, `docs/STARTING-A-PROJECT.md`, `offer_env_carryover()` comments, CLAUDE.md first-session region). The rationale (permission classifier blocks agent-side key copies) is accurate and actionable.
+
+### [POSITIVE]: Upgrade Path Handled
+
+The `FIRST_SESSION_BODY_LEGACY` mechanism for handling pre-KIT-0084 consumers on `--no-kit` re-bootstrap is clean and the test covers it specifically.
+
+### [POSITIVE]: GIT_* Variable Scrubbing
+
+Both `bootstrap` and `engine-consumer.sh` scrub all `GIT_*` variables at startup, preventing the KIT-0048 class of GIT_DIR leak corruption.
+
+---
+
+## Context Required / Unverifiable
+
+- The behavior of `is_tty` in CI and automated environments cannot be confirmed without runtime context. Tests use `stdin=subprocess.DEVNULL` which correctly triggers the non-TTY path.
+- The `stat -f '%Lp'` (macOS) vs `stat -c '%a'` (Linux) fallback for mode checking is inherited from existing code and assumed correct.
+- The `git check-ignore` behavior with `.gitignore` patterns containing `.env` is assumed to work as expected; this is not exercised with a real `.gitignore` in `TestFillEnvIdentityUnits` (only in `TestEnvSeedingE2E`).
+- Whether the Claude Code permission classifier actually blocks agent-side `.env` writes is a runtime claim that cannot be verified from the code alone.
+
+---
+
+## Overall Assessment
+
+**APPROVED**
+
+The implementation is security-conscious and well-executed. The critical path — secret file creation — correctly implements umask-first permissions, gitignore verification, and non-printing discipline. Values are passed to `awk` via environment variables, not string interpolation. The operator/agent boundary is clearly defined and documented. Test coverage is thorough with both unit and E2E tests.
+
+The findings are:
+- Two **MEDIUM** issues: an acknowledged trade-off (shell variable holding `.env` contents during rewrite) and a cosmetic trailing-newline behavior — neither is a security vulnerability
+- Three **LOW** issues: a missing mode-check before printing the carry-over command, a test robustness improvement, and a UX issue with unquoted paths in printed commands
+
+None of these block production readiness. The medium findings should be tracked as follow-up improvements but do not require rework before merge.

--- a/.kit/context/reviews/KIT-0084-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0084-evaluator-review.md
@@ -81,7 +81,7 @@
 
 #  Code Reviewer Fast V2
 
-**Source**: /Users/broadcaster_one/Github/ask-worktrees/KIT-0084/.adversarial/inputs/KIT-0084-code-review-input.md
+**Source**: .adversarial/inputs/KIT-0084-code-review-input.md
 **Evaluator**: code-reviewer-fast-v2
 **Model**: gemini/gemini-3-flash-preview
 **Generated**: 2026-08-04 19:44 UTC
@@ -157,7 +157,7 @@ The logic for `doctor` and `bootstrap` is slightly inconsistent regarding how it
 
 #  Code Reviewer
 
-**Source**: /Users/broadcaster_one/Github/ask-worktrees/KIT-0084/.adversarial/inputs/KIT-0084-code-review-input.md
+**Source**: .adversarial/inputs/KIT-0084-code-review-input.md
 **Evaluator**: code-reviewer
 **Model**: o3
 **Generated**: 2026-08-04 19:33 UTC
@@ -250,7 +250,7 @@ Found 6 non-trivial edge-case/logic problems (2 immediate correctness bugs, 3 la
 
 #  Claude Code
 
-**Source**: /Users/broadcaster_one/Github/ask-worktrees/KIT-0084/.adversarial/inputs/KIT-0084-code-review-input.md
+**Source**: .adversarial/inputs/KIT-0084-code-review-input.md
 **Evaluator**: claude-code
 **Model**: anthropic/claude-sonnet-4-6
 **Generated**: 2026-08-04 19:35 UTC

--- a/.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md
+++ b/.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md
@@ -1,6 +1,6 @@
 # KIT-0084: New projects start with a working .env — seeded, filled, operator-consented
 
-**Status**: Todo
+**Status**: In Progress
 **Priority**: high (blocks the first evaluation in every fresh project; agents cannot self-serve the fix)
 **Type**: Infrastructure
 **Estimated Effort**: 3-5 h

--- a/.kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md
+++ b/.kit/tasks/4-in-review/KIT-0084-working-env-from-day-one.md
@@ -1,6 +1,6 @@
 # KIT-0084: New projects start with a working .env — seeded, filled, operator-consented
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: high (blocks the first evaluation in every fresh project; agents cannot self-serve the fix)
 **Type**: Infrastructure
 **Estimated Effort**: 3-5 h

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -275,6 +275,24 @@ prepares and assigns tasks, feature developers implement them in their
 own tabs, and completion gates (`/preflight`, review bots, evaluators)
 keep the work honest.
 
+## API keys: the operator moves them, never an agent
+
+Every `--new` project starts with a working `.env`: the door seeds it
+(mode 0600, gitignored) from your preset's `env-source` when you have
+one, else from the project's own `.env.template`, and fills
+`PROJECT_NAME`/`TASK_PREFIX`. What the door cannot invent is your API
+keys. With no `env-source`, a terminal run asks you before copying the
+kit clone's `.env`; a non-interactive run prints the exact `cp`
+command for you to run.
+
+**Run that command yourself — do not ask an agent to.** Copying key
+material into a project is an operator-only act: the Claude Code
+permission classifier blocks agents from doing it (correctly — secrets
+handling), so an agent session asked to "fix the missing keys" can
+only stall. The seeded `CLAUDE.md` first-session note and
+`project doctor`'s `env-keys` check both surface a skipped copy before
+it can block your first evaluation.
+
 ## Checking your environment
 
 Whenever something seems off — missing tools, keys, or config — run

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -284,8 +284,8 @@ one, else from the project's own `.env.template`, and fills
 keys. With no `env-source`, a terminal run asks you before copying the
 kit clone's `.env` — the whole file, replacing the just-seeded
 template copy (the door re-fills `PROJECT_NAME`/`TASK_PREFIX`
-afterwards); a non-interactive run prints the exact `cp` command for
-you to run.
+afterward); a non-interactive run prints the exact copy command
+(`install -m 600 …`) for you to run.
 
 **Run that command yourself — do not ask an agent to.** Copying key
 material into a project is an operator-only act: the Claude Code

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -282,8 +282,10 @@ Every `--new` project starts with a working `.env`: the door seeds it
 one, else from the project's own `.env.template`, and fills
 `PROJECT_NAME`/`TASK_PREFIX`. What the door cannot invent is your API
 keys. With no `env-source`, a terminal run asks you before copying the
-kit clone's `.env`; a non-interactive run prints the exact `cp`
-command for you to run.
+kit clone's `.env` — the whole file, replacing the just-seeded
+template copy (the door re-fills `PROJECT_NAME`/`TASK_PREFIX`
+afterwards); a non-interactive run prints the exact `cp` command for
+you to run.
 
 **Run that command yourself — do not ask an agent to.** Copying key
 material into a project is an operator-only act: the Claude Code

--- a/scripts/core/doctor.d/20-env-keys.py
+++ b/scripts/core/doctor.d/20-env-keys.py
@@ -29,6 +29,10 @@ from pathlib import Path
 REQUIRED_KEYS = ["ANTHROPIC_API_KEY"]
 # WARN-level: o3 / Gemini evaluators silently drop out without these.
 RECOMMENDED_KEYS = ["OPENAI_API_KEY", "GEMINI_API_KEY"]
+# WARN-level (KIT-0084): TASK_PREFIX left unset or at the old template
+# placeholder is silently-wrong project identity — the door writes it
+# empty on planning-shape --new precisely so this check surfaces it.
+PREFIX_PLACEHOLDER = "TASK"
 
 
 def key_state(lines, key):
@@ -63,6 +67,29 @@ def key_state(lines, key):
     return state
 
 
+def key_value(lines, key):
+    """Effective value of key, normalized like key_state (comments and
+    quotes stripped, `export ` accepted, first NON-EMPTY assignment
+    wins). Returns None when no uncommented assignment exists at all.
+    Only ever called for non-secret identity keys — key_state stays the
+    reader for key material.
+    """
+    value_seen = None
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("export "):
+            stripped = stripped[len("export ") :].lstrip()
+        if stripped.startswith(f"{key}="):
+            _, _, value = stripped.partition("=")
+            value = value.split("#", 1)[0].strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1].strip()
+            if value:
+                return value
+            value_seen = ""
+    return value_seen
+
+
 def main():
     root = Path(os.environ.get("DOCTOR_ROOT") or Path(__file__).resolve().parents[3])
     env_file = root / ".env"
@@ -90,16 +117,26 @@ def main():
         print(f"DOCTOR:env-keys:FAIL:{'; '.join(problems)} in .env")
         return 0
 
+    warn_parts = []
     warnings = []
     for key in RECOMMENDED_KEYS:
         if key_state(lines, key) != "present":
             warnings.append(key)
     if warnings:
-        print(
-            "DOCTOR:env-keys:WARN:evaluator keys not set: "
+        warn_parts.append(
+            "evaluator keys not set: "
             + ", ".join(warnings)
             + " — those evaluators will drop out of the trio"
         )
+    prefix = key_value(lines, "TASK_PREFIX")
+    if prefix is None or prefix == "" or prefix == PREFIX_PLACEHOLDER:
+        warn_parts.append(
+            "TASK_PREFIX not set (empty, missing, or the 'TASK' placeholder)"
+            " — set your project's task prefix in .env (decided at intake"
+            " Step 4a / project onboarding)"
+        )
+    if warn_parts:
+        print("DOCTOR:env-keys:WARN:" + "; ".join(warn_parts))
         return 0
 
     print(

--- a/scripts/core/doctor.d/20-env-keys.py
+++ b/scripts/core/doctor.d/20-env-keys.py
@@ -78,24 +78,23 @@ def key_state(lines, key):
 
 
 def key_value(lines, key):
-    """Effective value of key, normalized like key_state (comments and
-    quotes stripped, `export ` accepted, first NON-EMPTY assignment
-    wins). Returns None when no uncommented assignment exists at all.
-    Only ever called for non-secret identity keys — key_state stays the
-    reader for key material.
+    """Effective value of key for identity checks: the LAST uncommented
+    assignment wins, matching dotenv semantics (CodeRabbit, KIT-0084 —
+    key_state's first-non-empty scan serves key PRESENCE, where the
+    copy-template-then-append layout matters; a VALUE check must report
+    what a parser would actually load). Comments and quotes stripped,
+    `export ` accepted. Returns None when no uncommented assignment
+    exists at all. Only ever called for non-secret identity keys —
+    key_state stays the reader for key material.
     """
-    value_seen = None
-    for line in lines:
+    for line in reversed(lines):
         stripped = line.strip()
         if stripped.startswith("export "):
             stripped = stripped[len("export ") :].lstrip()
         if stripped.startswith(f"{key}="):
             _, _, value = stripped.partition("=")
-            value = _effective_value(value)
-            if value:
-                return value
-            value_seen = ""
-    return value_seen
+            return _effective_value(value)
+    return None
 
 
 def main():

--- a/scripts/core/doctor.d/20-env-keys.py
+++ b/scripts/core/doctor.d/20-env-keys.py
@@ -35,6 +35,22 @@ RECOMMENDED_KEYS = ["OPENAI_API_KEY", "GEMINI_API_KEY"]
 PREFIX_PLACEHOLDER = "TASK"
 
 
+def _effective_value(raw):
+    """Normalize an assignment's right-hand side: a QUOTED value keeps
+    everything inside the quotes (a '#' inside quotes is data — the
+    old split-then-unquote order corrupted such values, fast-v2
+    evaluator KIT-0084); an unquoted trailing `# comment` is not a
+    value, and quoted-empty ("" / '') is empty — KEY="" or
+    KEY= # placeholder must not PASS an unusable env.
+    """
+    value = raw.strip()
+    if value and value[0] in "\"'":
+        closing = value.find(value[0], 1)
+        if closing != -1:
+            return value[1:closing].strip()
+    return value.split("#", 1)[0].strip()
+
+
 def key_state(lines, key):
     """Return 'present', 'commented', or 'missing' for key. Values unread.
 
@@ -52,13 +68,7 @@ def key_state(lines, key):
             stripped = stripped[len("export ") :].lstrip()
         if stripped.startswith(f"{key}="):
             _, _, value = stripped.partition("=")
-            # normalize before judging: an unquoted trailing `# comment`
-            # is not a value, and quoted-empty ("" / '') is empty —
-            # KEY="" or KEY= # placeholder must not PASS an unusable env
-            value = value.split("#", 1)[0].strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-                value = value[1:-1].strip()
-            if value:
+            if _effective_value(value):
                 return "present"
             state = "commented"
             continue
@@ -81,9 +91,7 @@ def key_value(lines, key):
             stripped = stripped[len("export ") :].lstrip()
         if stripped.startswith(f"{key}="):
             _, _, value = stripped.partition("=")
-            value = value.split("#", 1)[0].strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-                value = value[1:-1].strip()
+            value = _effective_value(value)
             if value:
                 return value
             value_seen = ""

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -89,6 +89,18 @@
 # folder itself). Author a preset conversationally with the
 # /setup-preset command; example file: docs/preset.example.
 #
+# Working .env from day one (KIT-0084): every --new target ends with a
+# present, mode-0600, gitignored .env — copied from the preset's
+# env-source when set, else seeded from the target's own .env.template.
+# The door then fills PROJECT_NAME (target basename) and TASK_PREFIX
+# (single shape: the export engine's derived prefix; planning shape:
+# left EMPTY until intake decides it — `project doctor` warns while it
+# is empty or the old 'TASK' placeholder). API keys move only by
+# OPERATOR action: with no env-source, a TTY run asks consent before
+# copying the kit checkout's .env, and a non-TTY run prints the exact
+# copy command and continues. Agents must never copy key material into
+# a project — the permission classifier blocks it, by design.
+#
 # Exit contract (F6):
 #   0  install succeeded — the doctor verdict is REPORTED prominently,
 #      never encoded (a fresh repo with doctor WARNs still installed)
@@ -560,11 +572,27 @@ CONFIG_README
     return 0
 }
 
+copy_env_into_target() {  # $1 source file — the ONE writer of $TARGET/.env
+    # Shared discipline for every .env seeding path (KIT-0084): the
+    # copy is refused unless .env is gitignored in the target; the file
+    # is BORN 0600 (umask-first — no window at looser permissions,
+    # claude-code review, PR #83); contents are NEVER printed, logged,
+    # or staged.
+    if ! git -C "$TARGET" check-ignore -q .env; then
+        echo "Error: .env is not gitignored in the target — refusing to seed secrets into it" >&2
+        exit 1
+    fi
+    (
+        umask 077
+        cat "$1" > "$TARGET/.env"
+    )
+    chmod 600 "$TARGET/.env"
+}
+
 apply_env_source() {  # $1 source path (from the preset) — --new only (F6)
     # Secrets by reference: the preset names an operator-owned .env
-    # template; the door copies it 0600. The contents are NEVER
-    # printed, logged, or staged — .env must be gitignored in the
-    # target or the copy is refused outright.
+    # template; the door copies it 0600 (discipline lives in
+    # copy_env_into_target).
     local src="${1/#\~/$HOME}"
     if [ ! -f "$src" ] || [ ! -r "$src" ]; then
         # defense in depth — main pre-validated both before any work
@@ -576,18 +604,98 @@ apply_env_source() {  # $1 source path (from the preset) — --new only (F6)
     if [ "$mode" != "600" ]; then
         echo "Warning: env-source $src is mode $mode (0600 expected) — tighten it: chmod 600 $src" >&2
     fi
-    if ! git -C "$TARGET" check-ignore -q .env; then
-        echo "Error: .env is not gitignored in the target — refusing to seed secrets from env-source" >&2
-        exit 1
+    copy_env_into_target "$src"
+    echo "Seeded .env from preset env-source (mode 0600, gitignored; contents never printed)"
+}
+
+seed_env_from_template() {  # KIT-0084 F1 — --new with no env-source preset
+    # Fallback seeding: the target's own .env.template. It carries no
+    # secrets, but the seeded file will — so the same discipline as
+    # the env-source path applies from birth.
+    if [ ! -f "$TARGET/.env.template" ]; then
+        echo "Warning: no .env.template in the target — .env not seeded; create it by hand (chmod 600)" >&2
+        return 0
     fi
-    # umask-first so the file is BORN 0600 — no window at looser
-    # permissions (claude-code review, this PR)
+    copy_env_into_target "$TARGET/.env.template"
+    echo "Seeded .env from .env.template (mode 0600, gitignored) — API keys still to be added"
+}
+
+offer_env_carryover() {  # KIT-0084 F3 — operator-consented key carry-over
+    # Key material moves ONLY by operator action. The door runs under
+    # the operator's own hands, so a TTY consent question is the
+    # acceptable surface; agents must never copy keys into a project
+    # (the permission classifier blocks it — correctly, so a non-TTY
+    # run prints the exact command for the operator and continues).
+    local kit_env="$PROJECT_ROOT/.env"
+    if [ ! -f "$kit_env" ] || [ ! -r "$kit_env" ]; then
+        echo "No API keys seeded — add them to $TARGET/.env ('project doctor' names what is missing)"
+        return 0
+    fi
+    if is_tty; then
+        local ans
+        ans="$(prompt_yn "Copy API keys from $kit_env into the new project's .env?")"
+        if [ "$ans" = "yes" ]; then
+            copy_env_into_target "$kit_env"
+            echo "Seeded .env from $kit_env (mode 0600, gitignored; contents never printed)"
+        else
+            echo "Keys not copied — add them to $TARGET/.env yourself, or run:"
+            echo "    cp $kit_env $TARGET/.env && chmod 600 $TARGET/.env"
+            echo "  (then re-check PROJECT_NAME/TASK_PREFIX in it — 'project doctor' flags them)"
+        fi
+    else
+        echo "API keys not seeded (non-interactive) — as the operator, run:"
+        echo "    cp $kit_env $TARGET/.env && chmod 600 $TARGET/.env"
+        echo "  (operator-only: agents must never copy key material; then re-check"
+        echo "   PROJECT_NAME/TASK_PREFIX in it and re-run 'project doctor')"
+    fi
+}
+
+fill_env_identity() {  # KIT-0084 F2 — PROJECT_NAME/TASK_PREFIX, --new only
+    [ -f "$TARGET/.env" ] || return 0
+    local name prefix=""
+    name="$(basename "$TARGET")"
+    if [ "$SHAPE" = "single" ]; then
+        # the export engine already derived and recorded the prefix
+        # (from --prefix or the name's initials) — read the recorded
+        # value rather than re-deriving it here
+        prefix="$(python3 - "$TARGET/.kit/context/current-state.json" 2>/dev/null <<'PYEOF'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as f:
+        print(json.load(f)["project"]["task_prefix"])
+except (OSError, ValueError, KeyError):
+    pass
+PYEOF
+)" || prefix=""
+        [ -n "$prefix" ] || prefix="$PREFIX"
+    fi
+    # planning shape: no prefix exists at door time — written EMPTY,
+    # never 'TASK'; intake decides it and doctor warns meanwhile.
+    # Rewrite in memory (no temp file: a leaked temp beside .env would
+    # not be gitignored), values passed via ENVIRON — never
+    # interpolated into the awk program.
+    local content
+    content="$(ENV_NAME="$name" ENV_PREFIX="$prefix" awk '
+        !seen_name && /^PROJECT_NAME=/ {
+            print "PROJECT_NAME=" ENVIRON["ENV_NAME"]; seen_name = 1; next
+        }
+        !seen_prefix && /^TASK_PREFIX=/ {
+            print "TASK_PREFIX=" ENVIRON["ENV_PREFIX"]; seen_prefix = 1; next
+        }
+        { print }
+        END {
+            if (!seen_name) print "PROJECT_NAME=" ENVIRON["ENV_NAME"]
+            if (!seen_prefix) print "TASK_PREFIX=" ENVIRON["ENV_PREFIX"]
+        }
+    ' "$TARGET/.env")"
     (
         umask 077
-        cat "$src" > "$TARGET/.env"
+        printf '%s\n' "$content" > "$TARGET/.env"
     )
     chmod 600 "$TARGET/.env"
-    echo "Seeded .env from preset env-source (mode 0600, gitignored; contents never printed)"
+    echo "Project identity written to .env: PROJECT_NAME=$name TASK_PREFIX=${prefix:-(empty — set at intake; doctor warns until then)}"
 }
 
 run_offers() {
@@ -909,9 +1017,17 @@ main() {
             { echo "Error: consumer engine failed (exit $?)" >&2; exit 1; }
     fi
 
-    # ── Secrets by reference (F6): preset env-source, --new only ──
-    if [ -n "$ENV_SOURCE" ]; then
-        apply_env_source "$ENV_SOURCE"
+    # ── Working .env from day one (KIT-0084) — --new only: seed from
+    #    the preset env-source (F6) or the target's template, offer the
+    #    operator key carry-over, then fill the identity fields ──
+    if [ "$MODE" = "new" ]; then
+        if [ -n "$ENV_SOURCE" ]; then
+            apply_env_source "$ENV_SOURCE"
+        else
+            seed_env_from_template
+            offer_env_carryover
+        fi
+        fill_env_identity
     fi
 
     run_offers

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -631,6 +631,13 @@ offer_env_carryover() {  # KIT-0084 F3 — operator-consented key carry-over
         echo "No API keys seeded — add them to $TARGET/.env ('project doctor' names what is missing)"
         return 0
     fi
+    # same source-mode courtesy warning as apply_env_source (claude-code
+    # review, this PR)
+    local mode
+    mode="$(stat -f '%Lp' "$kit_env" 2>/dev/null || stat -c '%a' "$kit_env" 2>/dev/null || echo unknown)"
+    if [ "$mode" != "600" ]; then
+        echo "Warning: $kit_env is mode $mode (0600 expected) — tighten it: chmod 600 $kit_env" >&2
+    fi
     if is_tty; then
         local ans
         ans="$(prompt_yn "Copy API keys from $kit_env into the new project's .env?")"
@@ -639,18 +646,20 @@ offer_env_carryover() {  # KIT-0084 F3 — operator-consented key carry-over
             echo "Seeded .env from $kit_env (mode 0600, gitignored; contents never printed)"
         else
             echo "Keys not copied — add them to $TARGET/.env yourself, or run:"
-            echo "    cp $kit_env $TARGET/.env && chmod 600 $TARGET/.env"
+            echo "    cp \"$kit_env\" \"$TARGET/.env\" && chmod 600 \"$TARGET/.env\""
             echo "  (then re-check PROJECT_NAME/TASK_PREFIX in it — 'project doctor' flags them)"
         fi
     else
         echo "API keys not seeded (non-interactive) — as the operator, run:"
-        echo "    cp $kit_env $TARGET/.env && chmod 600 $TARGET/.env"
+        echo "    cp \"$kit_env\" \"$TARGET/.env\" && chmod 600 \"$TARGET/.env\""
         echo "  (operator-only: agents must never copy key material; then re-check"
         echo "   PROJECT_NAME/TASK_PREFIX in it and re-run 'project doctor')"
     fi
 }
 
 fill_env_identity() {  # KIT-0084 F2 — PROJECT_NAME/TASK_PREFIX, --new only
+    # Callers must have seeded $TARGET/.env via copy_env_into_target
+    # (which verifies the gitignore) — this rewrite adds no new file.
     [ -f "$TARGET/.env" ] || return 0
     local name prefix=""
     name="$(basename "$TARGET")"
@@ -664,25 +673,41 @@ import sys
 
 try:
     with open(sys.argv[1], encoding="utf-8") as f:
-        print(json.load(f)["project"]["task_prefix"])
+        value = json.load(f)["project"]["task_prefix"]
 except (OSError, ValueError, KeyError):
-    pass
+    value = None
+# a JSON null must yield nothing, never the string "None" (fast-v2
+# evaluator, this PR)
+if isinstance(value, str):
+    print(value)
 PYEOF
 )" || prefix=""
         [ -n "$prefix" ] || prefix="$PREFIX"
     fi
+    # newlines/CRs in a folder name or prefix would smuggle extra
+    # assignments into .env — strip them (o3 review, this PR; the
+    # values are operator-owned, so this is hardening, not a trust
+    # boundary)
+    name="${name//$'\n'/}"; name="${name//$'\r'/}"
+    prefix="${prefix//$'\n'/}"; prefix="${prefix//$'\r'/}"
     # planning shape: no prefix exists at door time — written EMPTY,
     # never 'TASK'; intake decides it and doctor warns meanwhile.
     # Rewrite in memory (no temp file: a leaked temp beside .env would
     # not be gitignored), values passed via ENVIRON — never
     # interpolated into the awk program.
+    # first assignment rewritten, later DUPLICATES dropped — dotenv
+    # parsers are last-assignment-wins, so a surviving duplicate would
+    # silently override the identity just written (fast-v2 evaluator,
+    # this PR)
     local content
     content="$(ENV_NAME="$name" ENV_PREFIX="$prefix" awk '
-        !seen_name && /^PROJECT_NAME=/ {
-            print "PROJECT_NAME=" ENVIRON["ENV_NAME"]; seen_name = 1; next
+        /^PROJECT_NAME=/ {
+            if (!seen_name++) print "PROJECT_NAME=" ENVIRON["ENV_NAME"]
+            next
         }
-        !seen_prefix && /^TASK_PREFIX=/ {
-            print "TASK_PREFIX=" ENVIRON["ENV_PREFIX"]; seen_prefix = 1; next
+        /^TASK_PREFIX=/ {
+            if (!seen_prefix++) print "TASK_PREFIX=" ENVIRON["ENV_PREFIX"]
+            next
         }
         { print }
         END {
@@ -690,6 +715,8 @@ PYEOF
             if (!seen_prefix) print "TASK_PREFIX=" ENVIRON["ENV_PREFIX"]
         }
     ' "$TARGET/.env")"
+    # command substitution strips trailing newlines; printf restores
+    # exactly one — trailing blank lines collapse, which is fine here
     (
         umask 077
         printf '%s\n' "$content" > "$TARGET/.env"

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -645,13 +645,15 @@ offer_env_carryover() {  # KIT-0084 F3 — operator-consented key carry-over
             copy_env_into_target "$kit_env"
             echo "Seeded .env from $kit_env (mode 0600, gitignored; contents never printed)"
         else
+            # install -m 600: the copy is BORN 0600 — a cp+chmod pair
+            # would open a window at the source's mode (CodeRabbit)
             echo "Keys not copied — add them to $TARGET/.env yourself, or run:"
-            echo "    cp \"$kit_env\" \"$TARGET/.env\" && chmod 600 \"$TARGET/.env\""
+            echo "    install -m 600 \"$kit_env\" \"$TARGET/.env\""
             echo "  (then re-check PROJECT_NAME/TASK_PREFIX in it — 'project doctor' flags them)"
         fi
     else
         echo "API keys not seeded (non-interactive) — as the operator, run:"
-        echo "    cp \"$kit_env\" \"$TARGET/.env\" && chmod 600 \"$TARGET/.env\""
+        echo "    install -m 600 \"$kit_env\" \"$TARGET/.env\""
         echo "  (operator-only: agents must never copy key material; then re-check"
         echo "   PROJECT_NAME/TASK_PREFIX in it and re-run 'project doctor')"
     fi

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -640,7 +640,7 @@ offer_env_carryover() {  # KIT-0084 F3 — operator-consented key carry-over
     fi
     if is_tty; then
         local ans
-        ans="$(prompt_yn "Copy API keys from $kit_env into the new project's .env?")"
+        ans="$(prompt_yn "Copy the kit clone's .env — the WHOLE file, all keys and settings — from $kit_env into the new project's .env?")"
         if [ "$ans" = "yes" ]; then
             copy_env_into_target "$kit_env"
             echo "Seeded .env from $kit_env (mode 0600, gitignored; contents never printed)"
@@ -685,11 +685,12 @@ PYEOF
         [ -n "$prefix" ] || prefix="$PREFIX"
     fi
     # newlines/CRs in a folder name or prefix would smuggle extra
-    # assignments into .env — strip them (o3 review, this PR; the
-    # values are operator-owned, so this is hardening, not a trust
-    # boundary)
-    name="${name//$'\n'/}"; name="${name//$'\r'/}"
-    prefix="${prefix//$'\n'/}"; prefix="${prefix//$'\r'/}"
+    # assignments into .env, and quote characters cannot be written
+    # into a dotenv line faithfully — strip them (o3 + CodeRabbit
+    # reviews, this PR; the values are operator-owned, so this is
+    # hardening, not a trust boundary)
+    name="${name//[$'\n'$'\r'\"\']/}"
+    prefix="${prefix//[$'\n'$'\r'\"\']/}"
     # planning shape: no prefix exists at door time — written EMPTY,
     # never 'TASK'; intake decides it and doctor warns meanwhile.
     # Rewrite in memory (no temp file: a leaked temp beside .env would
@@ -699,31 +700,50 @@ PYEOF
     # parsers are last-assignment-wins, so a surviving duplicate would
     # silently override the identity just written (fast-v2 evaluator,
     # this PR)
-    # indentation tolerated to stay in step with the doctor's reader,
-    # which strips lines before matching (fast-v2 round 2)
+    # indentation and an `export ` prefix tolerated to stay in step
+    # with the doctor's reader (fast-v2 round 2; CodeRabbit). Values
+    # carrying '#', spaces, or tabs are written double-quoted so a
+    # dotenv parser (and the doctor) reads them back intact — safe
+    # because quote characters were stripped above.
     local content
     content="$(ENV_NAME="$name" ENV_PREFIX="$prefix" awk '
-        /^[[:space:]]*PROJECT_NAME=/ {
-            if (!seen_name++) print "PROJECT_NAME=" ENVIRON["ENV_NAME"]
+        function emit(k, v) {
+            if (v ~ /[# \t]/) print k "=\"" v "\""
+            else print k "=" v
+        }
+        /^[[:space:]]*(export[[:space:]]+)?PROJECT_NAME=/ {
+            if (!seen_name++) emit("PROJECT_NAME", ENVIRON["ENV_NAME"])
             next
         }
-        /^[[:space:]]*TASK_PREFIX=/ {
-            if (!seen_prefix++) print "TASK_PREFIX=" ENVIRON["ENV_PREFIX"]
+        /^[[:space:]]*(export[[:space:]]+)?TASK_PREFIX=/ {
+            if (!seen_prefix++) emit("TASK_PREFIX", ENVIRON["ENV_PREFIX"])
             next
         }
         { print }
         END {
-            if (!seen_name) print "PROJECT_NAME=" ENVIRON["ENV_NAME"]
-            if (!seen_prefix) print "TASK_PREFIX=" ENVIRON["ENV_PREFIX"]
+            if (!seen_name) emit("PROJECT_NAME", ENVIRON["ENV_NAME"])
+            if (!seen_prefix) emit("TASK_PREFIX", ENVIRON["ENV_PREFIX"])
         }
     ' "$TARGET/.env")"
     # command substitution strips trailing newlines; printf restores
-    # exactly one — trailing blank lines collapse, which is fine here
-    (
-        umask 077
-        printf '%s\n' "$content" > "$TARGET/.env"
-    )
-    chmod 600 "$TARGET/.env"
+    # exactly one — trailing blank lines collapse, which is fine here.
+    # Temp-then-mv so a failed write never truncates the operator's
+    # .env (CodeRabbit); the temp lives inside .git/ when possible so
+    # an interrupted run can never leave stageable key material.
+    local tmpdir="$TARGET"
+    [ -d "$TARGET/.git" ] && tmpdir="$TARGET/.git"
+    local tmp
+    tmp="$(mktemp "$tmpdir/.env-rewrite.XXXXXX")" || {
+        echo "Error: could not create temp file for the .env rewrite" >&2
+        exit 1
+    }
+    if ! printf '%s\n' "$content" > "$tmp"; then
+        rm -f "$tmp"
+        echo "Error: .env rewrite failed — the seeded .env is untouched" >&2
+        exit 1
+    fi
+    chmod 600 "$tmp"
+    mv "$tmp" "$TARGET/.env"
     echo "Project identity written to .env: PROJECT_NAME=$name TASK_PREFIX=${prefix:-(empty — set at intake; doctor warns until then)}"
 }
 

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -699,13 +699,15 @@ PYEOF
     # parsers are last-assignment-wins, so a surviving duplicate would
     # silently override the identity just written (fast-v2 evaluator,
     # this PR)
+    # indentation tolerated to stay in step with the doctor's reader,
+    # which strips lines before matching (fast-v2 round 2)
     local content
     content="$(ENV_NAME="$name" ENV_PREFIX="$prefix" awk '
-        /^PROJECT_NAME=/ {
+        /^[[:space:]]*PROJECT_NAME=/ {
             if (!seen_name++) print "PROJECT_NAME=" ENVIRON["ENV_NAME"]
             next
         }
-        /^TASK_PREFIX=/ {
+        /^[[:space:]]*TASK_PREFIX=/ {
             if (!seen_prefix++) print "TASK_PREFIX=" ENVIRON["ENV_PREFIX"]
             next
         }

--- a/scripts/local/engine-consumer.sh
+++ b/scripts/local/engine-consumer.sh
@@ -888,6 +888,9 @@ fi
 # letting the awk below eat everything to EOF (fast-gate evaluator
 # round 2, KIT-0067). Only for regions an install MODE invalidates.
 remove_region_if_unmodified() {
+    # $4 (optional): a LEGACY seeded body — a consumer seeded before
+    # the kit's text changed still carries the old body verbatim, and
+    # that is "unmodified", not "customized" (KIT-0084 upgrade path).
     if ! printf '%s\n' "$REGIONS_OUT" | grep -qx "$1"; then
         return 0
     fi
@@ -896,7 +899,7 @@ remove_region_if_unmodified() {
         echo "       $REGION_BODY_NOW"
         exit 1
     fi
-    if [ "$REGION_BODY_NOW" != "$2" ]; then
+    if [ "$REGION_BODY_NOW" != "$2" ] && { [ -z "${4:-}" ] || [ "$REGION_BODY_NOW" != "$4" ]; }; then
         echo "  $1 region customized — left in place (consumer-owned)"
         return 0
     fi
@@ -916,12 +919,15 @@ remove_region_if_unmodified() {
 # closes by telling a cold-open session what to do first. Only where
 # the planner actually ships (--no-kit prunes the kit agents — and
 # removes an unmodified region left by an earlier kit-enabled install).
-FIRST_SESSION_BODY="First session in this repo: invoke the \`planner\` agent (in a new tab) — it triages the backlog and recommends what to start."
+# The pre-KIT-0084 body: consumers seeded with it and left unmodified
+# must still count as unmodified on a --no-kit re-bootstrap.
+FIRST_SESSION_BODY_LEGACY="First session in this repo: invoke the \`planner\` agent (in a new tab) — it triages the backlog and recommends what to start."
+FIRST_SESSION_BODY="First session in this repo: invoke the \`planner\` agent (in a new tab) — it triages the backlog and recommends what to start. Before the first evaluation, verify \`./scripts/core/project doctor\` reports env-keys green (API keys are operator-provisioned — see .env)."
 if [ "$KIT_ENABLED" -eq 1 ]; then
     seed_region first-session "$FIRST_SESSION_BODY" "planner self-direction"
 else
     remove_region_if_unmodified first-session "$FIRST_SESSION_BODY" \
-        "--no-kit: planner not shipped"
+        "--no-kit: planner not shipped" "$FIRST_SESSION_BODY_LEGACY"
 fi
 echo
 

--- a/tests/test_bootstrap_shapes.py
+++ b/tests/test_bootstrap_shapes.py
@@ -470,8 +470,8 @@ class TestProfiles:
         seeded = claude_path.read_text(encoding="utf-8")
         begin = "<!-- BEGIN KIT-LOCAL: first-session -->\n"
         end = "<!-- END KIT-LOCAL: first-session -->"
-        head, rest = seeded.split(begin)
-        _, tail = rest.split(end)
+        head, rest = seeded.split(begin, 1)
+        _, tail = rest.split(end, 1)
         claude_path.write_text(
             head + begin + legacy_body + "\n" + end + tail, encoding="utf-8"
         )

--- a/tests/test_bootstrap_shapes.py
+++ b/tests/test_bootstrap_shapes.py
@@ -454,6 +454,32 @@ class TestProfiles:
         assert "first-session region customized — left in place" in result.stdout
         assert custom_line in claude_path.read_text(encoding="utf-8")
 
+    def test_no_kit_rebootstrap_removes_legacy_first_session_body(self, tmp_path):
+        # KIT-0084 upgrade path: a consumer seeded BEFORE the body
+        # gained the doctor/env-keys sentence carries the legacy text
+        # verbatim — that is unmodified, not customized, and --no-kit
+        # must still remove it
+        legacy_body = (
+            "First session in this repo: invoke the `planner` agent"
+            " (in a new tab) — it triages the backlog and recommends"
+            " what to start."
+        )
+        target = make_consumer_dir(tmp_path, "legacy-body")
+        assert run_bootstrap(target).returncode == 0
+        claude_path = target / "CLAUDE.md"
+        seeded = claude_path.read_text(encoding="utf-8")
+        begin = "<!-- BEGIN KIT-LOCAL: first-session -->\n"
+        end = "<!-- END KIT-LOCAL: first-session -->"
+        head, rest = seeded.split(begin)
+        _, tail = rest.split(end)
+        claude_path.write_text(
+            head + begin + legacy_body + "\n" + end + tail, encoding="utf-8"
+        )
+        result = run_bootstrap(target, "--no-kit")
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "first-session region removed" in result.stdout
+        assert "first-session" not in claude_path.read_text(encoding="utf-8")
+
     def test_no_kit_malformed_marker_fails_loud_without_data_loss(self, tmp_path):
         # CodeRabbit (this PR): a first-session BEGIN marker whose END
         # marker is missing must abort the --no-kit re-bootstrap loudly

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -657,6 +657,24 @@ class TestTaskPrefixWarn:
         assert "DOCTOR:env-keys:WARN:" in result.stdout
         assert "TASK_PREFIX" in result.stdout
 
+    def test_quoted_value_with_hash_not_truncated(self, tmp_path):
+        """fast-v2 review: a '#' inside quotes is data, not a comment —
+        the old split-then-unquote order corrupted such values."""
+        (tmp_path / ".env").write_text(
+            self._without_prefix() + 'TASK_PREFIX="PROJ#1"\n', encoding="utf-8"
+        )
+        result = run_env_check(tmp_path)
+        assert "DOCTOR:env-keys:PASS:" in result.stdout
+
+    def test_quoted_key_with_hash_is_present(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            'ANTHROPIC_API_KEY="sk-test#part"\nOPENAI_API_KEY=x\n'
+            "GEMINI_API_KEY=y\nTASK_PREFIX=DEMO\n",
+            encoding="utf-8",
+        )
+        result = run_env_check(tmp_path)
+        assert "DOCTOR:env-keys:PASS:" in result.stdout
+
 
 def _stub_executable(path: Path, body: str) -> None:
     path.write_text("#!/bin/bash\n" + textwrap.dedent(body), encoding="utf-8")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -551,10 +551,13 @@ def run_env_check(root: Path) -> subprocess.CompletedProcess:
 class TestEnvKeysCheck:
     """F2.2: required keys present AND uncommented (KIT-0032 incident)."""
 
+    # TASK_PREFIX included: without it the identity WARN (KIT-0084)
+    # would mask the PASS these fixtures assert
     ALL_KEYS = (
         "ANTHROPIC_API_KEY=sk-test-anthropic\n"
         "OPENAI_API_KEY=sk-test-openai\n"
         "GEMINI_API_KEY=sk-test-gemini\n"
+        "TASK_PREFIX=DEMO\n"
     )
 
     def test_missing_env_file_fails(self, tmp_path):
@@ -587,7 +590,8 @@ class TestEnvKeysCheck:
 
     def test_missing_recommended_key_warns(self, tmp_path):
         (tmp_path / ".env").write_text(
-            "ANTHROPIC_API_KEY=sk-test-anthropic\nOPENAI_API_KEY=sk-test-openai\n",
+            "ANTHROPIC_API_KEY=sk-test-anthropic\nOPENAI_API_KEY=sk-test-openai\n"
+            "TASK_PREFIX=DEMO\n",
             encoding="utf-8",
         )
         result = run_env_check(tmp_path)
@@ -599,6 +603,59 @@ class TestEnvKeysCheck:
         result = run_env_check(tmp_path)
         assert "sk-test" not in result.stdout
         assert "sk-test" not in result.stderr
+
+
+class TestTaskPrefixWarn:
+    """KIT-0084 F2: TASK_PREFIX empty, missing, or the old 'TASK'
+    placeholder is silently-wrong identity — the doctor says so."""
+
+    KEYS = TestEnvKeysCheck.ALL_KEYS  # includes TASK_PREFIX=DEMO
+
+    def _without_prefix(self):
+        return self.KEYS.replace("TASK_PREFIX=DEMO\n", "")
+
+    @pytest.mark.parametrize("line", ["TASK_PREFIX=\n", "TASK_PREFIX=TASK\n", ""])
+    def test_unset_or_placeholder_warns(self, tmp_path, line):
+        (tmp_path / ".env").write_text(self._without_prefix() + line, encoding="utf-8")
+        result = run_env_check(tmp_path)
+        assert "DOCTOR:env-keys:WARN:" in result.stdout
+        assert "TASK_PREFIX" in result.stdout
+        assert "intake" in result.stdout  # the fix's decision point is named
+
+    def test_real_prefix_passes(self, tmp_path):
+        (tmp_path / ".env").write_text(self.KEYS, encoding="utf-8")
+        result = run_env_check(tmp_path)
+        assert "DOCTOR:env-keys:PASS:" in result.stdout
+
+    def test_real_prefix_value_not_printed(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            self._without_prefix() + "TASK_PREFIX=XZQ9\n", encoding="utf-8"
+        )
+        result = run_env_check(tmp_path)
+        assert "XZQ9" not in result.stdout + result.stderr
+
+    def test_combined_with_evaluator_warning_one_line(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "ANTHROPIC_API_KEY=sk-test-anthropic\nOPENAI_API_KEY=sk-test-openai\n",
+            encoding="utf-8",
+        )
+        result = run_env_check(tmp_path)
+        warn_lines = [
+            ln
+            for ln in result.stdout.splitlines()
+            if ln.startswith("DOCTOR:env-keys:WARN:")
+        ]
+        assert len(warn_lines) == 1  # one check, one protocol line
+        assert "GEMINI_API_KEY" in warn_lines[0]
+        assert "TASK_PREFIX" in warn_lines[0]
+
+    def test_commented_prefix_line_warns(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            self._without_prefix() + "# TASK_PREFIX=DEMO\n", encoding="utf-8"
+        )
+        result = run_env_check(tmp_path)
+        assert "DOCTOR:env-keys:WARN:" in result.stdout
+        assert "TASK_PREFIX" in result.stdout
 
 
 def _stub_executable(path: Path, body: str) -> None:
@@ -878,7 +935,7 @@ class TestEnvKeysDuplicates:
         (tmp_path / ".env").write_text(
             "# ANTHROPIC_API_KEY=template-placeholder\n"
             "ANTHROPIC_API_KEY=sk-test-real\n"
-            "OPENAI_API_KEY=x\nGEMINI_API_KEY=y\n",
+            "OPENAI_API_KEY=x\nGEMINI_API_KEY=y\nTASK_PREFIX=DEMO\n",
             encoding="utf-8",
         )
         result = run_env_check(tmp_path)
@@ -887,7 +944,8 @@ class TestEnvKeysDuplicates:
     def test_export_prefix_recognized(self, tmp_path):
         (tmp_path / ".env").write_text(
             "export ANTHROPIC_API_KEY=sk-test-real\n"
-            "export OPENAI_API_KEY=x\nexport GEMINI_API_KEY=y\n",
+            "export OPENAI_API_KEY=x\nexport GEMINI_API_KEY=y\n"
+            "export TASK_PREFIX=DEMO\n",
             encoding="utf-8",
         )
         result = run_env_check(tmp_path)
@@ -908,7 +966,8 @@ class TestEnvKeysDuplicates:
 
     def test_quoted_real_value_passes(self, tmp_path):
         (tmp_path / ".env").write_text(
-            'ANTHROPIC_API_KEY="sk-test-real"\nOPENAI_API_KEY=x\nGEMINI_API_KEY=y\n',
+            'ANTHROPIC_API_KEY="sk-test-real"\nOPENAI_API_KEY=x\nGEMINI_API_KEY=y\n'
+            "TASK_PREFIX=DEMO\n",
             encoding="utf-8",
         )
         result = run_env_check(tmp_path)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -657,6 +657,37 @@ class TestTaskPrefixWarn:
         assert "DOCTOR:env-keys:WARN:" in result.stdout
         assert "TASK_PREFIX" in result.stdout
 
+    def test_valid_then_placeholder_warns_last_wins(self, tmp_path):
+        """CodeRabbit (KIT-0084): dotenv parsers are last-assignment-
+        wins — a trailing placeholder overrides an earlier real value,
+        so the doctor must warn."""
+        (tmp_path / ".env").write_text(
+            self._without_prefix() + "TASK_PREFIX=DEMO\nTASK_PREFIX=TASK\n",
+            encoding="utf-8",
+        )
+        result = run_env_check(tmp_path)
+        assert "DOCTOR:env-keys:WARN:" in result.stdout
+        assert "TASK_PREFIX" in result.stdout
+
+    def test_valid_then_empty_warns_last_wins(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            self._without_prefix() + "TASK_PREFIX=DEMO\nTASK_PREFIX=\n",
+            encoding="utf-8",
+        )
+        result = run_env_check(tmp_path)
+        assert "DOCTOR:env-keys:WARN:" in result.stdout
+        assert "TASK_PREFIX" in result.stdout
+
+    def test_empty_then_valid_passes_last_wins(self, tmp_path):
+        """The copy-template-then-append layout: the template's empty
+        line comes first, the operator's real value last — last wins."""
+        (tmp_path / ".env").write_text(
+            self._without_prefix() + "TASK_PREFIX=\nTASK_PREFIX=DEMO\n",
+            encoding="utf-8",
+        )
+        result = run_env_check(tmp_path)
+        assert "DOCTOR:env-keys:PASS:" in result.stdout
+
     def test_quoted_value_with_hash_not_truncated(self, tmp_path):
         """fast-v2 review: a '#' inside quotes is data, not a comment —
         the old split-then-unquote order corrupted such values."""

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -832,7 +832,7 @@ class TestFillEnvIdentityUnits:
         target = self._target_with_env(
             tmp_path,
             "PROJECT_NAME=old-one\nOPENAI_API_KEY=x\n"
-            "PROJECT_NAME=old-two\nTASK_PREFIX=AAA\nTASK_PREFIX=BBB\n",
+            "  PROJECT_NAME=old-two\nTASK_PREFIX=AAA\nTASK_PREFIX=BBB\n",
         )
         result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
         assert result.returncode == 0, result.stderr

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -787,9 +787,14 @@ class TestEnvSeedingE2E:
 class TestFillEnvIdentityUnits:
     """KIT-0084 F2, sourced: the .env rewrite in isolation."""
 
-    def _target_with_env(self, tmp_path: Path, content: str) -> Path:
-        target = tmp_path / "unit-target"
+    def _target_with_env(
+        self, tmp_path: Path, content: str, name: str = "unit-target"
+    ) -> Path:
+        target = tmp_path / name
         target.mkdir()
+        # a .git dir so the rewrite's temp file takes its real home
+        # (inside .git/, never stageable)
+        (target / ".git").mkdir()
         (target / ".env").write_text(content, encoding="utf-8")
         (target / ".env").chmod(0o600)
         return target
@@ -842,6 +847,36 @@ class TestFillEnvIdentityUnits:
         assert name_lines == ["PROJECT_NAME=unit-target"]
         assert prefix_lines == ["TASK_PREFIX="]
         assert "OPENAI_API_KEY=x" in lines
+
+    def test_export_prefixed_duplicates_deduplicated(self, tmp_path):
+        """CodeRabbit: the doctor accepts `export KEY=`, so an exported
+        duplicate surviving the rewrite would override the identity
+        under last-wins parsers — it must be dropped too."""
+        target = self._target_with_env(
+            tmp_path,
+            "PROJECT_NAME=old\nexport PROJECT_NAME=older\n"
+            "export TASK_PREFIX=ZZZ\nOPENAI_API_KEY=x\n",
+        )
+        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
+        assert result.returncode == 0, result.stderr
+        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
+        assert [ln for ln in lines if "PROJECT_NAME" in ln] == [
+            "PROJECT_NAME=unit-target"
+        ]
+        assert [ln for ln in lines if "TASK_PREFIX" in ln] == ["TASK_PREFIX="]
+        assert "OPENAI_API_KEY=x" in lines
+
+    def test_special_char_name_written_quoted(self, tmp_path):
+        """CodeRabbit: a value carrying '#' or spaces is written
+        double-quoted so the doctor (and dotenv parsers) read it back
+        intact; quote characters themselves are stripped."""
+        target = self._target_with_env(
+            tmp_path, "PROJECT_NAME=\nTASK_PREFIX=\n", name="acme #1's"
+        )
+        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
+        assert result.returncode == 0, result.stderr
+        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
+        assert 'PROJECT_NAME="acme #1s"' in lines  # quoted; "'" stripped
 
     def test_null_recorded_prefix_writes_empty_never_none(self, tmp_path):
         """fast-v2 review: a JSON null task_prefix must never become

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -714,10 +714,8 @@ class TestEnvSeedingE2E:
         # the kit clone has a .env to carry over) or the add-keys notice
         kit_env = REPO_ROOT / ".env"
         if kit_env.is_file():
-            assert (
-                f'cp "{kit_env}" "{target}/.env" && chmod 600 "{target}/.env"'
-                in result.stdout
-            )
+            # install -m 600: the copy is born 0600, no cp+chmod window
+            assert f'install -m 600 "{kit_env}" "{target}/.env"' in result.stdout
             assert "operator" in result.stdout
         else:
             assert "No API keys seeded" in result.stdout

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -714,8 +714,9 @@ class TestEnvSeedingE2E:
         # the kit clone has a .env to carry over) or the add-keys notice
         kit_env = REPO_ROOT / ".env"
         if kit_env.is_file():
-            assert f"cp {kit_env} {target}/.env && chmod 600 {target}/.env" in (
-                result.stdout
+            assert (
+                f'cp "{kit_env}" "{target}/.env" && chmod 600 "{target}/.env"'
+                in result.stdout
             )
             assert "operator" in result.stdout
         else:
@@ -823,6 +824,39 @@ class TestFillEnvIdentityUnits:
         result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
         assert result.returncode == 0, result.stderr
         assert not (target / ".env").exists()
+
+    def test_duplicate_identity_lines_deduplicated(self, tmp_path):
+        """fast-v2/o3 review: dotenv parsers are last-assignment-wins,
+        so a surviving duplicate would silently override the identity
+        the door just wrote — later duplicates must be dropped."""
+        target = self._target_with_env(
+            tmp_path,
+            "PROJECT_NAME=old-one\nOPENAI_API_KEY=x\n"
+            "PROJECT_NAME=old-two\nTASK_PREFIX=AAA\nTASK_PREFIX=BBB\n",
+        )
+        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
+        assert result.returncode == 0, result.stderr
+        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
+        name_lines = [ln for ln in lines if ln.startswith("PROJECT_NAME=")]
+        prefix_lines = [ln for ln in lines if ln.startswith("TASK_PREFIX=")]
+        assert name_lines == ["PROJECT_NAME=unit-target"]
+        assert prefix_lines == ["TASK_PREFIX="]
+        assert "OPENAI_API_KEY=x" in lines
+
+    def test_null_recorded_prefix_writes_empty_never_none(self, tmp_path):
+        """fast-v2 review: a JSON null task_prefix must never become
+        the literal string 'None' in .env."""
+        target = self._target_with_env(tmp_path, "TASK_PREFIX=TASK\n")
+        state_dir = target / ".kit" / "context"
+        state_dir.mkdir(parents=True)
+        (state_dir / "current-state.json").write_text(
+            '{"project": {"name": "x", "task_prefix": null}}', encoding="utf-8"
+        )
+        result = sourced(f'TARGET="{target}"; SHAPE=single; fill_env_identity')
+        assert result.returncode == 0, result.stderr
+        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
+        assert "TASK_PREFIX=" in lines
+        assert "TASK_PREFIX=None" not in lines
 
 
 SECRET = "KIT0056-FIXTURE-SECRET-NEVER-PRINT"

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -19,6 +19,7 @@ it is excluded from the consumer tests/ rsync in engine-consumer.sh
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -676,6 +677,152 @@ class TestNewE2E:
         region = _kit_install_region(target)
         assert "shape: planning" in region
         assert "profile: none" in region
+
+
+def _env_lines(target: Path) -> list[str]:
+    return (target / ".env").read_text(encoding="utf-8").splitlines()
+
+
+def _assert_env_invariants(target: Path, env: dict) -> None:
+    """KIT-0084 F1: present, mode 0600, gitignored."""
+    dotenv = target / ".env"
+    assert dotenv.is_file(), ".env must be seeded on --new"
+    assert (dotenv.stat().st_mode & 0o777) == 0o600
+    check_ignore = subprocess.run(
+        ["git", "-C", str(target), "check-ignore", "-q", ".env"],
+        env=env,
+        timeout=30,
+    )
+    assert check_ignore.returncode == 0, ".env must be gitignored"
+
+
+@pytest.mark.slow
+class TestEnvSeedingE2E:
+    """KIT-0084: every --new target ends with a working, safe .env."""
+
+    def test_new_single_seeds_env_with_identity(self, tmp_path):
+        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
+        target = tmp_path / "fresh-env-app"
+        result = run_door("--new", str(target), "--prefix", "FEA", env=env)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "Seeded .env from .env.template" in result.stdout
+        _assert_env_invariants(target, env)
+        lines = _env_lines(target)
+        assert "PROJECT_NAME=fresh-env-app" in lines
+        assert "TASK_PREFIX=FEA" in lines
+        # F3, non-TTY face: the operator gets the exact command (when
+        # the kit clone has a .env to carry over) or the add-keys notice
+        kit_env = REPO_ROOT / ".env"
+        if kit_env.is_file():
+            assert f"cp {kit_env} {target}/.env && chmod 600 {target}/.env" in (
+                result.stdout
+            )
+            assert "operator" in result.stdout
+        else:
+            assert "No API keys seeded" in result.stdout
+
+    def test_new_single_default_prefix_matches_recorded_state(self, tmp_path):
+        """Without --prefix the export engine derives one; the .env line
+        must be the RECORDED value, never re-derived and never TASK."""
+        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
+        target = tmp_path / "derived-app"
+        result = run_door("--new", str(target), env=env)
+        assert result.returncode == 0, result.stderr + result.stdout
+        _assert_env_invariants(target, env)
+        state = json.loads(
+            (target / ".kit" / "context" / "current-state.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        recorded = state["project"]["task_prefix"]
+        assert recorded  # the export engine always derives something
+        lines = _env_lines(target)
+        assert f"TASK_PREFIX={recorded}" in lines
+        assert "TASK_PREFIX=TASK" not in lines
+
+    def test_new_planning_seeds_env_with_empty_prefix(self, tmp_path):
+        """Planning shape has no prefix at door time — written EMPTY
+        (doctor warns until intake decides it), never 'TASK'."""
+        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
+        target = tmp_path / "fresh-env-planning"
+        result = run_door(
+            "--new",
+            str(target),
+            "--shape",
+            "planning",
+            "--target-path",
+            "../product",
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "Seeded .env from .env.template" in result.stdout
+        _assert_env_invariants(target, env)
+        lines = _env_lines(target)
+        assert "PROJECT_NAME=fresh-env-planning" in lines
+        assert "TASK_PREFIX=" in lines  # the line exists, empty
+        assert "TASK_PREFIX=TASK" not in lines
+
+    def test_env_source_seeded_env_gets_identity_filled(self, tmp_path):
+        """The preset env-source path (F6) gains the identity fields
+        too — appended when the operator's template lacks them — and
+        the secret still never surfaces."""
+        _cfg, env = _demo_preset_env(tmp_path)
+        target = tmp_path / "preset-env-app"
+        result = run_door("--new", str(target), env=env)
+        assert result.returncode == 0, result.stderr + result.stdout
+        _assert_env_invariants(target, env)
+        lines = _env_lines(target)
+        assert f"OPENAI_API_KEY={SECRET}" in lines  # carried over intact
+        assert "PROJECT_NAME=preset-env-app" in lines
+        # appended: single shape reads the export engine's recorded prefix
+        prefix_lines = [ln for ln in lines if ln.startswith("TASK_PREFIX=")]
+        assert prefix_lines and prefix_lines[0] not in ("TASK_PREFIX=TASK",)
+        assert SECRET not in result.stdout + result.stderr
+        # env-source present → no template seeding, no carry-over offer
+        assert "Seeded .env from .env.template" not in result.stdout
+        assert "API keys not seeded" not in result.stdout
+
+
+class TestFillEnvIdentityUnits:
+    """KIT-0084 F2, sourced: the .env rewrite in isolation."""
+
+    def _target_with_env(self, tmp_path: Path, content: str) -> Path:
+        target = tmp_path / "unit-target"
+        target.mkdir()
+        (target / ".env").write_text(content, encoding="utf-8")
+        (target / ".env").chmod(0o600)
+        return target
+
+    def test_planning_rewrites_placeholder_to_empty(self, tmp_path):
+        target = self._target_with_env(
+            tmp_path, "PROJECT_NAME=\nTASK_PREFIX=TASK\nOPENAI_API_KEY=x\n"
+        )
+        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
+        assert result.returncode == 0, result.stderr
+        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
+        assert "PROJECT_NAME=unit-target" in lines
+        assert "TASK_PREFIX=" in lines
+        assert "TASK_PREFIX=TASK" not in lines
+        assert "OPENAI_API_KEY=x" in lines  # untouched
+        assert ((target / ".env").stat().st_mode & 0o777) == 0o600
+
+    def test_missing_lines_appended_commented_left_alone(self, tmp_path):
+        target = self._target_with_env(
+            tmp_path, "# PROJECT_NAME=commented\nOPENAI_API_KEY=x\n"
+        )
+        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
+        assert result.returncode == 0, result.stderr
+        text = (target / ".env").read_text(encoding="utf-8")
+        assert "# PROJECT_NAME=commented" in text  # comments never rewritten
+        assert "PROJECT_NAME=unit-target" in text.splitlines()
+        assert "TASK_PREFIX=" in text.splitlines()
+
+    def test_no_env_file_is_a_quiet_noop(self, tmp_path):
+        target = tmp_path / "no-env"
+        target.mkdir()
+        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
+        assert result.returncode == 0, result.stderr
+        assert not (target / ".env").exists()
 
 
 SECRET = "KIT0056-FIXTURE-SECRET-NEVER-PRINT"


### PR DESCRIPTION
## Summary

Closes #104. A fresh `bootstrap --new` project previously shipped only `.env.template`; the doctor flagged the missing `.env` but nothing created it, and agents cannot fix it (the permission classifier blocks agent-side key copies — correctly). Now every `--new` target ends with a present, mode-0600, gitignored `.env` with its identity filled.

- **F1 — door seeds `.env`**: from the preset `env-source` when configured (existing path, discipline factored into a shared `copy_env_into_target`), else from the target's own `.env.template` — same gitignore refusal, umask-first 0600 birth, contents never printed.
- **F2 — identity fields**: `PROJECT_NAME` from the target basename; `TASK_PREFIX` from the export engine's recorded prefix (single shape, read from `current-state.json`) or written empty (planning shape) — never the silent `TASK` placeholder. Template default is now empty, and the doctor env-keys check WARNs while `TASK_PREFIX` is missing, empty, or `TASK`.
- **F3 — operator-consented carry-over**: with no env-source, a TTY run asks consent before copying the kit clone's `.env`; a non-TTY run prints the exact quoted `cp` command and continues. The agent/operator boundary is documented in the door header and `docs/STARTING-A-PROJECT.md`.
- **F4 — first-session surfacing**: the consumer engine's `first-session` region now tells the operator to verify doctor env-keys before the first evaluation, with a legacy-body parameter on `remove_region_if_unmodified` so pre-change consumers' `--no-kit` re-bootstraps still remove the unmodified old text.
- **F5 — template honesty**: the `.env.template` project-configuration comments describe the real mechanism (door-seeded, operator carry-over), replacing the fictional onboarding claim.

## Evaluator gate (run before PR open, per KIT-0035)

code-reviewer-fast-v2 (CONCERNS→actioned), code-reviewer/o3 (FAIL→2 actioned, 4 rejected with reasoning), claude-code security (**APPROVED**). Full triage + embedded logs: `.kit/context/reviews/KIT-0084-evaluator-review.md`. Actioned: JSON-null prefix, duplicate/indented identity-line dedup, quote-aware `#` handling, CR/LF stripping, quoted printed command, kit-`.env` mode warning.

## Test plan

- [x] `TestEnvSeedingE2E`: single (explicit + derived prefix), planning (empty prefix), env-source identity fill — mode 0600, gitignored, no secret echoed
- [x] `TestFillEnvIdentityUnits`: placeholder rewrite, append-if-missing, dedup (incl. indented), JSON-null → empty, no-.env noop
- [x] `TestTaskPrefixWarn`: WARN on empty/missing/`TASK`/commented; PASS on real prefix; single merged WARN line; value never printed
- [x] Legacy first-session body removal on `--no-kit` re-bootstrap
- [x] Live `bootstrap --new` run verified by hand (0600, gitignored, identity filled)
- [ ] CI green (local full suite has the 8 pre-existing KIT-0080 Apple-git-2.30.1 failures; verified identical on clean `main`)

Task spec: `.kit/tasks/3-in-progress/KIT-0084-working-env-from-day-one.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bootstrap door and `.env`/secret handling (gitignore gate, 0600 writes, optional full-file key copy), but boundaries are explicit and covered by security review and new tests.
> 
> **Overview**
> **`bootstrap --new`** now leaves every new project with a **gitignored, mode-0600 `.env`**: preset **`env-source`** when set, otherwise the target’s **`.env.template`**, via shared **`copy_env_into_target`** (refuse if `.env` isn’t ignored, umask-first write, never log contents). It then **`fill_env_identity`** for **`PROJECT_NAME`** (folder basename) and **`TASK_PREFIX`** (single: prefix from **`current-state.json`** / CLI; planning: empty, not the old **`TASK`** placeholder), with awk dedup, quoting, and atomic rewrite under **`.git`**.
> 
> Without **`env-source`**, **`offer_env_carryover`** is **operator-only**: TTY consent to copy the kit clone’s whole **`.env`**, or non-TTY **`install -m 600`** instructions—documented in **`docs/STARTING-A-PROJECT.md`** and the door header (agents must not move keys).
> 
> **`project doctor` env-keys** adds a **WARN** when **`TASK_PREFIX`** is missing, empty, or **`TASK`**, using new **`key_value`** (last-assignment-wins, dotenv-aligned) alongside existing **`key_state`** presence logic and quote-aware **`_effective_value`**.
> 
> **`.env.template`** default **`TASK_PREFIX=`** and honest comments; consumer **`first-session`** CLAUDE.md mentions checking env-keys, with **legacy body** support on **`--no-kit`** re-bootstrap. Tests cover E2E seeding, identity rewrite units, and prefix warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1723336faa748f225e7139baffe19a4c6bb168f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->