### PR TITLE
feat(KIT-0083): ship the adversarial CLI, not just its config

### DIFF
--- a/.adversarial/config.yml
+++ b/.adversarial/config.yml
@@ -48,5 +48,13 @@ test_command: pytest tests/ -v
 #
 # Unknown keys are ignored by adversarial-workflow 1.0.1 (it reads this
 # file as a plain dict, `if "key" in config`) — verified 2026-08-05.
+# NOTE on evaluator_library_version: it is deliberately INERT today —
+# `_get_evaluator_library_version()` still reads the pyproject pin, and
+# moving that reader is KIT-0079's scope, not this task's. It is written
+# here now so KIT-0079 has the canonical home already populated. Until
+# that lands the two copies could drift, so a test asserts they stay
+# equal (tests/test_core_manifest.py::test_library_pin_mirrors_agree) —
+# an inert key that silently disagrees with the live one is worse than
+# no key at all (CodeRabbit round 1).
 adversarial_cli_version: "1.0.1"        # PyPI dist — uv tool install adversarial-workflow
 evaluator_library_version: "v0.10.0"    # git tag — KIT-0079 moves the reader here

--- a/.adversarial/config.yml
+++ b/.adversarial/config.yml
@@ -17,3 +17,36 @@ artifacts_directory: .adversarial/artifacts/
 
 # Command to run tests (for test validation phase)
 test_command: pytest tests/ -v
+
+# ── Version pins (KIT-0083; canonical home for BOTH, issue #60) ─────────
+#
+# These two pins name DIFFERENT ARTIFACTS. They were never inconsistent
+# with each other, and #60's "v0.10.0 does not exist on PyPI" reading is
+# a category error:
+#
+#   adversarial_cli_version    → the CLI: a PyPI *distribution*
+#                                (adversarial-workflow), installed with
+#                                `uv tool install`
+#   evaluator_library_version  → the evaluator library: a *git tag* on
+#                                movito/adversarial-evaluator-library,
+#                                cloned by `project install-evaluators`
+#
+# A PyPI version and a git tag are not comparable, so there is nothing
+# to reconcile. #60 is a LOCATION bug wearing a consistency costume:
+# both pins used to live in pyproject.toml (added at c851276, KIT-0035,
+# when the kit was single-shape and every project had one). The planning
+# shape arrived later (924a5bb, KIT-0053) and deliberately never ships
+# pyproject.toml — engine-consumer.sh:294 — so half of all projects
+# could not READ their own pins. The split did not create a bad
+# location; it turned a previously-fine one into an unreadable one.
+#
+# This file is the canonical home because it ships to BOTH shapes
+# (engine-consumer.sh rsyncs .adversarial/ verbatim), already owns
+# evaluator-suite config, and shares its lifetime with the thing being
+# pinned. pyproject.toml keeps a mirror of the CLI pin for Python
+# tooling, but no reader may REQUIRE pyproject.toml.
+#
+# Unknown keys are ignored by adversarial-workflow 1.0.1 (it reads this
+# file as a plain dict, `if "key" in config`) — verified 2026-08-05.
+adversarial_cli_version: "1.0.1"        # PyPI dist — uv tool install adversarial-workflow
+evaluator_library_version: "v0.10.0"    # git tag — KIT-0079 moves the reader here

--- a/.kit/context/reviews/KIT-0083-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0083-evaluator-review.md
@@ -1,0 +1,102 @@
+# KIT-0083 — Evaluator Review Record
+
+**Date**: 2026-08-05
+**Branch**: `feature/KIT-0083-ship-adversarial-cli`
+**Input**: `.adversarial/inputs/KIT-0083-code-review-input.md`
+(full-file format, 8 files, ~87k tokens)
+**Ordering**: trio run BEFORE the PR was opened, per the Phase 7
+ordering rule (local green → trio → PR). Code task, so the
+prose-sweep exception does not apply.
+
+## Verdicts
+
+| Evaluator | Model | Verdict |
+|---|---|---|
+| code-reviewer-fast | gemini-2.5-flash | CONCERNS |
+| code-reviewer | o3 | CONCERNS |
+| claude-code | claude-sonnet-4-6 | APPROVED |
+
+Logs: `.adversarial/logs/KIT-0083-code-review-input--*.md`
+
+## Findings and dispositions
+
+### Actioned
+
+**1. False ✅ on a present-but-broken binary** (fast + o3 — the two
+evaluators converged on this independently, which is why it was fixed
+first). The install step gated on `shutil.which` (presence) while
+doctor.d/31 probes `--version` (liveness), so a corrupt install printed
+✅ and the very next `project doctor` FAILed on it — two surfaces
+disagreeing about one install.
+→ Added `_adversarial_cli_works()` (which + `--version` exit code, with
+its own timeout) and routed both the pre-check and the post-install
+verification through it. The post-install branch now distinguishes
+three states with three different remedies: works → ✅; on PATH but not
+runnable → `--force` reinstall; not on PATH → PATH advice. Covered by
+`TestAdversarialCliLiveness` (6 cases).
+
+**2. Mirror regex ignored `==` pins** (o3). Verified reproducible before
+fixing: the `>=`-only regex returned `None` for
+`adversarial-workflow==1.2.3`, which the caller reads as "no pin" and
+sends down the instruct-only path — an installable project would
+silently not install. Relevant because KIT-0079 may write an exact pin
+into the mirror.
+→ Regex accepts `>=`, `==`, `~=` and bare. Covered by
+`TestPyprojectMirrorPinForms`, which drives the REAL reader (via a
+fixture tree + patched `__file__`) rather than re-implementing the
+regex in the test.
+
+**3. Unbounded `--version` probe could hang the doctor run** (o3).
+→ Bounded to 20s. Deliberately NOT GNU `timeout`: it is a homebrew
+add-on on macOS, absent from a stock system, so depending on it would
+work on this machine and hang on a plain one — the same "passes
+locally, proves nothing" trap that let #103 ship. Verified against a
+`sleep 300` stub: bounded FAIL at 20.2s instead of hanging.
+
+**4. Junk pin reaches uv as a confusing spec** (claude-code, low).
+Not injection — the pin is a list element to `subprocess.run`, never a
+shell string. But a pin of `--force` becomes
+`adversarial-workflow==--force` and surfaces as a baffling uv error
+instead of "your pin is wrong".
+→ Added `_is_version_like()`, applied to BOTH the config.yml read and
+the pyproject mirror. A junk pin now falls through to the
+instruct-don't-install path. Covered by `TestPinValidation`.
+
+**Bug found by my own new tests while fixing #3**: the first bounded
+implementation used a bare `sleep`, which does not exist under the
+restricted PATH the doctor tests run with — so the loop spun instantly
+and reported a **false FAIL on a healthy CLI**. `sleep` is now resolved
+to an absolute path (same idea as `BASH` in `tests/test_doctor.py`),
+with a blocking `wait` fallback when no sleep binary exists. This is
+precisely the bug class this task exists to prevent, caught by the
+PATH-isolation discipline the task mandated.
+
+### Declined, with reasons
+
+**`.adversarial` existing as a FILE reports SKIP** (o3, "minor bug").
+Reproduced — it does report SKIP. Declined anyway: `30-evaluators.sh`
+uses the identical `[ ! -d ]` test, so "fixing" it here alone would
+make two sibling checks disagree about what an initialized project
+looks like, for a corrupt-tree state neither check is meant to
+diagnose. If it is worth fixing it is worth fixing consistently, in its
+own task. Noted in the PR body.
+
+**Concurrent `install-evaluators` invocations race on uv's lock** (o3).
+Speculative: `uv` performs its own locking, and a lock collision
+already degrades to the "install failed → retry manually" path, which
+never fails the caller. Adding a file lock would be more machinery than
+the risk warrants for a developer-tooling install step. Not actioned.
+
+## Verification beyond the evaluators
+
+- **End-to-end against a fixture of the exact #103 shape** (library
+  installed, CLI absent, uv absent): the CLI warning prints BEFORE the
+  already-installed early return, at the pinned version read from
+  config.yml, and the command still exits 0.
+- **Both doctor lines side by side on that fixture**:
+  `evaluators:PASS` and `evaluator-cli:FAIL` — the masking bug, closed
+  and demonstrated rather than asserted.
+- **uv-present path** with a stub `uv` that "succeeds" without
+  producing a binary: correctly detected as installed-but-not-on-PATH.
+- **Full `ci-check.sh`**: 7/7 stages, 872 passed, 12 skipped, 93%
+  coverage.

--- a/scripts/.core-manifest.json
+++ b/scripts/.core-manifest.json
@@ -11,6 +11,7 @@
       "core/doctor.d/10-gh-auth.sh",
       "core/doctor.d/20-env-keys.py",
       "core/doctor.d/30-evaluators.sh",
+      "core/doctor.d/31-evaluator-cli.sh",
       "core/doctor.d/40-version-skew.py",
       "core/doctor.d/50-plugin-source.sh",
       "core/doctor.d/55-worktree-provisioning.sh",

--- a/scripts/core/doctor.d/31-evaluator-cli.sh
+++ b/scripts/core/doctor.d/31-evaluator-cli.sh
@@ -65,6 +65,13 @@ for candidate in /bin/sleep /usr/bin/sleep; do
     fi
 done
 
+# MUST match CLI_PROBE_TIMEOUT in scripts/core/project: the installer and
+# this check probe the same binary for the same purpose, and a CLI that
+# answers in between the two bounds would be "working" to one surface and
+# FAIL to the other — the two-surfaces-disagree state this check exists
+# to close (CodeRabbit round 1).
+PROBE_TIMEOUT=20
+
 REINSTALL="reinstall: uv tool install --force adversarial-workflow"
 
 adversarial --version >/dev/null 2>&1 </dev/null &
@@ -72,20 +79,27 @@ probe_pid=$!
 
 if [ -n "$SLEEP_BIN" ]; then
     probe_waited=0
-    while kill -0 "$probe_pid" 2>/dev/null && [ "$probe_waited" -lt 20 ]; do
+    while kill -0 "$probe_pid" 2>/dev/null && [ "$probe_waited" -lt "$PROBE_TIMEOUT" ]; do
         "$SLEEP_BIN" 1
         probe_waited=$((probe_waited + 1))
     done
     if kill -0 "$probe_pid" 2>/dev/null; then
         kill "$probe_pid" 2>/dev/null
         wait "$probe_pid" 2>/dev/null
-        echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' did not finish within 20s — likely a corrupt install; $REINSTALL"
+        echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' did not finish within ${PROBE_TIMEOUT}s — likely a corrupt install; $REINSTALL"
         exit 0
     fi
 fi
 # Reaped either way: the polling loop above exits only once the probe is
-# done, and with no sleep binary this `wait` IS the bound (unbounded, but
-# a slow answer beats a wrong one).
+# done. With NO sleep binary this `wait` blocks unbounded — a deliberate
+# tradeoff, not an oversight (CodeRabbit round 1 proposed a `read -t`
+# timer instead). Rejected because every bash-builtin timer needs a
+# non-EOF descriptor, which needs a long-lived helper process holding a
+# pipe open — reintroducing the very external-binary dependency this
+# branch exists to survive, in exchange for a rarer, harder-to-audit
+# construct. The branch requires neither /bin/sleep nor /usr/bin/sleep
+# to exist, i.e. effectively no POSIX system; there, answering slowly
+# beats answering wrongly.
 if ! wait "$probe_pid"; then
     echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' failed — $REINSTALL"
     exit 0

--- a/scripts/core/doctor.d/31-evaluator-cli.sh
+++ b/scripts/core/doctor.d/31-evaluator-cli.sh
@@ -41,8 +41,53 @@ fi
 # "Unknown fields in evaluator.yml" warnings to stderr on a healthy
 # install (verified 2026-08-05), so an output-parsing check would report
 # a false FAIL.
-if ! adversarial --version >/dev/null 2>&1; then
-    echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' failed — reinstall: uv tool install --force adversarial-workflow"
+#
+# Bounded so a corrupt install that blocks on stdin/network cannot hang
+# the whole doctor run (o3 review). Deliberately NOT GNU `timeout`:
+# it is a homebrew add-on on macOS (absent from a stock system), so
+# depending on it would work on a brew-equipped machine and hang on a
+# plain one — the same "passes locally, proves nothing" trap that let
+# issue #103 ship. </dev/null closes the stdin path; the
+# background-and-poll below bounds everything else.
+#
+# `sleep` is resolved to an ABSOLUTE path (same idea as BASH in
+# tests/test_doctor.py): doctor checks must survive a restricted PATH,
+# and a bare `sleep` there fails, spins the loop instantly and reports a
+# false FAIL on a perfectly healthy CLI — caught by
+# test_stub_binary_on_path_passes. If no sleep exists at all, skip the
+# bound rather than invent one: an unbounded probe is still better than
+# a wrong verdict.
+SLEEP_BIN=""
+for candidate in /bin/sleep /usr/bin/sleep; do
+    if [ -x "$candidate" ]; then
+        SLEEP_BIN="$candidate"
+        break
+    fi
+done
+
+REINSTALL="reinstall: uv tool install --force adversarial-workflow"
+
+adversarial --version >/dev/null 2>&1 </dev/null &
+probe_pid=$!
+
+if [ -n "$SLEEP_BIN" ]; then
+    probe_waited=0
+    while kill -0 "$probe_pid" 2>/dev/null && [ "$probe_waited" -lt 20 ]; do
+        "$SLEEP_BIN" 1
+        probe_waited=$((probe_waited + 1))
+    done
+    if kill -0 "$probe_pid" 2>/dev/null; then
+        kill "$probe_pid" 2>/dev/null
+        wait "$probe_pid" 2>/dev/null
+        echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' did not finish within 20s — likely a corrupt install; $REINSTALL"
+        exit 0
+    fi
+fi
+# Reaped either way: the polling loop above exits only once the probe is
+# done, and with no sleep binary this `wait` IS the bound (unbounded, but
+# a slow answer beats a wrong one).
+if ! wait "$probe_pid"; then
+    echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' failed — $REINSTALL"
     exit 0
 fi
 

--- a/scripts/core/doctor.d/31-evaluator-cli.sh
+++ b/scripts/core/doctor.d/31-evaluator-cli.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: the `adversarial` CLI binary is on PATH and runnable.
+#
+# Incident (KIT-0083, issue #103): a fresh consumer project shipped
+# .adversarial/config.yml AND the evaluator library, so 30-evaluators.sh
+# reported PASS — but nothing had ever installed the CLI itself. The
+# failure surfaced at the planner's Phase 3 evaluation GATE as
+# `adversarial: command not found`, long after the project looked fully
+# provisioned. This check exists so the library's PASS can never mask a
+# missing binary again.
+#
+# Deliberately separate from 30-evaluators.sh: that one answers "is the
+# evaluator library installed" (a tree fact), this one answers "can we
+# actually run an evaluation" (a PATH fact). One verdict cannot carry
+# both. (KIT-0055 will add a third question — *which* binary is it,
+# editable vs tool install — which is meaningless before this one.)
+#
+# Read-only. Root from DOCTOR_ROOT (driver-set; tests use tmp fixtures),
+# else derived from this file's location.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+if [ ! -d "$ROOT/.adversarial" ]; then
+    echo "DOCTOR:evaluator-cli:SKIP:adversarial workflow not initialized (.adversarial/ absent)"
+    exit 0
+fi
+
+FIX="run: ./scripts/core/project install-evaluators (or: uv tool install adversarial-workflow)"
+PATH_HINT="if you just installed it, uv puts binaries in ~/.local/bin — add it to PATH"
+
+if ! command -v adversarial >/dev/null 2>&1; then
+    echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI not on PATH — $FIX; $PATH_HINT"
+    exit 0
+fi
+
+# Probe the EXIT CODE, never the output: `adversarial --version` prints
+# "Unknown fields in evaluator.yml" warnings to stderr on a healthy
+# install (verified 2026-08-05), so an output-parsing check would report
+# a false FAIL.
+if ! adversarial --version >/dev/null 2>&1; then
+    echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' failed — reinstall: uv tool install --force adversarial-workflow"
+    exit 0
+fi
+
+echo "DOCTOR:evaluator-cli:PASS:adversarial CLI available ($(command -v adversarial))"

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -86,6 +86,19 @@ EVALUATOR_LIBRARY_REPO = "https://github.com/movito/adversarial-evaluator-librar
 ADVERSARIAL_CLI_DIST = "adversarial-workflow"
 
 
+def _is_version_like(value):
+    """True for a plausible PEP 440-ish version string.
+
+    config.yml is hand-edited, so the pin can be anything. The value is
+    passed as a LIST element to subprocess.run (never a shell), so this
+    is not about injection — it is about failing clearly: a pin of
+    `--force` would otherwise become `adversarial-workflow==--force` and
+    surface as a baffling uv error instead of "your pin is wrong"
+    (claude-code review).
+    """
+    return bool(re.fullmatch(r"[0-9][0-9A-Za-z.\-_+!]*", value or ""))
+
+
 def _get_adversarial_cli_version(project_dir):
     """Read the CLI pin: .adversarial/config.yml first, pyproject.toml as mirror.
 
@@ -114,19 +127,53 @@ def _get_adversarial_cli_version(project_dir):
     match = re.search(
         r'^\s*adversarial_cli_version\s*:\s*["\']?([^"\'\s#]+)', text, re.MULTILINE
     )
-    if match:
+    if match and _is_version_like(match.group(1)):
         return match.group(1)
 
-    # Mirror: pyproject's dependency spec, e.g. "adversarial-workflow>=1.0.1"
+    # Mirror: pyproject's dependency spec, e.g. "adversarial-workflow>=1.0.1".
+    # Accepts >=, ==, ~= and a bare version: KIT-0079 may write an exact
+    # pin here, and matching only >= would silently read as "no pin" and
+    # send an installable project down the instruct-only path (o3 review).
     pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
     try:
         ptext = pyproject.read_text(encoding="utf-8")
     except (FileNotFoundError, OSError):
         return None
     mirror = re.search(
-        r'["\']' + re.escape(ADVERSARIAL_CLI_DIST) + r'\s*>=\s*([^"\',]+)', ptext
+        r'["\']' + re.escape(ADVERSARIAL_CLI_DIST) + r'\s*(?:>=|==|~=)?\s*([^"\',\s]+)',
+        ptext,
     )
-    return mirror.group(1).strip() if mirror else None
+    if not mirror:
+        return None
+    candidate = mirror.group(1).strip()
+    return candidate if _is_version_like(candidate) else None
+
+
+def _adversarial_cli_works():
+    """True when `adversarial` is on PATH AND actually runs.
+
+    Presence is not liveness: a corrupt or half-written install leaves a
+    binary that `shutil.which` finds but that exits non-zero on every
+    invocation. Checking only presence here while doctor.d/31 probes
+    `--version` would let the installer print ✅ for a CLI the very next
+    doctor run reports as FAIL (o3 + fast-v2 review, both rounds).
+
+    Probes the EXIT CODE, never the output: a healthy CLI prints
+    "Unknown fields in evaluator.yml" warnings to stderr.
+    """
+    if not shutil.which("adversarial"):
+        return False
+    try:
+        probe = subprocess.run(
+            ["adversarial", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        # A hanging or unexecutable binary is not a working one.
+        return False
+    return probe.returncode == 0
 
 
 def _ensure_adversarial_cli(project_dir):
@@ -141,7 +188,7 @@ def _ensure_adversarial_cli(project_dir):
     job and must not be undone by an optional CLI step. Degrades to
     printing the exact command, mirroring the git-missing block below.
     """
-    if shutil.which("adversarial"):
+    if _adversarial_cli_works():
         print("✅ adversarial CLI already installed")
         return
 
@@ -189,8 +236,17 @@ def _ensure_adversarial_cli(project_dir):
         print(f"   Retry manually: {install_cmd}")
         return
 
-    if shutil.which("adversarial"):
+    # Three post-install states, three different remedies — never one
+    # blanket ✅. uv exiting 0 does not by itself mean a usable CLI.
+    if _adversarial_cli_works():
         print("✅ adversarial CLI installed")
+    elif shutil.which("adversarial"):
+        # On PATH but not runnable: a corrupt/partial install. Reinstall
+        # is the fix, NOT a PATH change.
+        print("⚠️  adversarial CLI installed but not runnable")
+        print("   It is on PATH, yet '--version' fails — likely a partial")
+        print("   or corrupt install. Reinstall:")
+        print(f"     uv tool install --force {spec}")
     else:
         # uv installs into ~/.local/bin; an install can succeed while the
         # binary stays unreachable. Say so here rather than letting the

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -82,6 +82,124 @@ def _get_evaluator_library_version():
 
 EVALUATOR_LIBRARY_REPO = "https://github.com/movito/adversarial-evaluator-library.git"
 
+# The PyPI distribution providing the `adversarial` CLI (KIT-0083).
+ADVERSARIAL_CLI_DIST = "adversarial-workflow"
+
+
+def _get_adversarial_cli_version(project_dir):
+    """Read the CLI pin: .adversarial/config.yml first, pyproject.toml as mirror.
+
+    Canonical home is .adversarial/config.yml because it ships to BOTH
+    shapes; planning-shape repos have no pyproject.toml at all
+    (engine-consumer.sh:294), which is what made pyproject an unreadable
+    home for half of all projects (#60, KIT-0083). pyproject stays a
+    fallback mirror so the kit's own checkout keeps working.
+
+    Returns None when no pin is readable — callers install nothing and
+    print the exact command instead. Deliberately NOT a silent
+    unpinned-latest: that is the KIT-0068 A08 class, where a quiet
+    fallback installed a five-versions-old library.
+
+    Parsed with a regex rather than a YAML load: `project` runs on bare
+    Python with no third-party imports, and PyYAML is not guaranteed
+    (same reasoning as the tomllib fallback above).
+    """
+    config_yml = Path(project_dir) / ".adversarial" / "config.yml"
+    try:
+        text = config_yml.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        text = ""
+    # Anchored to line start so a commented-out example (# adversarial_
+    # cli_version: "9.9.9") can never be read as the live pin.
+    match = re.search(
+        r'^\s*adversarial_cli_version\s*:\s*["\']?([^"\'\s#]+)', text, re.MULTILINE
+    )
+    if match:
+        return match.group(1)
+
+    # Mirror: pyproject's dependency spec, e.g. "adversarial-workflow>=1.0.1"
+    pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+    try:
+        ptext = pyproject.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return None
+    mirror = re.search(
+        r'["\']' + re.escape(ADVERSARIAL_CLI_DIST) + r'\s*>=\s*([^"\',]+)', ptext
+    )
+    return mirror.group(1).strip() if mirror else None
+
+
+def _ensure_adversarial_cli(project_dir):
+    """Ensure the `adversarial` CLI is on PATH; instruct if it can't be.
+
+    The KIT-0083 / issue #103 trap: .adversarial/ config and the evaluator
+    library both shipped and doctor reported PASS, but nothing ever
+    installed the CLI itself — so the planner's Phase 3 evaluation GATE
+    was the first thing to discover it, with `command not found`.
+
+    Never fails the caller: the library install is the command's primary
+    job and must not be undone by an optional CLI step. Degrades to
+    printing the exact command, mirroring the git-missing block below.
+    """
+    if shutil.which("adversarial"):
+        print("✅ adversarial CLI already installed")
+        return
+
+    version = _get_adversarial_cli_version(project_dir)
+    spec = f"{ADVERSARIAL_CLI_DIST}=={version}" if version else ADVERSARIAL_CLI_DIST
+    install_cmd = f"uv tool install {spec}"
+
+    if not shutil.which("uv"):
+        print("⚠️  adversarial CLI not found, and uv is not installed")
+        print("   The evaluator library is installed, but running an")
+        print("   evaluation needs the CLI. Install uv, then run:")
+        print(f"     {install_cmd}")
+        print("   uv: https://docs.astral.sh/uv/getting-started/installation/")
+        return
+
+    if not version:
+        # No readable pin: instruct rather than install unpinned-latest
+        # (KIT-0068 A08 — silent fallbacks install the wrong thing).
+        print("⚠️  Could not read the adversarial CLI version pin")
+        print("   Source: .adversarial/config.yml → adversarial_cli_version")
+        print("   Fix that pin, or install explicitly:")
+        print(f"     {install_cmd}")
+        return
+
+    print(f"📦 Installing the adversarial CLI ({spec})...")
+    try:
+        result = subprocess.run(
+            ["uv", "tool", "install", spec],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        print("⚠️  CLI install timed out (network issue?)")
+        print(f"   Retry manually: {install_cmd}")
+        return
+
+    if result.returncode != 0:
+        print("⚠️  CLI install failed — the evaluator library is still installed")
+        # Surface only uv's last line: its full stderr is long and the
+        # actionable part is the tail.
+        detail = (result.stderr or "").strip().splitlines()
+        if detail:
+            print(f"   {detail[-1]}")
+        print(f"   Retry manually: {install_cmd}")
+        return
+
+    if shutil.which("adversarial"):
+        print("✅ adversarial CLI installed")
+    else:
+        # uv installs into ~/.local/bin; an install can succeed while the
+        # binary stays unreachable. Say so here rather than letting the
+        # doctor check be the first to notice.
+        print("✅ adversarial CLI installed — but it is not on your PATH")
+        print("   uv installs tools into ~/.local/bin; add it to PATH:")
+        print('     export PATH="$HOME/.local/bin:$PATH"')
+
+
 # Status to folder mapping
 STATUS_FOLDER_MAP = {
     "backlog": "1-backlog",
@@ -829,7 +947,15 @@ def cmd_install_evaluators(args, project_dir):
     print("📦 Adversarial Evaluator Library Installer")
     print("=" * 50)
 
-    # 2. Check if already installed — BEFORE resolving the version pin:
+    # 2. Ensure the CLI — BEFORE the already-installed early return
+    # below. The #103 shape is precisely "library present, CLI absent":
+    # a rerun there must still fix the CLI, so this cannot sit after a
+    # `return` that the library check owns. Never fails the command
+    # (KIT-0083).
+    _ensure_adversarial_cli(project_dir)
+    print()
+
+    # 3. Check if already installed — BEFORE resolving the version pin:
     # the no-op rerun path must keep working on repos with no readable
     # pyproject pin (planning shape, or installs done only with --ref);
     # the pin is only needed to clone (BugBot round 2, KIT-0068).
@@ -846,7 +972,7 @@ def cmd_install_evaluators(args, project_dir):
     print(f"   Version: {version}")
     print()
 
-    # 3. Clone specific version
+    # 4. Clone specific version
     with tempfile.TemporaryDirectory() as tmpdir:
         print(f"📥 Cloning evaluator library @ {version}...")
         try:
@@ -2509,7 +2635,10 @@ Setup:
                          (--no-hooks: skip pre-commit hook install —
                          used by worktree provisioning; refuses if
                          .venv is a symlink, KIT-0065)
-  install-evaluators     Install evaluators from adversarial-evaluator-library
+  install-evaluators     Install the evaluator library + CLI
+                         (library from adversarial-evaluator-library;
+                         CLI via uv tool install — pinned in
+                         .adversarial/config.yml)
                          Options: --force (reinstall), --ref <tag> (version)
   doctor                 Run incident-mapped environment checks (doctor.d/)
                          Exit: 0 ok, 1 failures, 2 warnings only, 3 driver error

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1032,8 +1032,22 @@ def cmd_install_evaluators(args, project_dir):
     # 2. Check for git (required for CLONING the library — not for the
     # CLI step above)
     try:
-        git_check = subprocess.run(["git", "--version"], capture_output=True, text=True)
+        git_check = subprocess.run(
+            ["git", "--version"],
+            capture_output=True,
+            text=True,
+            # Bounded and stdin-closed for the same reasons as the CLI
+            # probe: a wedged git (prompting credential helper, hung
+            # filesystem) would otherwise hang install-evaluators
+            # indefinitely, and an open stdin lets it consume input the
+            # user typed for the surrounding flow (CodeRabbit round 2).
+            timeout=CLI_PROBE_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
         git_ok = git_check.returncode == 0
+    except subprocess.TimeoutExpired:
+        # A git that never answers is not a usable git — same guidance.
+        git_ok = False
     except (FileNotFoundError, OSError):
         # A genuinely absent git raises rather than returning non-zero;
         # without this the intended message below never prints and the

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -210,8 +210,11 @@ def _ensure_adversarial_cli(project_dir):
 
     if not shutil.which("uv"):
         print("⚠️  adversarial CLI not found, and uv is not installed")
-        print("   The evaluator library is installed, but running an")
-        print("   evaluation needs the CLI. Install uv, then run:")
+        # Deliberately says nothing about the LIBRARY's state: this step
+        # now runs before the git gate and the clone, so the library may
+        # not be installed yet — and if git then fails, it never will be
+        # (CodeRabbit round 3).
+        print("   Running an evaluation needs the CLI. Install uv, then run:")
         print(f"     {install_cmd}")
         print("   uv: https://docs.astral.sh/uv/getting-started/installation/")
         return
@@ -249,7 +252,9 @@ def _ensure_adversarial_cli(project_dir):
         return
 
     if result.returncode != 0:
-        print("⚠️  CLI install failed — the evaluator library is still installed")
+        # No claim about the library here either — see the uv-missing
+        # branch above (CodeRabbit round 3).
+        print("⚠️  CLI install failed — continuing with the library install")
         # Surface only uv's last line: its full stderr is long and the
         # actionable part is the tail.
         detail = (result.stderr or "").strip().splitlines()

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -85,6 +85,13 @@ EVALUATOR_LIBRARY_REPO = "https://github.com/movito/adversarial-evaluator-librar
 # The PyPI distribution providing the `adversarial` CLI (KIT-0083).
 ADVERSARIAL_CLI_DIST = "adversarial-workflow"
 
+# Seconds allowed for `adversarial --version`. MUST match the bound in
+# scripts/core/doctor.d/31-evaluator-cli.sh: the whole point of the
+# liveness probe is that the installer and the doctor never disagree
+# about one install, and a CLI answering in, say, 25s would otherwise be
+# "working" to one surface and FAIL to the other (CodeRabbit round 1).
+CLI_PROBE_TIMEOUT = 20
+
 
 def _is_version_like(value):
     """True for a plausible PEP 440-ish version string.
@@ -168,7 +175,12 @@ def _adversarial_cli_works():
             ["adversarial", "--version"],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=CLI_PROBE_TIMEOUT,
+            # Closes the stdin path, exactly as the doctor check does: a
+            # corrupt CLI that blocks on stdin must not stall an
+            # interactive install, nor swallow input the user typed for
+            # the surrounding prompt flow (CodeRabbit round 1).
+            stdin=subprocess.DEVNULL,
         )
     except (subprocess.TimeoutExpired, OSError):
         # A hanging or unexecutable binary is not a working one.
@@ -223,6 +235,16 @@ def _ensure_adversarial_cli(project_dir):
         )
     except subprocess.TimeoutExpired:
         print("⚠️  CLI install timed out (network issue?)")
+        print(f"   Retry manually: {install_cmd}")
+        return
+    except OSError as exc:
+        # `shutil.which` proves the executable bit, not that uv can
+        # actually run (noexec mount, broken shim, removed between check
+        # and run). Without this the exception escapes the "never fails
+        # the caller" contract in this function's docstring — and since
+        # this step now runs BEFORE the library install, the user would
+        # get neither the CLI nor the library (CodeRabbit round 1).
+        print(f"⚠️  Could not run uv: {exc}")
         print(f"   Retry manually: {install_cmd}")
         return
 
@@ -985,17 +1007,6 @@ def cmd_install_evaluators(args, project_dir):
             version = args[i + 1]
             break
 
-    # 1. Check for git (required for cloning)
-    git_check = subprocess.run(["git", "--version"], capture_output=True, text=True)
-    if git_check.returncode != 0:
-        print("❌ Git is required but not found")
-        print()
-        print("Install git:")
-        print("  macOS:  brew install git")
-        print("  Ubuntu: sudo apt install git")
-        print("  Windows: https://git-scm.com/download/win")
-        sys.exit(1)
-
     # CLI hardcodes .adversarial/ at repo root (see e2465ae) — do not move into .kit/
     evaluators_dir = project_dir / ".adversarial" / "evaluators"
     evaluators_dir.mkdir(parents=True, exist_ok=True)
@@ -1003,13 +1014,40 @@ def cmd_install_evaluators(args, project_dir):
     print("📦 Adversarial Evaluator Library Installer")
     print("=" * 50)
 
-    # 2. Ensure the CLI — BEFORE the already-installed early return
-    # below. The #103 shape is precisely "library present, CLI absent":
-    # a rerun there must still fix the CLI, so this cannot sit after a
-    # `return` that the library check owns. Never fails the command
-    # (KIT-0083).
+    # 1. Ensure the CLI FIRST — before both gates below.
+    #
+    # It must precede the already-installed early return, because the
+    # #103 shape is precisely "library present, CLI absent" and a rerun
+    # there must still fix the CLI.
+    #
+    # It must ALSO precede the git gate: the CLI path needs only `uv`,
+    # never git, and doctor.d/31 tells users to run THIS COMMAND to fix
+    # a missing CLI. With git absent or broken, that advice would exit
+    # 1 without ever attempting the thing it was recommended for
+    # (BugBot round 1). The two installs have independent
+    # prerequisites, so neither gate may own the other's path.
     _ensure_adversarial_cli(project_dir)
     print()
+
+    # 2. Check for git (required for CLONING the library — not for the
+    # CLI step above)
+    try:
+        git_check = subprocess.run(["git", "--version"], capture_output=True, text=True)
+        git_ok = git_check.returncode == 0
+    except (FileNotFoundError, OSError):
+        # A genuinely absent git raises rather than returning non-zero;
+        # without this the intended message below never prints and the
+        # user gets a raw traceback instead (found reproducing the
+        # BugBot finding above).
+        git_ok = False
+    if not git_ok:
+        print("❌ Git is required but not found")
+        print()
+        print("Install git:")
+        print("  macOS:  brew install git")
+        print("  Ubuntu: sudo apt install git")
+        print("  Windows: https://git-scm.com/download/win")
+        sys.exit(1)
 
     # 3. Check if already installed — BEFORE resolving the version pin:
     # the no-op rerun path must keep working on repos with no readable

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -51,7 +51,8 @@
 #                        (adopt, single+python) run the bootstrap-agent
 #                        materials flow / silence its detection hint
 #   --with-evaluators / --without-evaluators
-#                        answer the evaluator-install offer
+#                        answer the evaluator-install offer (provisions
+#                        the evaluator library + the adversarial CLI)
 #   --with-venv / --without-venv
 #                        answer the venv offer (profile python only)
 #   --no-preset          ignore the operator preset for this run (the
@@ -752,9 +753,9 @@ PYEOF
 run_offers() {
     if [ "$WITH_EVALUATORS" = "" ]; then
         if is_tty; then
-            WITH_EVALUATORS="$(prompt_yn "Install adversarial evaluators now?")"
+            WITH_EVALUATORS="$(prompt_yn "Install adversarial evaluators now? (library + CLI)")"
         else
-            echo "Offer skipped (non-interactive): evaluators — pass --with-evaluators to install"
+            echo "Offer skipped (non-interactive): evaluators (library + CLI) — pass --with-evaluators to install"
             WITH_EVALUATORS="no"
         fi
     fi

--- a/tests/test_core_manifest.py
+++ b/tests/test_core_manifest.py
@@ -140,7 +140,7 @@ class TestManifestConsistency:
 
     def test_scripts_core_count(self, manifest):
         count = len(manifest["files"]["scripts_core"])
-        assert count == 26, f"Expected 26 scripts_core entries, got {count}"
+        assert count == 27, f"Expected 27 scripts_core entries, got {count}"
 
     def test_commands_core_count(self, manifest):
         count = len(manifest["files"]["commands_core"])
@@ -156,7 +156,7 @@ class TestManifestConsistency:
 
     def test_total_entry_count(self, manifest):
         total = sum(len(entries) for entries in manifest["files"].values())
-        assert total == 47, f"Expected 47 total entries, got {total}"
+        assert total == 48, f"Expected 48 total entries, got {total}"
 
 
 def _planning_heredoc_core_version(engine_text: str) -> str | None:

--- a/tests/test_core_manifest.py
+++ b/tests/test_core_manifest.py
@@ -245,9 +245,18 @@ def test_library_pin_mirrors_agree():
         config_yml.read_text(encoding="utf-8"),
         re.MULTILINE,
     )
+    # Scope to [tool.adversarial] before matching: `library_version` is a
+    # generic-enough key that another section could define one, and this
+    # test would then compare against the wrong value and MISS real drift
+    # — a false green on a drift detector (CodeRabbit round 2).
+    ptext = pyproject.read_text(encoding="utf-8")
+    section = re.search(
+        r"^\[tool\.adversarial\]\s*$(.*?)(?=^\[|\Z)", ptext, re.MULTILINE | re.DOTALL
+    )
+    assert section, "pyproject.toml lost the [tool.adversarial] section"
     live = re.search(
         r'^\s*library_version\s*=\s*"([^"]+)"',
-        pyproject.read_text(encoding="utf-8"),
+        section.group(1),
         re.MULTILINE,
     )
     assert canonical, ".adversarial/config.yml lost evaluator_library_version"

--- a/tests/test_core_manifest.py
+++ b/tests/test_core_manifest.py
@@ -223,3 +223,37 @@ class TestBakedManifestVersion:
             _planning_heredoc_core_version(desynced)
             != VERSION_FILE.read_text(encoding="utf-8").strip()
         )
+
+
+def test_library_pin_mirrors_agree():
+    """The library pin exists in two places until KIT-0079 lands.
+
+    `.adversarial/config.yml` is the canonical home (KIT-0083 F3), but
+    `_get_evaluator_library_version()` still reads the pyproject pin —
+    moving that reader is KIT-0079's scope. While both copies exist they
+    MUST agree: an inert key that silently disagrees with the live one
+    is worse than no key at all (CodeRabbit round 1). Delete this test
+    when KIT-0079 removes the pyproject copy.
+    """
+    config_yml = REPO_ROOT / ".adversarial" / "config.yml"
+    pyproject = REPO_ROOT / "pyproject.toml"
+    if not config_yml.exists() or not pyproject.exists():
+        pytest.skip("not a full kit checkout")
+
+    canonical = re.search(
+        r'^\s*evaluator_library_version\s*:\s*["\']?([^"\'\s#]+)',
+        config_yml.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    live = re.search(
+        r'^\s*library_version\s*=\s*"([^"]+)"',
+        pyproject.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert canonical, ".adversarial/config.yml lost evaluator_library_version"
+    assert live, "pyproject.toml lost [tool.adversarial] library_version"
+    assert canonical.group(1) == live.group(1), (
+        "library pin drifted between its canonical home and the pyproject "
+        f"copy the reader still uses: config.yml={canonical.group(1)!r}, "
+        f"pyproject={live.group(1)!r}"
+    )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2050,6 +2050,23 @@ class TestEvaluatorCliCheck:
         assert "DOCTOR:evaluator-cli:FAIL:" in result.stdout
         assert "--version" in result.stdout
 
+    def test_hanging_version_probe_is_bounded(self, tmp_path):
+        """A corrupt install whose --version blocks must FAIL on a bound,
+        not hang the whole doctor run (o3 review). Deliberately not GNU
+        `timeout`: stock macOS ships neither timeout nor gtimeout, so a
+        check depending on one would work on the maintainer's brew-
+        equipped machine and hang on a plain one."""
+        import time
+
+        (tmp_path / ".adversarial").mkdir()
+        bin_dir = _restricted_bin(tmp_path)
+        _stub_executable(bin_dir / "adversarial", "sleep 120\n")
+        started = time.monotonic()
+        result = run_evaluator_cli_check(tmp_path, bin_dir)
+        elapsed = time.monotonic() - started
+        assert "DOCTOR:evaluator-cli:FAIL:" in result.stdout
+        assert elapsed < 60, f"probe was not bounded (took {elapsed:.0f}s)"
+
     def test_check_exits_zero_on_every_path(self, tmp_path):
         """Checks report via DOCTOR: lines; the driver owns exit codes."""
         (tmp_path / ".adversarial").mkdir()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1971,3 +1971,88 @@ class TestWorktreeProvisioningCheck:
             if ln.startswith("DOCTOR:worktree-venv:WARN:")
         )
         assert "--no-hooks" not in line
+
+
+def run_evaluator_cli_check(root: Path, path_dir: Path | None = None):
+    """Run 31-evaluator-cli.sh; restrict PATH to control `adversarial` visibility.
+
+    PATH control is the whole point (KIT-0083): both `uv` and
+    `adversarial` are installed on the maintainer's machine, so an
+    unrestricted `command -v` passes locally and proves nothing about a
+    fresh project — the exact blind spot that let issue #103 ship.
+    """
+    env = {**os.environ, "DOCTOR_ROOT": str(root)}
+    if path_dir is not None:
+        env["PATH"] = str(path_dir)
+    check = DOCTOR_D / "31-evaluator-cli.sh"
+    return subprocess.run(
+        [BASH, str(check)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestEvaluatorCliCheck:
+    """KIT-0083 / issue #103: the library's PASS must not mask a missing CLI."""
+
+    def test_no_adversarial_dir_skips(self, tmp_path):
+        """No .adversarial/ — nothing to say (mirrors 30-evaluators.sh)."""
+        result = run_evaluator_cli_check(tmp_path, _restricted_bin(tmp_path))
+        assert "DOCTOR:evaluator-cli:SKIP:" in result.stdout
+        assert "not initialized" in result.stdout
+
+    def test_config_present_but_binary_missing_fails(self, tmp_path):
+        """THE #103 TRAP: config/library present, CLI absent → FAIL."""
+        (tmp_path / ".adversarial" / "evaluators").mkdir(parents=True)
+        result = run_evaluator_cli_check(tmp_path, _restricted_bin(tmp_path))
+        assert "DOCTOR:evaluator-cli:FAIL:" in result.stdout
+        assert "not on PATH" in result.stdout
+
+    def test_fail_message_names_the_fix_and_path(self, tmp_path):
+        """An actionable message: the fix command AND the PATH hint —
+        uv installs into ~/.local/bin, so 'installed but invisible' is a
+        real state a bare 'not found' would leave unexplained."""
+        (tmp_path / ".adversarial").mkdir()
+        result = run_evaluator_cli_check(tmp_path, _restricted_bin(tmp_path))
+        assert "install-evaluators" in result.stdout
+        assert "uv tool install adversarial-workflow" in result.stdout
+        assert "~/.local/bin" in result.stdout
+
+    def test_stub_binary_on_path_passes(self, tmp_path):
+        """A working CLI on PATH → PASS."""
+        (tmp_path / ".adversarial").mkdir()
+        bin_dir = _restricted_bin(tmp_path)
+        _stub_executable(bin_dir / "adversarial", "exit 0\n")
+        result = run_evaluator_cli_check(tmp_path, bin_dir)
+        assert "DOCTOR:evaluator-cli:PASS:" in result.stdout
+
+    def test_version_probe_uses_exit_code_not_output(self, tmp_path):
+        """A healthy CLI prints 'Unknown fields in evaluator.yml' warnings
+        to stderr (verified 2026-08-05). Exit 0 with noisy stderr must
+        still PASS — an output-parsing check would false-FAIL here."""
+        (tmp_path / ".adversarial").mkdir()
+        bin_dir = _restricted_bin(tmp_path)
+        _stub_executable(
+            bin_dir / "adversarial",
+            'echo "Unknown fields in evaluator.yml: status" >&2\nexit 0\n',
+        )
+        result = run_evaluator_cli_check(tmp_path, bin_dir)
+        assert "DOCTOR:evaluator-cli:PASS:" in result.stdout
+
+    def test_broken_binary_fails(self, tmp_path):
+        """On PATH but non-functional (exit non-zero) → FAIL, not PASS."""
+        (tmp_path / ".adversarial").mkdir()
+        bin_dir = _restricted_bin(tmp_path)
+        _stub_executable(bin_dir / "adversarial", "exit 1\n")
+        result = run_evaluator_cli_check(tmp_path, bin_dir)
+        assert "DOCTOR:evaluator-cli:FAIL:" in result.stdout
+        assert "--version" in result.stdout
+
+    def test_check_exits_zero_on_every_path(self, tmp_path):
+        """Checks report via DOCTOR: lines; the driver owns exit codes."""
+        (tmp_path / ".adversarial").mkdir()
+        assert (
+            run_evaluator_cli_check(tmp_path, _restricted_bin(tmp_path)).returncode == 0
+        )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -13,6 +13,7 @@ covers the git-facing tests — no per-module env handling here.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -1990,7 +1991,10 @@ def run_evaluator_cli_check(root: Path, path_dir: Path | None = None):
         env=env,
         capture_output=True,
         text=True,
-        timeout=30,
+        # Comfortably above the check's own 20s probe bound, so a
+        # genuinely-blocking stub is cut off by the CHECK (producing its
+        # timeout verdict) and not by pytest (producing an error).
+        timeout=60,
     )
 
 
@@ -2050,21 +2054,37 @@ class TestEvaluatorCliCheck:
         assert "DOCTOR:evaluator-cli:FAIL:" in result.stdout
         assert "--version" in result.stdout
 
+    @pytest.mark.slow
     def test_hanging_version_probe_is_bounded(self, tmp_path):
-        """A corrupt install whose --version blocks must FAIL on a bound,
-        not hang the whole doctor run (o3 review). Deliberately not GNU
-        `timeout`: stock macOS ships neither timeout nor gtimeout, so a
-        check depending on one would work on the maintainer's brew-
-        equipped machine and hang on a plain one."""
+        """A corrupt install whose --version BLOCKS must FAIL on a bound,
+        not hang the whole doctor run (o3 review).
+
+        The stub calls sleep by ABSOLUTE path. A bare `sleep 120` exits
+        127 instantly under the restricted PATH, so the earlier version
+        of this test passed on the broken-binary branch and never
+        exercised the bound at all (CodeRabbit round 1). Asserting the
+        timeout message specifically — not merely FAIL — is what keeps
+        that confusion from returning.
+        """
         import time
+
+        sleep_bin = next(
+            (c for c in ("/bin/sleep", "/usr/bin/sleep") if Path(c).exists()), None
+        )
+        if sleep_bin is None:
+            pytest.skip("no absolute sleep binary to build a blocking stub with")
 
         (tmp_path / ".adversarial").mkdir()
         bin_dir = _restricted_bin(tmp_path)
-        _stub_executable(bin_dir / "adversarial", "sleep 120\n")
+        _stub_executable(bin_dir / "adversarial", f"exec {sleep_bin} 120\n")
         started = time.monotonic()
         result = run_evaluator_cli_check(tmp_path, bin_dir)
         elapsed = time.monotonic() - started
         assert "DOCTOR:evaluator-cli:FAIL:" in result.stdout
+        assert "did not finish" in result.stdout, (
+            "FAILed for the wrong reason — the stub did not actually block: "
+            f"{result.stdout!r}"
+        )
         assert elapsed < 60, f"probe was not bounded (took {elapsed:.0f}s)"
 
     def test_check_exits_zero_on_every_path(self, tmp_path):
@@ -2073,3 +2093,29 @@ class TestEvaluatorCliCheck:
         assert (
             run_evaluator_cli_check(tmp_path, _restricted_bin(tmp_path)).returncode == 0
         )
+
+
+def test_probe_bounds_match_the_installer():
+    """The doctor bound and the installer bound must stay equal.
+
+    The liveness probe's purpose is that `install-evaluators` and
+    `project doctor` never disagree about one install. A CLI answering
+    between two different bounds would be "working" to one surface and
+    FAIL to the other — the exact split this check exists to close
+    (CodeRabbit round 1). Coupling asserted here so it cannot drift
+    silently.
+    """
+    check_text = (DOCTOR_D / "31-evaluator-cli.sh").read_text(encoding="utf-8")
+    doctor_bound = re.search(r"^PROBE_TIMEOUT=(\d+)", check_text, re.MULTILINE)
+    assert doctor_bound, "doctor check no longer declares PROBE_TIMEOUT"
+
+    project_text = PROJECT_SCRIPT.read_text(encoding="utf-8")
+    installer_bound = re.search(
+        r"^CLI_PROBE_TIMEOUT\s*=\s*(\d+)", project_text, re.MULTILINE
+    )
+    assert installer_bound, "project no longer declares CLI_PROBE_TIMEOUT"
+
+    assert doctor_bound.group(1) == installer_bound.group(1), (
+        f"probe bounds drifted: doctor={doctor_bound.group(1)}s, "
+        f"installer={installer_bound.group(1)}s"
+    )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2085,6 +2085,14 @@ class TestEvaluatorCliCheck:
             "FAILed for the wrong reason — the stub did not actually block: "
             f"{result.stdout!r}"
         )
+        # Bound the timing from BOTH sides. An upper bound alone passes a
+        # probe whose timeout was shortened to near-zero, which is the
+        # same class of unfalsifiable assertion as the one that let this
+        # test hide behind the broken-binary branch (CodeRabbit round 2).
+        assert elapsed >= 18, (
+            f"probe terminated after {elapsed:.0f}s — it did not wait out "
+            "its configured bound"
+        )
         assert elapsed < 60, f"probe was not bounded (took {elapsed:.0f}s)"
 
     def test_check_exits_zero_on_every_path(self, tmp_path):

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -1918,10 +1918,15 @@ def _assert_no_library_state_claim(output):
     express — any new phrasing would silently escape it. Substring/regex
     matching is justified for that reason (DK rules require the
     justification, not the avoidance).
+
+    Covers plural agreement ("have been") and NEGATED forms ("has not
+    been installed") — a negative statement about the library's state is
+    still a statement about it, and equally outside what this step can
+    know (CodeRabbit round 5).
     """
     claim = re.search(
         r"\blibrar(?:y|ies)\b[^\n]*\b(?:is|are|was|were|remains?|still|"
-        r"has been|already)\b",
+        r"already|(?:has|have)(?:\s+not)?\s+been)\b",
         output,
         re.IGNORECASE,
     )
@@ -1929,6 +1934,49 @@ def _assert_no_library_state_claim(output):
         "the CLI step claimed something about the library's state: "
         f"{claim.group(0)!r}"
     )
+
+
+class TestNoLibraryStateClaimHelper:
+    """The shared assertion's own coverage.
+
+    It is the only thing standing between a reordered install step and a
+    message that lies about state, so its blind spots matter as much as
+    the messages it guards (CodeRabbit rounds 4-5).
+    """
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "The evaluator library is installed, but running an",
+            "CLI install failed — the evaluator library is still installed",
+            "the evaluator library is already installed",
+            "the library remains installed",
+            "The Library Was Installed",
+            "evaluator libraries are installed",
+            # plural agreement + negated forms: a negative claim about the
+            # library's state is still a claim (CodeRabbit round 5)
+            "the libraries have been installed",
+            "the library has been installed",
+            "the library has not been installed",
+            "the libraries have not been installed",
+        ],
+    )
+    def test_rejects_state_claims(self, message):
+        with pytest.raises(AssertionError):
+            _assert_no_library_state_claim(message)
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Running an evaluation needs the CLI. Install uv, then run:",
+            "CLI install failed — continuing with the library install",
+            "uv tool install adversarial-workflow==1.0.1",
+            "Retry manually: uv tool install adversarial-workflow==1.0.1",
+            "   uv: https://docs.astral.sh/uv/getting-started/installation/",
+        ],
+    )
+    def test_allows_messages_that_claim_nothing(self, message):
+        _assert_no_library_state_claim(message)
 
 
 class TestCliStepMakesNoLibraryClaims:

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -1902,3 +1902,51 @@ class TestGitGateDoesNotBlockCliInstall:
                     _project_module.cmd_install_evaluators([], project_with_pin)
 
         assert ["uv", "tool", "install", "adversarial-workflow==1.0.1"] in calls
+
+
+class TestCliStepMakesNoLibraryClaims:
+    """The CLI step runs BEFORE the git gate and the library clone, so it
+    cannot assert anything about the library's state.
+
+    Those messages were written when the CLI step ran last, where the
+    claim was true. The reorder (BugBot round 1) falsified them: with git
+    absent, `install-evaluators` printed 'the evaluator library is
+    installed' and then exited having installed nothing at all
+    (CodeRabbit round 3).
+    """
+
+    @pytest.fixture
+    def project_with_pin(self, tmp_path):
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            'adversarial_cli_version: "1.0.1"\n', encoding="utf-8"
+        )
+        return tmp_path
+
+    def test_uv_missing_message_claims_nothing_about_the_library(
+        self, project_with_pin, capsys
+    ):
+        with patch.object(_project_module.shutil, "which", return_value=None):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                _project_module._ensure_adversarial_cli(project_with_pin)
+        out = capsys.readouterr().out
+        assert "uv tool install adversarial-workflow==1.0.1" in out
+        assert "library is installed" not in out
+
+    def test_install_failure_message_claims_nothing_about_the_library(
+        self, project_with_pin, capsys
+    ):
+        which = {"adversarial": None, "uv": "/usr/bin/uv"}
+        with patch.object(
+            _project_module.shutil, "which", side_effect=lambda n: which.get(n)
+        ):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.DEVNULL = subprocess.DEVNULL
+                mock_sub.run.return_value = MagicMock(returncode=1, stderr="boom")
+                _project_module._ensure_adversarial_cli(project_with_pin)
+        out = capsys.readouterr().out
+        assert "Retry manually" in out
+        assert "still installed" not in out

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -1504,43 +1504,86 @@ class TestEnsureAdversarialCli:
 
 
 class TestAdversarialCliPinReader:
-    """The pin's canonical home is .adversarial/config.yml (KIT-0083 F3)."""
+    """The pin's canonical home is .adversarial/config.yml (KIT-0083 F3).
 
-    def test_reads_config_yml_pin(self, tmp_path):
+    Every test here controls the mirror to a KNOWN, DISTINCT value via
+    the fixture below. Asserting against the real repo's pyproject made
+    two of these unfalsifiable: a precedence test whose two sources hold
+    the SAME value cannot detect inverted precedence, and a
+    `!= "0.0.1"` assertion is satisfied by None — so it passed even for
+    a reader that returned nothing for every input (CodeRabbit round 1).
+    """
+
+    MIRROR_VERSION = "7.7.7"
+
+    @pytest.fixture
+    def mirror_root(self, tmp_path):
+        """A fake kit root whose pyproject mirror pins MIRROR_VERSION.
+
+        The reader locates pyproject relative to its own __file__, so
+        the fixture returns a path to patch that with.
+        """
+        fake_root = tmp_path / "root"
+        (fake_root / "scripts" / "core").mkdir(parents=True)
+        fake_script = fake_root / "scripts" / "core" / "project"
+        fake_script.write_text("", encoding="utf-8")
+        (fake_root / "pyproject.toml").write_text(
+            "[project]\ndependencies = "
+            f'["adversarial-workflow=={self.MIRROR_VERSION}"]\n',
+            encoding="utf-8",
+        )
+        return fake_script
+
+    def test_reads_config_yml_pin(self, tmp_path, mirror_root):
         adv = tmp_path / ".adversarial"
         adv.mkdir()
         (adv / "config.yml").write_text(
             'adversarial_cli_version: "1.2.3"\n', encoding="utf-8"
         )
-        assert _project_module._get_adversarial_cli_version(tmp_path) == "1.2.3"
+        with patch.dict(_project_module.__dict__, {"__file__": str(mirror_root)}):
+            assert _project_module._get_adversarial_cli_version(tmp_path) == "1.2.3"
 
-    def test_config_yml_wins_over_pyproject_mirror(self, tmp_path):
-        """config.yml is canonical; pyproject is only a mirror."""
+    def test_config_yml_wins_over_pyproject_mirror(self, tmp_path, mirror_root):
+        """config.yml is canonical; pyproject is only a mirror.
+
+        The two sources hold DIFFERENT values, so inverted precedence
+        fails this test instead of silently passing it.
+        """
         adv = tmp_path / ".adversarial"
         adv.mkdir()
         (adv / "config.yml").write_text(
             'adversarial_cli_version: "9.9.9"\n', encoding="utf-8"
         )
-        assert _project_module._get_adversarial_cli_version(tmp_path) == "9.9.9"
+        with patch.dict(_project_module.__dict__, {"__file__": str(mirror_root)}):
+            got = _project_module._get_adversarial_cli_version(tmp_path)
+        assert got == "9.9.9", f"mirror won over the canonical home (got {got!r})"
 
-    def test_planning_shape_without_config_pin_falls_back_to_pyproject(self, tmp_path):
-        """No config.yml pin → the kit's own pyproject mirror still works.
-
-        (Reads the REAL repo pyproject, which is the mirror by design.)
-        """
+    def test_planning_shape_without_config_pin_falls_back_to_pyproject(
+        self, tmp_path, mirror_root
+    ):
+        """No config.yml pin → the mirror supplies the value."""
         (tmp_path / ".adversarial").mkdir()
-        assert _project_module._get_adversarial_cli_version(tmp_path) is not None
+        with patch.dict(_project_module.__dict__, {"__file__": str(mirror_root)}):
+            got = _project_module._get_adversarial_cli_version(tmp_path)
+        assert got == self.MIRROR_VERSION
 
-    def test_commented_pin_is_not_read(self, tmp_path):
-        """A commented-out example must never be mistaken for the live pin."""
+    def test_commented_pin_is_not_read(self, tmp_path, mirror_root):
+        """A commented-out example must never be read as the live pin.
+
+        Asserts the mirror's exact value: `!= "0.0.1"` would also be
+        satisfied by None, i.e. by a reader that found nothing at all.
+        """
         adv = tmp_path / ".adversarial"
         adv.mkdir()
         (adv / "config.yml").write_text(
             '# adversarial_cli_version: "0.0.1"\ntask_directory: .kit/tasks/\n',
             encoding="utf-8",
         )
-        # Falls through to the pyproject mirror rather than reading 0.0.1
-        assert _project_module._get_adversarial_cli_version(tmp_path) != "0.0.1"
+        with patch.dict(_project_module.__dict__, {"__file__": str(mirror_root)}):
+            got = _project_module._get_adversarial_cli_version(tmp_path)
+        assert (
+            got == self.MIRROR_VERSION
+        ), f"commented pin leaked, or fall-through broke (got {got!r})"
 
 
 class TestInstallEvaluatorsEnsuresCli:
@@ -1757,3 +1800,74 @@ class TestPinValidation:
         )
         with patch.dict(_project_module.__dict__, {"__file__": str(fake_script)}):
             assert _project_module._get_adversarial_cli_version(tmp_path) is None
+
+
+class TestGitGateDoesNotBlockCliInstall:
+    """BugBot round 1: the git gate must not own the CLI path.
+
+    doctor.d/31 tells users to run `install-evaluators` when the library
+    is present but the CLI is missing. The CLI path needs only `uv` —
+    never git — so a broken/absent git must not exit before the CLI step
+    has even been attempted, or the doctor's advice cannot fix the thing
+    it was recommended for.
+    """
+
+    @pytest.fixture
+    def project_with_pin(self, tmp_path):
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            'adversarial_cli_version: "1.0.1"\n', encoding="utf-8"
+        )
+        return tmp_path
+
+    def test_cli_step_runs_before_git_gate(self, project_with_pin):
+        """git --version returns non-zero → CLI step still ran."""
+        with patch.object(_project_module, "_ensure_adversarial_cli") as ensure:
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.return_value = MagicMock(returncode=1)  # git missing
+                with pytest.raises(SystemExit):
+                    _project_module.cmd_install_evaluators([], project_with_pin)
+            ensure.assert_called_once()
+
+    def test_absent_git_binary_prints_message_not_traceback(
+        self, project_with_pin, capsys
+    ):
+        """A genuinely ABSENT git raises FileNotFoundError rather than
+        returning non-zero. Without catching it the friendly message
+        never prints and the user gets a raw traceback (found while
+        reproducing the BugBot finding)."""
+        with patch.object(_project_module, "_ensure_adversarial_cli"):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.side_effect = FileNotFoundError(2, "No such file", "git")
+                with pytest.raises(SystemExit) as exc:
+                    _project_module.cmd_install_evaluators([], project_with_pin)
+                assert exc.value.code == 1
+        assert "Git is required but not found" in capsys.readouterr().out
+
+    def test_cli_install_attempted_when_git_absent_but_uv_present(
+        self, project_with_pin, capsys
+    ):
+        """The whole point of the reorder: git broken, uv fine → the CLI
+        genuinely installs instead of being skipped."""
+        which = {"adversarial": None, "uv": "/usr/bin/uv"}
+        calls = []
+
+        def fake_run(cmd, *a, **k):
+            calls.append(cmd)
+            if cmd[0] == "git":
+                raise FileNotFoundError(2, "No such file", "git")
+            return MagicMock(returncode=0, stderr="")
+
+        with patch.object(
+            _project_module.shutil, "which", side_effect=lambda n: which.get(n)
+        ):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.side_effect = fake_run
+                with pytest.raises(SystemExit):
+                    _project_module.cmd_install_evaluators([], project_with_pin)
+
+        assert ["uv", "tool", "install", "adversarial-workflow==1.0.1"] in calls

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -1389,11 +1389,14 @@ class TestEnsureAdversarialCli:
         )
         return tmp_path
 
-    def test_present_cli_is_not_reinstalled(self, project_with_pin, capsys):
-        """Already on PATH → no install attempt at all."""
-        with patch.object(
-            _project_module.shutil, "which", return_value="/usr/bin/adversarial"
-        ):
+    def test_present_working_cli_is_not_reinstalled(self, project_with_pin, capsys):
+        """A WORKING CLI short-circuits: no install attempt at all.
+
+        Keys on _adversarial_cli_works, not shutil.which — presence alone
+        is no longer the gate (a present-but-broken binary must still
+        trigger a reinstall; see TestAdversarialCliLiveness).
+        """
+        with patch.object(_project_module, "_adversarial_cli_works", return_value=True):
             with patch.object(_project_module, "subprocess") as mock_sub:
                 _project_module._ensure_adversarial_cli(project_with_pin)
                 mock_sub.run.assert_not_called()
@@ -1559,3 +1562,198 @@ class TestInstallEvaluatorsEnsuresCli:
             ensure.assert_called_once()
 
         assert "already installed" in capsys.readouterr().out
+
+
+class TestAdversarialCliLiveness:
+    """Presence is not liveness (o3 + fast-v2, converging finding).
+
+    The install step must not print ✅ for a binary that `which` finds
+    but that fails to run — the very next `project doctor` would FAIL on
+    it, and the user would have two surfaces disagreeing about the same
+    install.
+    """
+
+    def test_present_but_broken_binary_is_not_working(self):
+        with patch.object(
+            _project_module.shutil, "which", return_value="/usr/bin/adversarial"
+        ):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.return_value = MagicMock(returncode=1)
+                assert _project_module._adversarial_cli_works() is False
+
+    def test_noisy_stderr_with_exit_zero_is_working(self):
+        """A healthy CLI prints 'Unknown fields in evaluator.yml' to
+        stderr — exit code is the signal, not output."""
+        with patch.object(
+            _project_module.shutil, "which", return_value="/usr/bin/adversarial"
+        ):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.return_value = MagicMock(
+                    returncode=0, stderr="Unknown fields in evaluator.yml: status"
+                )
+                assert _project_module._adversarial_cli_works() is True
+
+    def test_hanging_binary_is_not_working(self):
+        with patch.object(
+            _project_module.shutil, "which", return_value="/usr/bin/adversarial"
+        ):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.side_effect = subprocess.TimeoutExpired(
+                    cmd="adversarial --version", timeout=30
+                )
+                assert _project_module._adversarial_cli_works() is False
+
+    def test_absent_binary_is_not_working(self):
+        with patch.object(_project_module.shutil, "which", return_value=None):
+            assert _project_module._adversarial_cli_works() is False
+
+    def test_broken_existing_cli_triggers_install_not_false_ok(self, tmp_path):
+        """The whole point: a broken CLI already on PATH must NOT
+        short-circuit the install step with a ✅."""
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            'adversarial_cli_version: "1.0.1"\n', encoding="utf-8"
+        )
+        with patch.object(
+            _project_module, "_adversarial_cli_works", return_value=False
+        ):
+            with patch.object(
+                _project_module.shutil, "which", side_effect=lambda n: "/usr/bin/uv"
+            ):
+                with patch.object(_project_module, "subprocess") as mock_sub:
+                    mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                    mock_sub.run.return_value = MagicMock(returncode=0, stderr="")
+                    _project_module._ensure_adversarial_cli(tmp_path)
+                    # It attempted the install rather than returning early
+                    assert mock_sub.run.called
+
+    def test_post_install_broken_binary_advises_reinstall_not_path(
+        self, tmp_path, capsys
+    ):
+        """uv exits 0 but the binary doesn't run: the remedy is
+        --force reinstall, NOT a PATH change (three states, three
+        messages)."""
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            'adversarial_cli_version: "1.0.1"\n', encoding="utf-8"
+        )
+        which = {"adversarial": "/usr/bin/adversarial", "uv": "/usr/bin/uv"}
+        with patch.object(
+            _project_module, "_adversarial_cli_works", return_value=False
+        ):
+            with patch.object(
+                _project_module.shutil, "which", side_effect=lambda n: which.get(n)
+            ):
+                with patch.object(_project_module, "subprocess") as mock_sub:
+                    mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                    mock_sub.run.return_value = MagicMock(returncode=0, stderr="")
+                    _project_module._ensure_adversarial_cli(tmp_path)
+        out = capsys.readouterr().out
+        assert "not runnable" in out
+        assert "--force" in out
+        assert "export PATH" not in out
+
+
+class TestPyprojectMirrorPinForms:
+    """The mirror must read every pin form pyproject may carry — matching
+    only '>=' would read an exact pin as 'no pin' and send an installable
+    project down the instruct-only path (o3 review). KIT-0079 may write
+    an exact pin here.
+
+    Drives the REAL reader (not a re-implemented regex): the mirror is
+    located relative to the script's own __file__, so the fixture builds
+    a throwaway tree and points __file__ at it.
+    """
+
+    @pytest.mark.parametrize(
+        "spec,expected",
+        [
+            ('"adversarial-workflow>=1.0.1",', "1.0.1"),
+            ('"adversarial-workflow==1.2.3",', "1.2.3"),
+            ('"adversarial-workflow~=1.2",', "1.2"),
+            ('"adversarial-workflow >= 2.0.0",', "2.0.0"),
+        ],
+    )
+    def test_pin_forms_are_read(self, tmp_path, spec, expected):
+        # Mirror the real layout: <root>/scripts/core/project
+        fake_root = tmp_path / "root"
+        (fake_root / "scripts" / "core").mkdir(parents=True)
+        fake_script = fake_root / "scripts" / "core" / "project"
+        fake_script.write_text("", encoding="utf-8")
+        (fake_root / "pyproject.toml").write_text(
+            f"[project]\ndependencies = [\n    {spec}\n]\n", encoding="utf-8"
+        )
+
+        # A project dir with .adversarial/ but NO config.yml pin, so the
+        # reader must fall through to the pyproject mirror.
+        project_dir = tmp_path / "proj"
+        (project_dir / ".adversarial").mkdir(parents=True)
+
+        with patch.dict(_project_module.__dict__, {"__file__": str(fake_script)}):
+            got = _project_module._get_adversarial_cli_version(project_dir)
+        assert got == expected, f"pin form {spec!r} read as {got!r}, want {expected!r}"
+
+    def test_absent_dependency_reads_as_no_pin(self, tmp_path):
+        """No adversarial-workflow line at all → None, which callers turn
+        into instruct-don't-install (never unpinned latest)."""
+        fake_root = tmp_path / "root"
+        (fake_root / "scripts" / "core").mkdir(parents=True)
+        fake_script = fake_root / "scripts" / "core" / "project"
+        fake_script.write_text("", encoding="utf-8")
+        (fake_root / "pyproject.toml").write_text(
+            '[project]\ndependencies = ["pytest>=8.0"]\n', encoding="utf-8"
+        )
+        project_dir = tmp_path / "proj"
+        (project_dir / ".adversarial").mkdir(parents=True)
+        with patch.dict(_project_module.__dict__, {"__file__": str(fake_script)}):
+            assert _project_module._get_adversarial_cli_version(project_dir) is None
+
+
+class TestPinValidation:
+    """A hand-edited config.yml can hold anything; a junk pin must fail
+    CLEARLY rather than becoming 'adversarial-workflow==--force' and
+    surfacing as a baffling uv error (claude-code review).
+
+    Not an injection concern: the pin is a list element to
+    subprocess.run, never a shell string.
+    """
+
+    @pytest.mark.parametrize(
+        "value,ok",
+        [
+            ("1.0.1", True),
+            ("1.0.1rc1", True),
+            ("2026.1.0", True),
+            ("1.0.1-beta+build2", True),
+            ("--force", False),
+            ("$(whoami)", False),
+            ("1.0.1;", False),
+            ("", False),
+            ("latest", False),
+        ],
+    )
+    def test_version_like(self, value, ok):
+        assert _project_module._is_version_like(value) is ok
+
+    def test_junk_config_pin_does_not_reach_uv(self, tmp_path, capsys):
+        """A junk pin must not be installed. It falls through to the
+        pyproject mirror; with neither readable the caller instructs."""
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            'adversarial_cli_version: "--force"\n', encoding="utf-8"
+        )
+        fake_root = tmp_path / "root"
+        (fake_root / "scripts" / "core").mkdir(parents=True)
+        fake_script = fake_root / "scripts" / "core" / "project"
+        fake_script.write_text("", encoding="utf-8")
+        (fake_root / "pyproject.toml").write_text(
+            '[project]\ndependencies = ["pytest>=8.0"]\n', encoding="utf-8"
+        )
+        with patch.dict(_project_module.__dict__, {"__file__": str(fake_script)}):
+            assert _project_module._get_adversarial_cli_version(tmp_path) is None

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -1847,6 +1847,37 @@ class TestGitGateDoesNotBlockCliInstall:
                 assert exc.value.code == 1
         assert "Git is required but not found" in capsys.readouterr().out
 
+    def test_hung_git_probe_times_out_into_the_guidance_path(
+        self, project_with_pin, capsys
+    ):
+        """A wedged git (prompting credential helper, hung filesystem)
+        must time out into the same guidance, not hang the installer
+        forever (CodeRabbit round 2)."""
+        with patch.object(_project_module, "_ensure_adversarial_cli"):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.side_effect = subprocess.TimeoutExpired(
+                    cmd="git --version", timeout=20
+                )
+                with pytest.raises(SystemExit) as exc:
+                    _project_module.cmd_install_evaluators([], project_with_pin)
+                assert exc.value.code == 1
+        assert "Git is required but not found" in capsys.readouterr().out
+
+    def test_git_probe_is_bounded_and_stdin_closed(self, project_with_pin):
+        """The git probe carries the same bound and stdin handling as the
+        CLI probe — an unbounded one hangs install-evaluators."""
+        with patch.object(_project_module, "_ensure_adversarial_cli"):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.DEVNULL = subprocess.DEVNULL
+                mock_sub.run.return_value = MagicMock(returncode=1)
+                with pytest.raises(SystemExit):
+                    _project_module.cmd_install_evaluators([], project_with_pin)
+                kwargs = mock_sub.run.call_args.kwargs
+        assert kwargs.get("timeout") == _project_module.CLI_PROBE_TIMEOUT
+        assert kwargs.get("stdin") == subprocess.DEVNULL
+
     def test_cli_install_attempted_when_git_absent_but_uv_present(
         self, project_with_pin, capsys
     ):

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -51,6 +51,26 @@ with open(_script_path, encoding="utf-8") as f:
 class TestInstallEvaluatorsCommand:
     """Tests for install-evaluators command."""
 
+    @pytest.fixture(autouse=True)
+    def _no_cli_ensure(self):
+        """Stub the CLI-ensure step for the LIBRARY-install tests.
+
+        These tests drive subprocess.run with positional side_effect
+        lists ([git --version, git clone]), so any additional subprocess
+        call would shift the list and fail them for the wrong reason.
+        The CLI step (KIT-0083) is covered on its own in
+        TestEnsureAdversarialCli; isolating it here keeps these tests
+        about the library install.
+
+        Autouse rather than per-test: without it these tests pass or
+        fail depending on whether the MACHINE happens to have
+        `adversarial` on PATH (the real shutil.which short-circuits the
+        step) — exactly the environment-dependence that let issue #103
+        ship unnoticed.
+        """
+        with patch.object(_project_module, "_ensure_adversarial_cli"):
+            yield
+
     @pytest.fixture
     def mock_project_dir(self, tmp_path):
         """Create a temporary project directory structure."""
@@ -1148,6 +1168,12 @@ class TestRefBypassesPinRead:
     KIT-0068): planning-shape repos have no pyproject.toml, and the
     pin reader's own error message tells users to pass --ref."""
 
+    @pytest.fixture(autouse=True)
+    def _no_cli_ensure(self):
+        """See TestInstallEvaluatorsCommand._no_cli_ensure (KIT-0083)."""
+        with patch.object(_project_module, "_ensure_adversarial_cli"):
+            yield
+
     def test_ref_skips_pin_reader(self, tmp_path, capsys):
         evaluators_dir = tmp_path / ".adversarial" / "evaluators"
         evaluators_dir.mkdir(parents=True)
@@ -1175,6 +1201,17 @@ class TestNoOpRerunWithoutPin:
     """A no-op rerun (already installed, no --force) must succeed on a
     repo with no readable pyproject pin — the pin is only needed to
     clone (BugBot round 2, KIT-0068)."""
+
+    @pytest.fixture(autouse=True)
+    def _no_cli_ensure(self):
+        """See TestInstallEvaluatorsCommand._no_cli_ensure (KIT-0083).
+
+        The CLI step on THIS path (already-installed rerun) is asserted
+        separately by TestInstallEvaluatorsEnsuresCli — the #103 shape
+        is 'library present, CLI absent', so it must not be lost here.
+        """
+        with patch.object(_project_module, "_ensure_adversarial_cli"):
+            yield
 
     def test_already_installed_skips_pin_read(self, tmp_path, capsys):
         evaluators_dir = tmp_path / ".adversarial" / "evaluators"
@@ -1332,3 +1369,193 @@ class TestReconfigureMissingConfigRemedy:
         assert match.group(1).endswith("&& bash .serena/setup-serena.sh")
         # root-scoped: the command names the project dir, not a cwd guess
         assert dirname in match.group(1)
+
+
+class TestEnsureAdversarialCli:
+    """KIT-0083 / issue #103: install-evaluators must ensure the CLI too.
+
+    All installs are stubbed — these tests never touch the network and
+    never run a real `uv tool install`.
+    """
+
+    @pytest.fixture
+    def project_with_pin(self, tmp_path):
+        """A project whose .adversarial/config.yml carries the CLI pin."""
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            'task_directory: .kit/tasks/\nadversarial_cli_version: "1.0.1"\n',
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_present_cli_is_not_reinstalled(self, project_with_pin, capsys):
+        """Already on PATH → no install attempt at all."""
+        with patch.object(
+            _project_module.shutil, "which", return_value="/usr/bin/adversarial"
+        ):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                _project_module._ensure_adversarial_cli(project_with_pin)
+                mock_sub.run.assert_not_called()
+        assert "already installed" in capsys.readouterr().out
+
+    def test_missing_cli_installs_at_the_pinned_version(self, project_with_pin, capsys):
+        """Absent CLI + uv present → uv tool install at the config.yml pin."""
+        which = {"adversarial": None, "uv": "/usr/bin/uv"}
+        calls = []
+
+        def fake_which(name):
+            return which.get(name)
+
+        with patch.object(_project_module.shutil, "which", side_effect=fake_which):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.side_effect = lambda *a, **k: (
+                    calls.append(a[0]) or MagicMock(returncode=0, stderr="")
+                )
+                _project_module._ensure_adversarial_cli(project_with_pin)
+
+        assert calls == [["uv", "tool", "install", "adversarial-workflow==1.0.1"]]
+
+    def test_uv_absent_prints_command_and_continues(self, project_with_pin, capsys):
+        """No uv → instruct, never raise: the library install is the
+        primary job and must not fail over the optional CLI step."""
+        with patch.object(_project_module.shutil, "which", return_value=None):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                _project_module._ensure_adversarial_cli(project_with_pin)
+                mock_sub.run.assert_not_called()
+        out = capsys.readouterr().out
+        assert "uv tool install adversarial-workflow==1.0.1" in out
+        assert "uv is not installed" in out
+
+    def test_install_failure_does_not_raise(self, project_with_pin, capsys):
+        """A failed install degrades to advice — never a SystemExit."""
+        which = {"adversarial": None, "uv": "/usr/bin/uv"}
+        with patch.object(
+            _project_module.shutil, "which", side_effect=lambda n: which.get(n)
+        ):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.return_value = MagicMock(returncode=1, stderr="boom")
+                _project_module._ensure_adversarial_cli(project_with_pin)
+        assert "Retry manually" in capsys.readouterr().out
+
+    def test_install_timeout_does_not_raise(self, project_with_pin, capsys):
+        which = {"adversarial": None, "uv": "/usr/bin/uv"}
+        with patch.object(
+            _project_module.shutil, "which", side_effect=lambda n: which.get(n)
+        ):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.side_effect = subprocess.TimeoutExpired(
+                    cmd="uv tool install", timeout=300
+                )
+                _project_module._ensure_adversarial_cli(project_with_pin)
+        assert "timed out" in capsys.readouterr().out
+
+    def test_install_succeeds_but_not_on_path_warns(self, project_with_pin, capsys):
+        """uv installs into ~/.local/bin: a 'successful' install whose
+        binary stays invisible must say so here, not leave the doctor
+        check to be the first to notice."""
+        seen = {"n": 0}
+
+        def fake_which(name):
+            if name == "uv":
+                return "/usr/bin/uv"
+            # adversarial: absent before AND after the install
+            seen["n"] += 1
+            return None
+
+        with patch.object(_project_module.shutil, "which", side_effect=fake_which):
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.return_value = MagicMock(returncode=0, stderr="")
+                _project_module._ensure_adversarial_cli(project_with_pin)
+
+        out = capsys.readouterr().out
+        assert "not on your PATH" in out
+        assert ".local/bin" in out
+
+    def test_no_pin_anywhere_instructs_instead_of_installing_latest(
+        self, tmp_path, capsys
+    ):
+        """No readable pin → instruct, never unpinned-latest (KIT-0068 A08:
+        a silent fallback installed a five-versions-old library)."""
+        (tmp_path / ".adversarial").mkdir()
+        (tmp_path / ".adversarial" / "config.yml").write_text(
+            "task_directory: .kit/tasks/\n", encoding="utf-8"
+        )
+        which = {"adversarial": None, "uv": "/usr/bin/uv"}
+        with patch.object(
+            _project_module.shutil, "which", side_effect=lambda n: which.get(n)
+        ):
+            with patch.object(
+                _project_module, "_get_adversarial_cli_version", return_value=None
+            ):
+                with patch.object(_project_module, "subprocess") as mock_sub:
+                    _project_module._ensure_adversarial_cli(tmp_path)
+                    mock_sub.run.assert_not_called()
+        assert (
+            "Could not read the adversarial CLI version pin" in capsys.readouterr().out
+        )
+
+
+class TestAdversarialCliPinReader:
+    """The pin's canonical home is .adversarial/config.yml (KIT-0083 F3)."""
+
+    def test_reads_config_yml_pin(self, tmp_path):
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            'adversarial_cli_version: "1.2.3"\n', encoding="utf-8"
+        )
+        assert _project_module._get_adversarial_cli_version(tmp_path) == "1.2.3"
+
+    def test_config_yml_wins_over_pyproject_mirror(self, tmp_path):
+        """config.yml is canonical; pyproject is only a mirror."""
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            'adversarial_cli_version: "9.9.9"\n', encoding="utf-8"
+        )
+        assert _project_module._get_adversarial_cli_version(tmp_path) == "9.9.9"
+
+    def test_planning_shape_without_config_pin_falls_back_to_pyproject(self, tmp_path):
+        """No config.yml pin → the kit's own pyproject mirror still works.
+
+        (Reads the REAL repo pyproject, which is the mirror by design.)
+        """
+        (tmp_path / ".adversarial").mkdir()
+        assert _project_module._get_adversarial_cli_version(tmp_path) is not None
+
+    def test_commented_pin_is_not_read(self, tmp_path):
+        """A commented-out example must never be mistaken for the live pin."""
+        adv = tmp_path / ".adversarial"
+        adv.mkdir()
+        (adv / "config.yml").write_text(
+            '# adversarial_cli_version: "0.0.1"\ntask_directory: .kit/tasks/\n',
+            encoding="utf-8",
+        )
+        # Falls through to the pyproject mirror rather than reading 0.0.1
+        assert _project_module._get_adversarial_cli_version(tmp_path) != "0.0.1"
+
+
+class TestInstallEvaluatorsEnsuresCli:
+    """The CLI step must run even on the already-installed early return —
+    'library present, CLI absent' IS the #103 shape (KIT-0083)."""
+
+    def test_cli_ensured_before_already_installed_return(self, tmp_path, capsys):
+        evaluators_dir = tmp_path / ".adversarial" / "evaluators"
+        evaluators_dir.mkdir(parents=True)
+        (evaluators_dir / ".installed-version").write_text(
+            "v0.10.0 (abc12345)\n", encoding="utf-8"
+        )
+
+        with patch.object(_project_module, "_ensure_adversarial_cli") as ensure:
+            with patch.object(_project_module, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+                mock_sub.run.return_value = MagicMock(returncode=0)
+                _project_module.cmd_install_evaluators([], tmp_path)
+            ensure.assert_called_once()
+
+        assert "already installed" in capsys.readouterr().out

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -7,6 +7,7 @@ Focus: install-evaluators command with mocked subprocess calls.
 import importlib.util
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1904,6 +1905,32 @@ class TestGitGateDoesNotBlockCliInstall:
         assert ["uv", "tool", "install", "adversarial-workflow==1.0.1"] in calls
 
 
+def _assert_no_library_state_claim(output):
+    """Fail if `output` asserts anything about the LIBRARY's install state.
+
+    One shared assertion for both call sites. Rejecting a single literal
+    per test (e.g. only "library is installed" in one and only "still
+    installed" in the other) let each test pass on the OTHER's wording —
+    so swapping the two messages kept both green (CodeRabbit round 4).
+
+    A regex rather than `==` on whole lines: the guarantee here is
+    "makes no claim of this KIND", which a fixed expected string cannot
+    express — any new phrasing would silently escape it. Substring/regex
+    matching is justified for that reason (DK rules require the
+    justification, not the avoidance).
+    """
+    claim = re.search(
+        r"\blibrar(?:y|ies)\b[^\n]*\b(?:is|are|was|were|remains?|still|"
+        r"has been|already)\b",
+        output,
+        re.IGNORECASE,
+    )
+    assert not claim, (
+        "the CLI step claimed something about the library's state: "
+        f"{claim.group(0)!r}"
+    )
+
+
 class TestCliStepMakesNoLibraryClaims:
     """The CLI step runs BEFORE the git gate and the library clone, so it
     cannot assert anything about the library's state.
@@ -1933,7 +1960,7 @@ class TestCliStepMakesNoLibraryClaims:
                 _project_module._ensure_adversarial_cli(project_with_pin)
         out = capsys.readouterr().out
         assert "uv tool install adversarial-workflow==1.0.1" in out
-        assert "library is installed" not in out
+        _assert_no_library_state_claim(out)
 
     def test_install_failure_message_claims_nothing_about_the_library(
         self, project_with_pin, capsys
@@ -1949,4 +1976,4 @@ class TestCliStepMakesNoLibraryClaims:
                 _project_module._ensure_adversarial_cli(project_with_pin)
         out = capsys.readouterr().out
         assert "Retry manually" in out
-        assert "still installed" not in out
+        _assert_no_library_state_claim(out)


### PR DESCRIPTION
Closes the issue #103 trap: `.adversarial/` config and the evaluator library both shipped and `project doctor` reported PASS, but nothing ever installed the `adversarial` CLI binary and no check verified it. Every fresh project looked fully provisioned until the planner's Phase 3 gate ran `adversarial arch-review-fast` and got `command not found`.

Task: `.kit/tasks/3-in-progress/KIT-0083-ship-adversarial-cli.md`
Source issue: #103

## What changed

**F1 — install step.** `project install-evaluators` now ensures the CLI alongside the library: `command -v` → `uv tool install` at the pinned version. It runs **before** the already-installed early return, because "library present, CLI absent" *is* the #103 shape — a rerun there must still fix it. It never fails the command: absent uv, unreadable pin, failed install, and install-succeeded-but-not-on-PATH each degrade to printing the exact command (mirroring the existing git-missing block). Both help surfaces plus the door's interactive and non-TTY offer text now say "library + CLI".

**F2 — doctor check.** New `scripts/core/doctor.d/31-evaluator-cli.sh`: SKIP without `.adversarial/`, FAIL when the config is present but the binary isn't, PASS otherwise. It probes the `--version` **exit code**, never its output — a healthy CLI prints `Unknown fields in evaluator.yml` warnings to stderr. Manifest entry and its count assertions are updated in the same commit.

**F3 — pin coherence (#60).** Canonical home is now `.adversarial/config.yml`, which ships to **both** shapes; `pyproject.toml` stays a fallback mirror so the kit's own checkout keeps working.

**#60 is a location bug wearing a consistency costume.** The two pins were never inconsistent — they name different artifacts: `adversarial-workflow>=1.0.1` is a PyPI *distribution* (the CLI), `v0.10.0` is a *git tag* on `adversarial-evaluator-library`. A PyPI version and a git tag are not comparable, so there is nothing to reconcile. Root cause: both pins landed in `pyproject.toml` at `c851276` (KIT-0035) when the kit was single-shape and every project had one. The planning shape arrived later at `924a5bb` (KIT-0053) and deliberately never ships `pyproject.toml` (`engine-consumer.sh:294`), so half of all projects could not read their own pins. **The split did not create a bad location; it turned a previously-fine one into an unreadable one.** Any surface predating `924a5bb` is suspect for the same class. The rationale is recorded in `config.yml` itself so the next reader doesn't re-open it.

Never installs unpinned-latest (the KIT-0068 A08 class, where a silent fallback installed a five-versions-old library).

## Verification

Beyond the unit tests, verified end-to-end against a fixture of the exact #103 shape (library installed, CLI absent, uv absent):

```
DOCTOR:evaluators:PASS:evaluator library installed (1 entries)
DOCTOR:evaluator-cli:FAIL:adversarial CLI not on PATH — run: ./scripts/core/project install-evaluators ...
```

The old line still reports green and the new one FAILs beside it — the masking bug demonstrated closed, not merely asserted. Also verified: the uv-present path with a stub uv that "succeeds" without producing a binary (correctly reported as installed-but-not-on-PATH), and a `sleep 300` stub CLI (bounded FAIL at 20.2s rather than hanging).

`./scripts/core/ci-check.sh`: 7/7 stages, 872 passed, 12 skipped, 93% coverage.

## Tests

7 doctor cases and 20 install/pin cases, all with a controlled PATH or stubbed uv — no network, no real installs. **PATH control is the whole point**: `uv` and `adversarial` are both installed on the maintainer's machine, so an unrestricted probe passes locally and proves nothing about a fresh project. That blind spot is how #103 shipped.

The pre-existing `install-evaluators` tests gained an autouse stub for the CLI step; without it they passed or failed depending on whether the machine happened to have the CLI on PATH.

## Evaluator trio (run pre-PR, per the Phase 7 ordering rule)

fast=CONCERNS, o3=CONCERNS, claude-code=APPROVED. Full record: `.kit/context/reviews/KIT-0083-evaluator-review.md`.

Actioned: false-✅-on-broken-binary (both evaluators converged on it), `==` pins ignored by the mirror regex, unbounded `--version` probe, junk-pin validation.

Declined with reasons: `.adversarial`-as-a-file reporting SKIP (real, but `30-evaluators.sh` shares the identical `[ ! -d ]` test — fixing one alone would make sibling checks disagree; worth its own task if worth doing), and uv concurrent-install locking (speculative; uv locks itself and the failure already degrades to advice).

Worth noting: **my own new tests caught a real bug mid-fix.** The first bounded-probe implementation used a bare `sleep`, which doesn't exist under the restricted PATH the doctor tests run with — so the loop spun instantly and reported a **false FAIL on a healthy CLI**. Exactly the bug class this task exists to prevent, caught by the PATH-isolation discipline the task mandated.

## Deferred / noted, not touched

- **F4 (KIT-0082 hook)** — deferred: KIT-0082 is still in `1-backlog`, so there is no acceptance test to add the assertion to. For KIT-0082 to pick up.
- **`.claude/agents/create-project.md`** — deliberately untouched (operator decision, `041f75d`). It contradicts this install path in three places: `pipx` at `:180`/`:317`, per-evaluator `adversarial library install` at `:214-217`, and an unearned `adversarial-workflow: <version> verified` summary at `:260`. **KIT-0087 F3 owns that file**, and KIT-0078 F2 may delete it outright.
- **KIT-0055 overlap** — it needs the same `command -v adversarial` probe this adds, plus editable-install detection. Kept separate: F2 answers "does a binary exist", KIT-0055 answers "*which* binary is it", and the second is meaningless before the first.
- **KIT-0079** — consumes this PR's pin-home decision; `evaluator_library_version` is already written into `config.yml` for it to move the reader onto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches developer provisioning (`install-evaluators`, doctor) and version-pin resolution across shapes; behavior is heavily tested but mis-pinned or partial installs could still confuse users until they rerun doctor/install.
> 
> **Overview**
> Fixes issue **#103**: projects could pass doctor with the evaluator library installed but no `adversarial` CLI on PATH until Phase 3 evaluation failed.
> 
> **`project install-evaluators`** now runs **`_ensure_adversarial_cli` first** (before the “already installed” shortcut and before the git gate), using a **liveness** check (`adversarial --version` exit code, 20s bound)—not just `which`. It installs via **`uv tool install`** at a pinned version, degrades to printed instructions on failure, and never fails the whole command. **Git** probing is bounded and stdin-closed for the same hang reasons.
> 
> **New doctor check** `31-evaluator-cli.sh` FAILs when `.adversarial/` exists but the CLI is missing or not runnable; it stays separate from the library tree check in `30-evaluators.sh`.
> 
> **Pins** move to **`.adversarial/config.yml`** (`adversarial_cli_version`, `evaluator_library_version`) so planning-shape repos without `pyproject.toml` can read them; pyproject remains a mirror for the CLI pin. Junk pins are rejected; library pin drift vs pyproject is tested until KIT-0079.
> 
> Bootstrap/help text now says **library + CLI**. Manifest counts and broad PATH-isolated tests cover doctor, installer, pin precedence, and git/CLI ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98b667835c42dc653d97ad59f401796191a9e28d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->