### PR TITLE
fix(KIT-0080): portable git path resolution (Apple git 2.30.1)

### DIFF
--- a/.claude/commands/setup-preset.md
+++ b/.claude/commands/setup-preset.md
@@ -62,10 +62,17 @@ language, one question at a time, then writing
 The config home is a visible sibling of the kit's primary clone:
 
 ```bash
-git rev-parse --path-format=absolute --git-common-dir
+cd "$(git rev-parse --git-common-dir)" && pwd
 ```
 
-Take the parent of the parent of that path, plus `/agentive-config`.
+Take the parent of that path, plus `/agentive-config`.
+
+(Do not use `git rev-parse --path-format=absolute` here: that flag
+needs git ≥ 2.31, and stock macOS ships Apple Git 2.30.1, which echoes
+the flag back as an output line instead of consuming it — you would
+silently compute a garbage path. The `cd`-then-`pwd` form above is
+portable across both, because plain `--git-common-dir` may print a
+path relative to the repo directory. — KIT-0080)
 If `AGENTIVE_KIT_CONFIG_DIR` is set in the environment, it overrides
 the location entirely (it is an override, never a search chain — do
 not look anywhere else). If the `git rev-parse` command fails (you

--- a/.kit/context/KIT-0080-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0080-HANDOFF-feature-developer.md
@@ -5,7 +5,7 @@
 **Date**: 2026-08-06
 **From**: planner-f5
 **To**: feature-developer
-**Task**: `.kit/tasks/3-in-progress/KIT-0080-doctor-apple-git-230-incompat.md`
+**Task**: `.kit/tasks/4-in-review/KIT-0080-doctor-apple-git-230-incompat.md`
 **Status**: Ready — KIT-0083 merged (d1e938e); this is the next assignment
 **Evaluation**: skipped (planner) — bugfix with a live-verified fix
 recipe and a causally-confirmed diagnosis; decisions are in-spec.
@@ -119,6 +119,6 @@ portability rule; the `timeout` lesson).
 
 ---
 
-**Task File**: `.kit/tasks/3-in-progress/KIT-0080-doctor-apple-git-230-incompat.md`
+**Task File**: `.kit/tasks/4-in-review/KIT-0080-doctor-apple-git-230-incompat.md`
 **Key evidence**: spec's 2026-08-05 causal table;
 `.kit/context/KIT-0083-SESSION-FINDINGS.md` F1 (working one-liner)

--- a/.kit/context/KIT-0080-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0080-REVIEW-STARTER.md
@@ -1,0 +1,130 @@
+# KIT-0080 — Human Review Starter
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/107
+**Branch**: `feature/KIT-0080-portable-git-resolution`
+**Head**: `fdb7ea4` · 3 commits · 14 files, +788/-14
+**Task**: `.kit/tasks/4-in-review/KIT-0080-doctor-apple-git-230-incompat.md`
+**Evaluator record**: `.kit/context/reviews/KIT-0080-evaluator-review.md`
+
+## What this fixes
+
+`git rev-parse --path-format=absolute` needs git ≥ 2.31. Apple's system
+git (2.30.1, stock on macOS) does **not** consume the flag — it echoes it
+back as the first output line and still **exits 0**. Every kit resolver
+built on it produced garbage, and CI could never catch it because Ubuntu
+runners ship modern git.
+
+| Symptom | Before (real 2.30.1) | After |
+|---|---|---|
+| **S1** stray stderr | `dirname: illegal option -- -` | clean, empty stderr |
+| **S2** `test_doctor.py` | 8 failed / 152 passed | **160 passed** |
+| **S3** preset home | `./agentive-config` (relative garbage) | correct absolute sibling |
+| **S4** `new-worktree.sh` | died; default topology unusable | provisions normally |
+
+## The evidence situation changed — read this first
+
+The task spec and handoff both state the local repro is **GONE** and that
+stub fixtures are the only proof mechanism. That turned out to be wrong in
+the operator's favour: **Apple git 2.30.1 is still on this machine at
+`/usr/bin/git`**. The Homebrew upgrade shadowed it via PATH, it did not
+remove it (the spec's own "Reproduction after the upgrade" section says
+exactly this — it was just read as unavailable).
+
+So every claim here is verified against the **real 2.30.1 binary**, not an
+emulation, including the untruncated 8-failure baseline the spec's
+correction #1 insisted on. The stub fixtures still ship, because they are
+the only 2.30.x coverage that runs in CI.
+
+## Gate status (all green)
+
+| Gate | Status |
+|---|---|
+| CI (lint + tests 3.10/3.12/3.14) | PASS — 6/6 checks |
+| CodeRabbit | **APPROVED** |
+| BugBot | PASS, no findings |
+| Review threads | 1 total, 1 resolved, 0 unresolved |
+| Evaluator trio | PASS / CONCERNS / APPROVED — triaged |
+| Local `ci-check.sh` | green, 932 passed, 93% coverage |
+
+## Review guidance — where to look
+
+**1. The two hazards introduced by the fix itself** (most worth your eyes).
+Neither was in the spec; both are the same silent-wrong-answer class the
+task exists to kill:
+
+- **`cd ""` is a silent no-op.** An empty rev-parse result would have made
+  "not a repo" resolve to a confident wrong path. Every resolver now
+  emptiness-checks *before* joining. Covered by the non-repo SKIP tests.
+- **`cd`+`pwd` resolves symlinked ancestors.** It would have reported
+  physical paths (`/var` → `/private/var`), breaking the door/doctor
+  equivalence invariant that `tests/test_setup_door.py` pins. The doctor
+  and door resolvers now join by **string**; `new-worktree.sh` deliberately
+  keeps `cd`+`pwd` because its value creates files rather than being
+  compared, and says so in a comment.
+
+**2. The floor moved 2.31 → 2.30 (a judgment call).** F4 said the floor
+"drops accordingly" if F1 makes things portable. It does, so stock macOS
+now **passes** rather than being warned at. README Requirements row updated
+to match, and `test_floor_agrees_with_the_readme_requirements_row` pins the
+two so they cannot drift. If you'd rather keep 2.31 as the advertised floor,
+that's a one-line change in `15-git-version.sh` plus the README row.
+
+**3. A 7th site the handoff didn't list.**
+`.claude/commands/setup-preset.md:65` instructed *agents* to run the
+unportable command — same bug, agent-executed. Fixed.
+
+## Falsification — every guard was broken once
+
+Each new guard was reverted to the **pristine pre-fix code**
+(`git show HEAD~1:…`, not a hand-edit) and watched to fail:
+
+| Reverted | Test that caught it |
+|---|---|
+| `90-config-home.sh` | reproduces S1's `dirname: illegal option -- -` |
+| `70` / `55` | "verdict diverged between git versions" + S1 |
+| `new-worktree.sh` | "S4 regressed — helper died on git 2.30.x" |
+| the emptiness guard | non-repo SKIP tests fail |
+| any `scripts/` file | the widened flag guard fails |
+
+The stub itself is pinned by `TestOldGitStubIsFaithful`, so it cannot go
+vacuously green.
+
+## Evaluator triage — 1 of 5 actioned, 4 refuted
+
+`code-reviewer` (o3) returned CONCERNS with 5 findings. Per the
+verify-before-believing reflex each was measured, not accepted:
+
+- **ACTIONED** — the regression guard only scanned `doctor.d`, so the
+  `scripts/local/` half (S3 + S4, the bug's most expensive faces) could
+  regress silently. Widened repo-wide, falsified.
+- **REFUTED ×4** — filesystem-root `dirname` math (unchanged pre-existing
+  code, and the arithmetic claim is wrong: `//agentive-config`, not empty);
+  `../.git` breaking the worktree comparison (git returns **absolute** paths
+  from a linked worktree — measured on a real pair); MSYS 2.30 bypassing the
+  floor (the fix is build-independent, so PASS is correct); the ERR trap
+  swallowing the exit code (measured: still exits 1).
+
+Each disproof with its measurement is in the evaluator record, so the next
+reader doesn't re-litigate them.
+
+CodeRabbit's one finding was real and independent of all five: both stub
+fixtures interpolated git's path into a bash `REAL=` assignment unquoted,
+so a spaced git path (e.g. an Xcode-bundled git) made the stub exit 127
+instead of emulating 2.30.x. Fixed in `fdb7ea4`, verified both ways.
+
+## Out of scope (per handoff)
+
+- KIT-ADR-0028 package extraction — this fix migrates there later; today's
+  users need it now
+- Preset authoring / `.env` seeding (KIT-0084 shipped it)
+- `feature-developer.md` worktree contract (KIT-0088, already landed)
+- The resolved 8-vs-3 baseline history
+
+## Note for the planner
+
+One environmental snag worth knowing: this repo's fetch refspec is narrowed
+to `+refs/heads/main:refs/remotes/origin/main`, so from a worktree
+`git push -u` cannot create a tracking ref and `gh pr create` refuses
+without an explicit `--head`. I worked around it rather than changing what
+looked like a deliberate repo config choice — but it will bite every future
+worktree session the same way, so it may deserve its own task.

--- a/.kit/context/reviews/KIT-0080-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0080-evaluator-review.md
@@ -1,0 +1,89 @@
+# KIT-0080 — Evaluator Review Record
+
+**Date**: 2026-08-06
+**Branch**: `feature/KIT-0080-portable-git-resolution`
+**Commit reviewed**: `eaf2c04`
+**Input**: `.adversarial/inputs/KIT-0080-code-review-input.md` (full-file
+context, 13 files, 8,978 lines)
+**Ordering**: trio run BEFORE the PR was opened (KIT-0035/KIT-0046 rule).
+
+## Trio results
+
+| Evaluator | Model | Verdict |
+|-----------|-------|---------|
+| `code-reviewer-fast` | gemini-2.5-flash | **PASS** |
+| `code-reviewer` | o3 | **CONCERNS** (5 findings) |
+| `claude-code` | claude-sonnet-4-6 | **APPROVED** |
+
+Logs: `.adversarial/logs/KIT-0080-code-review-input--*.md`
+
+## Triage of the 5 CONCERNS findings
+
+Per the verify-before-believing reflex, each was tested against the
+actual tree / actual git behavior rather than accepted on assertion.
+**One was real and is fixed; four were refuted by direct measurement.**
+
+### 1. ACTIONED — flag guard only scanned `doctor.d`
+
+> "Portable-flag sweep is limited to doctor.d — other scripts might
+> regress silently."
+
+**Real and worth fixing.** The bug's two most expensive faces (S3's
+silent preset miss, S4's hard death) both live in `scripts/local/`, so
+a guard watching only `doctor.d` would let the worse half regress.
+Widened to all of `scripts/` and renamed
+`test_no_script_still_uses_the_unportable_flag`. Falsified: reverting
+`scripts/local/new-worktree.sh` to its pre-fix form now fails the
+guard, where previously it passed.
+
+### 2. REFUTED — "wrong parent calculation at filesystem root"
+
+Claim: for a checkout at `/repo`, `dirname "$(dirname /repo/.git)"`
+returns an empty string, yielding `/agentive-config`.
+
+Measured: `dirname /repo/.git` → `/repo`; `dirname /repo` → `/`. The
+result is `//agentive-config`, not the claimed empty string. More
+importantly the double-`dirname` is **unchanged pre-existing code**
+(`git show HEAD~1:scripts/core/doctor.d/90-config-home.sh:52` is
+byte-identical) — not a regression from this PR, and a repo at the
+filesystem root is not a topology the kit supports. Out of scope.
+
+### 3. REFUTED — "`../.git` breaks the worktree path comparison"
+
+Claim: in a linked worktree `--git-common-dir` prints `../.git`, so
+the string join leaves `..` and the equality check misfires.
+
+Measured on a real primary+worktree pair, both git versions:
+`git -C <worktree> rev-parse --git-common-dir` returns an **absolute**
+path; `--git-dir` returns an absolute path too. From the primary both
+flags return the identical `.git`, so the comparison correctly reports
+"not a worktree". The premise about git's output is simply wrong.
+
+### 4. REFUTED (premise wrong) — "MSYS `2.30.windows.1` bypasses the floor"
+
+Claim: MSYS 2.30.* PASSes the floor but "carries the same broken
+`--path-format` behaviour — the portability fix only covers 2.30.1
+Apple". Measured: it does PASS. But the fix is **build-independent** —
+no resolver calls `--path-format` on any platform any more, so 2.30 on
+any build is genuinely supported. PASS is the correct verdict; warning
+there would cry wolf.
+
+### 5. REFUTED — "ERR trap makes the helper exit 0 on failure"
+
+Claim: `trap '…' ERR` overrides `set -e`, so provisioning failure
+exits 0 and automation believes the worktree was created.
+
+Measured directly: a `set -euo pipefail` script with a non-exiting ERR
+trap and a failing command exits **1**. The trap prints and the shell
+still aborts with a failing status. Claim is false.
+
+## Known evaluator blind spot
+
+Nothing CSS/dual-render-path shaped in this diff, so the documented
+blind spot does not apply.
+
+## Post-triage state
+
+Suite re-run after the finding-1 fix: green on modern git AND on the
+real Apple git 2.30.1 binary (`/usr/bin/git`, still present on this
+machine) — see the PR body for counts.

--- a/.kit/tasks/4-in-review/KIT-0080-doctor-apple-git-230-incompat.md
+++ b/.kit/tasks/4-in-review/KIT-0080-doctor-apple-git-230-incompat.md
@@ -1,6 +1,6 @@
 # KIT-0080: doctor.d checks + tests break on Apple git 2.30.1
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: high (raised from medium 2026-08-04 — see S3: the same root
 cause silently disables operator-preset resolution in the setup door.
 Reaffirmed 2026-08-05: **S4** makes it a hard block on the default

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Using agents to build software works better if you add a bit of structure — An
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| **git** | **≥ 2.31** | ⚠️ Stock macOS ships Apple Git 2.30.1 — one minor version too old. The kit's scripts use `git rev-parse --path-format=absolute` (added in 2.31, March 2021); on 2.30.1 the failures range from silent (operator preset ignored by the setup door) to hard (worktree helper dies). Fix: `brew install git`, then `hash -r` in existing shells. KIT-0080 tracks making the scripts portable to older git; 2.31+ stays recommended regardless. |
+| **git** | **≥ 2.30** | Stock macOS (Apple Git 2.30.1) works. The kit's scripts used to require ≥ 2.31 via `git rev-parse --path-format=absolute`, which 2.30.1 echoes back instead of consuming — silently (operator preset ignored by the setup door) or hard (worktree helper died). KIT-0080 made every resolver portable, so the floor is now 2.30; `project doctor` WARNs below it. Note `xcode-select --install` does **not** raise Apple's git — its Command Line Tools ship 2.30.x by design; use `brew install git` (then `hash -r`) if you want a newer one. |
 | **gh** | any recent | Authenticated: `gh auth status` must pass |
 | **Python** | ≥ 3.10 | For code-project shapes (CI tests 3.10/3.12/3.14); planning-shape repos need only system `python3` |
 | **Claude Code** | current | The kit is built around it |

--- a/scripts/.core-manifest.json
+++ b/scripts/.core-manifest.json
@@ -9,6 +9,7 @@
       "core/check_cross_repo_config.py",
       "core/ci-check.sh",
       "core/doctor.d/10-gh-auth.sh",
+      "core/doctor.d/15-git-version.sh",
       "core/doctor.d/20-env-keys.py",
       "core/doctor.d/30-evaluators.sh",
       "core/doctor.d/31-evaluator-cli.sh",

--- a/scripts/core/doctor.d/15-git-version.sh
+++ b/scripts/core/doctor.d/15-git-version.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: git meets the kit's supported version floor (KIT-0080 F4).
+#
+# Incident (KIT-0080): the kit's path resolvers used
+# `git rev-parse --path-format=absolute`, a flag added in git 2.31
+# (March 2021). Stock macOS ships Apple Git 2.30.1 — one minor version
+# below — which does NOT consume the flag: it echoes it back as the
+# first output line and still exits 0. Failures ranged from silent (the
+# setup door resolved an operator path to relative garbage, so a
+# correctly-authored preset was ignored on every run and planning repos
+# came out misprovisioned) to hard (new-worktree.sh died, making the
+# kit's DEFAULT session topology unusable). CI could not catch any of
+# it: Ubuntu runners ship modern git, so the whole class was green in
+# CI and broken on stock Macs.
+#
+# KIT-0080 made every resolver portable, which is why the floor below is
+# 2.30 and not 2.31 — this check documents the floor the scripts
+# actually hold to, and turns the next such incident loud instead of
+# silent. Raise FLOOR_* here (and the README Requirements row, which
+# must agree) if the kit ever adopts a newer git feature.
+#
+# Verdicts:
+#   PASS  git present and at/above the floor
+#   WARN  git present but below the floor (named, with the remedy)
+#   WARN  git present but the version string is unparseable
+#   FAIL  git not installed at all
+#
+# Read-only, no network. Portable by construction: `git --version` plus
+# bash string ops — no Homebrew-only tools (README portability rule; the
+# `timeout` lesson), and deliberately no sort -V, whose BSD/GNU
+# availability differs across the platforms the kit supports.
+
+set -u
+
+FLOOR_MAJOR=2
+FLOOR_MINOR=30
+FLOOR="$FLOOR_MAJOR.$FLOOR_MINOR"
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "DOCTOR:git-version:FAIL:git not installed — the kit's task, worktree and CI flows all run through it (install: https://git-scm.com/downloads)"
+    exit 0
+fi
+
+RAW="$(git --version 2>/dev/null)" || RAW=""
+
+# `git version 2.30.1 (Apple Git-130)` -> `2.30.1 (Apple Git-130)` -> `2.30.1`
+VERSION="${RAW#git version }"
+VERSION="${VERSION%% *}"
+
+# Split on dots without a subshell or external tool. A non-numeric or
+# absent field must not be silently treated as 0 — that would let an
+# unparseable string masquerade as an ancient (or modern) git, so bail
+# to WARN instead and name what we saw.
+MAJOR="${VERSION%%.*}"
+# A version with no dot at all ("git version 2") leaves REST identical
+# to VERSION, which would silently reuse the major as the minor and read
+# "2" as 2.2. Require the dot explicitly.
+if [ "$VERSION" = "${VERSION#*.}" ]; then
+    MINOR=""
+else
+    REST="${VERSION#*.}"
+    MINOR="${REST%%.*}"
+fi
+
+case "$MAJOR" in
+    '' | *[!0-9]*) MAJOR="" ;;
+esac
+case "$MINOR" in
+    '' | *[!0-9]*) MINOR="" ;;
+esac
+
+if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || [ "$VERSION" = "$RAW" ]; then
+    echo "DOCTOR:git-version:WARN:cannot parse the git version from '$RAW' — the kit needs git >= $FLOOR; verify manually with: git --version"
+    exit 0
+fi
+
+if [ "$MAJOR" -gt "$FLOOR_MAJOR" ] \
+    || { [ "$MAJOR" -eq "$FLOOR_MAJOR" ] && [ "$MINOR" -ge "$FLOOR_MINOR" ]; }; then
+    echo "DOCTOR:git-version:PASS:git $VERSION meets the supported floor (>= $FLOOR)"
+    exit 0
+fi
+
+# Below the floor. `xcode-select --install` is the intuitive first thing
+# to try and does NOT help — Apple's Command Line Tools ship 2.30.x by
+# design (a constrained system binary, not a stale download), so the
+# remedy names the two things that do work.
+echo "DOCTOR:git-version:WARN:git $VERSION is below the supported floor ($FLOOR) — path resolution and worktree flows may misbehave; upgrade with 'brew install git' then 'hash -r' (note: xcode-select --install does NOT help — Apple's CLT ship 2.30.x by design)"
+exit 0

--- a/scripts/core/doctor.d/55-worktree-provisioning.sh
+++ b/scripts/core/doctor.d/55-worktree-provisioning.sh
@@ -47,8 +47,33 @@ ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 # SHARED with the primary, so an in-worktree setup must say --no-hooks
 # or the reinstall re-points them at a venv that dies with the
 # worktree (BugBot, this PR).
-GIT_DIR_PATH="$(git -C "$ROOT" rev-parse --path-format=absolute --git-dir 2>/dev/null)" || GIT_DIR_PATH=""
-GIT_COMMON="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || GIT_COMMON=""
+# KIT-0080: --path-format=absolute needs git >= 2.31; Apple's system git
+# (2.30.1) echoes the flag back as an output line and exits 0, so both
+# vars became two-line garbage — they compared unequal, the check claimed
+# "in a worktree", and PRIMARY_ROOT resolved through a dirname that
+# errored to stderr. Every Serena verdict below was then computed against
+# a nonexistent primary (it reported SKIP "project does not use Serena").
+# Plain flags are portable; output is relative to the -C directory, so
+# absolutize there.
+#
+# Emptiness-checked BEFORE joining: on failure the substitution is
+# empty, which would otherwise resolve to $ROOT — turning "not a repo"
+# into a confident wrong answer and defeating the not-a-checkout SKIP
+# below. A relative answer is joined by STRING rather than `cd`+`pwd`,
+# so a symlinked checkout keeps its logical path (/var -> /private/var
+# on macOS); the two vars are only ever compared with each other, so
+# both must normalize the same way.
+git_path() {  # $1 = rev-parse path flag; prints an absolute path or nothing
+    local raw
+    raw="$(git -C "$ROOT" rev-parse "$1" 2>/dev/null)" || return 0
+    case "$raw" in
+        '') return 0 ;;
+        /*) printf '%s\n' "$raw" ;;
+        *)  printf '%s\n' "$ROOT/$raw" ;;
+    esac
+}
+GIT_DIR_PATH="$(git_path --git-dir)"
+GIT_COMMON="$(git_path --git-common-dir)"
 IN_WORKTREE=""
 if [ -n "$GIT_DIR_PATH" ] && [ -n "$GIT_COMMON" ] \
     && [ "$GIT_DIR_PATH" != "$GIT_COMMON" ]; then

--- a/scripts/core/doctor.d/70-core-bare.sh
+++ b/scripts/core/doctor.d/70-core-bare.sh
@@ -27,10 +27,31 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
-COMMON_DIR="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || {
+# KIT-0080: plain --git-common-dir, absolutized in shell. The
+# --path-format=absolute form needs git >= 2.31; Apple's system git
+# (2.30.1) echoes the flag back as an output line and still exits 0, so
+# the SKIP branch below never fired and COMMON_DIR became garbage — the
+# check then read core.bare from a nonexistent git dir and always said
+# PASS, blinding the KIT-0043 canary. Plain output may be relative to
+# the -C directory, hence the join below.
+#
+# The result is emptiness-checked BEFORE joining: on failure the
+# substitution is empty, which would otherwise resolve to $ROOT —
+# turning "not a repo" into a confident wrong answer, the very class
+# this task removes. A relative answer is joined by STRING rather than
+# `cd`+`pwd`, so a symlinked checkout keeps its logical path in the
+# verdict line (/var -> /private/var on macOS).
+COMMON_DIR=""
+COMMON_RAW="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null)" || COMMON_RAW=""
+case "$COMMON_RAW" in
+    '') COMMON_DIR="" ;;
+    /*) COMMON_DIR="$COMMON_RAW" ;;
+    *)  COMMON_DIR="$ROOT/$COMMON_RAW" ;;
+esac
+if [ -z "$COMMON_DIR" ]; then
     echo "DOCTOR:core-bare:SKIP:not a git repository ($ROOT)"
     exit 0
-}
+fi
 
 BARE="$(git --git-dir "$COMMON_DIR" config --get core.bare 2>/dev/null)"
 

--- a/scripts/core/doctor.d/90-config-home.sh
+++ b/scripts/core/doctor.d/90-config-home.sh
@@ -48,7 +48,34 @@ resolve_home() {
         return 0
     fi
     local common
-    common="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+    # KIT-0080: --path-format=absolute needs git >= 2.31; Apple's system
+    # git (2.30.1) does not consume the flag, echoes it back as the first
+    # output line and exits 0 — the nested dirname then sees an arg
+    # starting with `--` (the stray `dirname: illegal option`) and the
+    # home resolved to the relative garbage ./agentive-config, silently
+    # hiding the operator preset. Plain --git-common-dir is portable; its
+    # output is relative to the -C directory, so absolutize there.
+    #
+    # Emptiness-checked BEFORE joining: on failure the substitution is
+    # empty, which would otherwise resolve to $ROOT — a confident wrong
+    # home instead of the rc 1 that drives the SKIP branch.
+    #
+    # A RELATIVE answer (both gits print a bare ".git" from a primary
+    # clone) is joined by string, not by `cd`+`pwd`: cd-ing resolves
+    # symlinked ancestors and would return the PHYSICAL path, changing
+    # the reported home on any symlinked checkout (/var -> /private/var
+    # on macOS). String-joining preserves the caller's logical path,
+    # matching what this check reported before KIT-0080.
+    local raw
+    raw="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null)" || return 1
+    [ -n "$raw" ] || return 1
+    case "$raw" in
+        /*) common="$raw" ;;
+        *)  common="$ROOT/$raw" ;;
+    esac
+    # Two levels: $common is <primary-clone>/.git, so one dirname gives
+    # the clone root and the second its PARENT, which is where the
+    # visible agentive-config sibling lives.
     printf '%s\n' "$(dirname "$(dirname "$common")")/agentive-config"
 }
 

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1748,7 +1748,6 @@ def _config_home(project_dir):
                 "-C",
                 str(project_dir),
                 "rev-parse",
-                "--path-format=absolute",
                 "--git-common-dir",
             ],
             capture_output=True,
@@ -1761,7 +1760,24 @@ def _config_home(project_dir):
     common = result.stdout.strip()
     if result.returncode != 0 or not common:
         return None
-    return Path(common).parent.parent / "agentive-config"
+    # KIT-0080: plain --git-common-dir, absolutized here. The
+    # --path-format=absolute form needs git >= 2.31; Apple's system git
+    # (2.30.1) echoes the flag back as an output line and exits 0, so
+    # `common` became "--path-format=absolute\n<path>" and the home
+    # resolved to garbage. Plain output is RELATIVE to the -C directory
+    # (both gits return a bare ".git" from a primary clone), so anchor
+    # it on project_dir — never on the process cwd. `/` already discards
+    # the left operand when `common` is absolute.
+    #
+    # No .resolve(): that would follow symlinked ancestors and report a
+    # PHYSICAL path, diverging from the bash resolvers this function is
+    # pinned equivalent to (tests/test_setup_door.py). os.path.normpath
+    # collapses the "<root>/.git" join without touching symlinks.
+    # Two levels: `joined` is <primary-clone>/.git, so .parent is the
+    # clone root and .parent.parent its PARENT, where the visible
+    # agentive-config sibling lives.
+    joined = Path(os.path.normpath(Path(project_dir) / common))
+    return joined.parent.parent / "agentive-config"
 
 
 def _print_preset_comparison(shape, profile, bots, record_errors, project_dir):

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -171,7 +171,30 @@ config_home() {
         return 0
     fi
     local common
-    common="$(git -C "$PROJECT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+    # KIT-0080: --path-format=absolute needs git >= 2.31; Apple's system
+    # git (2.30.1) echoes the flag back as an output line and exits 0.
+    # That made this resolve to the relative garbage ./agentive-config,
+    # so a correctly-authored operator preset was SILENTLY ignored on
+    # every door run on stock macOS (S3 — misprovisioned planning
+    # repos). Plain --git-common-dir is portable; its output is relative
+    # to the -C directory, so absolutize there.
+    # Emptiness-checked BEFORE joining: on failure the substitution is
+    # empty, which would otherwise resolve to $PROJECT_ROOT — a
+    # confident wrong home instead of the rc 1 that tells the preset
+    # layer there is nothing to read. A relative answer is joined by
+    # STRING, not `cd`+`pwd`, so a symlinked checkout keeps its logical
+    # path (doctor's mirror of this resolver does the same, and the
+    # equivalence test pins the two together).
+    local raw
+    raw="$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)" || return 1
+    [ -n "$raw" ] || return 1
+    case "$raw" in
+        /*) common="$raw" ;;
+        *)  common="$PROJECT_ROOT/$raw" ;;
+    esac
+    # Two levels: $common is <primary-clone>/.git, so one dirname gives
+    # the clone root and the second its PARENT, the visible sibling's
+    # home.
     printf '%s\n' "$(dirname "$(dirname "$common")")/agentive-config"
 }
 

--- a/scripts/local/new-worktree.sh
+++ b/scripts/local/new-worktree.sh
@@ -33,7 +33,25 @@ set -euo pipefail
 # must always resolve to the primary clone, so derive it from the shared
 # git common dir instead of the script location.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir)"
+# KIT-0080: --path-format=absolute needs git >= 2.31. Apple's system git
+# (2.30.1, stock on macOS) does not consume the flag — it echoes it back
+# as the first output line and exits 0, so PRIMARY_ROOT became garbage
+# and the guard below hard-exited: worktree creation, the kit's DEFAULT
+# session topology, was dead on stock macOS. Plain --git-common-dir is
+# portable across both; its output is relative to the -C directory, so
+# absolutize there (anchor on the repo dir, never the caller's cwd).
+GIT_COMMON_RAW="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir)"
+if [ -z "$GIT_COMMON_RAW" ]; then
+    # `cd ""` is a silent no-op, so an empty result would resolve to
+    # SCRIPT_DIR and provision against the wrong tree — refuse instead.
+    echo "Error: git could not resolve the common dir from $SCRIPT_DIR" >&2
+    exit 1
+fi
+# cd+pwd here (rather than the string join the doctor resolvers use):
+# this value is never COMPARED with another path, it is used to create
+# symlinks and worktrees, so the fully-resolved physical path is the
+# safer one.
+GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && cd "$GIT_COMMON_RAW" && pwd)"
 PRIMARY_ROOT="$(dirname "$GIT_COMMON_DIR")"
 
 # Guard: the dirname math assumes a normal clone (<root>/.git). A bare

--- a/tests/test_core_manifest.py
+++ b/tests/test_core_manifest.py
@@ -140,7 +140,7 @@ class TestManifestConsistency:
 
     def test_scripts_core_count(self, manifest):
         count = len(manifest["files"]["scripts_core"])
-        assert count == 27, f"Expected 27 scripts_core entries, got {count}"
+        assert count == 28, f"Expected 28 scripts_core entries, got {count}"
 
     def test_commands_core_count(self, manifest):
         count = len(manifest["files"]["commands_core"])
@@ -156,7 +156,7 @@ class TestManifestConsistency:
 
     def test_total_entry_count(self, manifest):
         total = sum(len(entries) for entries in manifest["files"].values())
-        assert total == 48, f"Expected 48 total entries, got {total}"
+        assert total == 49, f"Expected 49 total entries, got {total}"
 
 
 def _planning_heredoc_core_version(engine_text: str) -> str | None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2127,3 +2127,304 @@ def test_probe_bounds_match_the_installer():
         f"probe bounds drifted: doctor={doctor_bound.group(1)}s, "
         f"installer={installer_bound.group(1)}s"
     )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# KIT-0080: portable git path resolution + the git-version floor check
+# ─────────────────────────────────────────────────────────────────────
+# Root cause: `git rev-parse --path-format=absolute` needs git >= 2.31.
+# Apple's system git (2.30.1, stock on macOS) does NOT consume the flag —
+# it echoes it back as the first output line and still exits 0, so every
+# resolver built on it silently produced garbage. CI runners ship modern
+# git, so nothing here would regress loudly without the stub below: it
+# is the ONLY coverage of the 2.30.x behavior on a modern-git machine.
+
+OLD_GIT_STUB = """#!/bin/bash
+# Emulates git 2.30.x argument handling for `rev-parse`: the
+# --path-format=* flag is NOT consumed, it is echoed as an output line
+# and the remaining args are answered normally. Everything else
+# delegates to the real git, so repos behave for real.
+REAL={real}
+args=()
+echoes=()
+for a in "$@"; do
+    case "$a" in
+        --path-format=*) echoes+=("$a") ;;
+        *) args+=("$a") ;;
+    esac
+done
+if [ "${{#echoes[@]}}" -gt 0 ]; then
+    for e in "${{echoes[@]}}"; do printf '%s\\n' "$e"; done
+fi
+exec "$REAL" "${{args[@]}}"
+"""
+
+
+def _old_git_bin(base: Path) -> Path:
+    """A PATH dir whose `git` mimics 2.30.x --path-format handling."""
+    real = shutil.which("git")
+    assert real, "git required for this fixture"
+    bin_dir = base / "old-git-bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "git"
+    stub.write_text(OLD_GIT_STUB.format(real=real), encoding="utf-8")
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def _with_old_git(path_dir: Path) -> dict[str, str]:
+    """Env putting the 2.30.x stub FIRST on PATH (real tools still found)."""
+    return {"PATH": f"{path_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+
+class TestOldGitStubIsFaithful:
+    """The stub is the oracle for every test below, so pin its behavior
+    first — a stub that quietly stopped emulating the bug would make the
+    whole class vacuously green."""
+
+    def test_stub_echoes_the_flag_instead_of_consuming_it(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "--quiet", str(repo)], check=True, timeout=30)
+        bin_dir = _old_git_bin(tmp_path)
+        result = subprocess.run(
+            [
+                str(bin_dir / "git"),
+                "-C",
+                str(repo),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        lines = result.stdout.splitlines()
+        assert lines[0] == "--path-format=absolute", result.stdout
+        assert result.returncode == 0, "2.30.x exits 0 — that is what made it silent"
+
+    def test_stub_delegates_plain_flags_to_real_git(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "--quiet", str(repo)], check=True, timeout=30)
+        bin_dir = _old_git_bin(tmp_path)
+        result = subprocess.run(
+            [str(bin_dir / "git"), "-C", str(repo), "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "--path-format" not in result.stdout
+        assert result.stdout.strip(), "plain flag must still answer"
+
+
+class TestPortableGitResolutionUnderOldGit:
+    """Each check must produce the SAME verdict on both gits, and must
+    never leak git/dirname noise to stderr (S1/S2/S3)."""
+
+    def test_core_bare_check_is_clean_and_identical(self, tmp_path):
+        primary, _ = _worktree_pair(tmp_path)
+        bin_dir = _old_git_bin(tmp_path)
+        modern = run_core_bare_check(primary)
+        old = subprocess.run(
+            [BASH, str(DOCTOR_D / "70-core-bare.sh")],
+            env={**os.environ, "DOCTOR_ROOT": str(primary), **_with_old_git(bin_dir)},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert "DOCTOR:core-bare:PASS:" in old.stdout, old.stdout
+        assert old.stdout == modern.stdout, "verdict diverged between git versions"
+        assert "dirname:" not in old.stderr
+        assert old.stderr == "", f"stray stderr under old git: {old.stderr!r}"
+
+    def test_config_home_check_is_clean_and_identical(self, tmp_path):
+        parent = tmp_path / "parent"
+        kit = parent / "kit"
+        kit.mkdir(parents=True)
+        subprocess.run(["git", "init", "--quiet", str(kit)], check=True, timeout=30)
+        (parent / "agentive-config").mkdir()
+        base_env = {
+            **os.environ,
+            "DOCTOR_ROOT": str(kit),
+            "XDG_CONFIG_HOME": str(tmp_path / "no-such-xdg"),
+        }
+        base_env.pop("AGENTIVE_KIT_CONFIG_DIR", None)
+        check = DOCTOR_D / "90-config-home.sh"
+        modern = subprocess.run(
+            [BASH, str(check)], env=base_env, capture_output=True, text=True, timeout=30
+        )
+        bin_dir = _old_git_bin(tmp_path)
+        old = subprocess.run(
+            [BASH, str(check)],
+            env={**base_env, **_with_old_git(bin_dir)},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        # The S1 symptom verbatim: `dirname: illegal option -- -`.
+        assert "dirname:" not in old.stderr, f"S1 regressed: {old.stderr!r}"
+        assert old.stderr == "", f"stray stderr under old git: {old.stderr!r}"
+        # The S3 symptom: the home resolved to relative garbage, so the
+        # operator preset was silently invisible.
+        assert "./agentive-config" not in old.stdout, "S3 regressed (relative garbage)"
+        assert str(parent / "agentive-config") in old.stdout, old.stdout
+        assert old.stdout == modern.stdout, "verdict diverged between git versions"
+
+    def test_worktree_check_is_clean_and_identical(self, tmp_path):
+        _, worktree = _worktree_pair(tmp_path)
+        bin_dir = _old_git_bin(tmp_path)
+        modern = run_worktree_check(worktree)
+        old = run_worktree_check(worktree, extra_env=_with_old_git(bin_dir))
+        assert "dirname:" not in old.stderr, f"S1 regressed: {old.stderr!r}"
+        assert old.stderr == "", f"stray stderr under old git: {old.stderr!r}"
+        # Under the bug both rev-parse answers were garbage, compared
+        # unequal, and the check wrongly believed it was in a worktree
+        # with a nonexistent primary.
+        assert "DOCTOR:worktree-audit:SKIP:" not in old.stdout, old.stdout
+        assert old.stdout == modern.stdout, "verdict diverged between git versions"
+
+    def test_no_check_still_uses_the_unportable_flag(self):
+        """The whole class returns the moment one resolver reverts."""
+        offenders = []
+        for path in sorted(DOCTOR_D.iterdir()):
+            if not path.is_file():
+                continue
+            for raw in path.read_text(encoding="utf-8").splitlines():
+                # Comments explaining the bug are expected and wanted;
+                # only an executable use is a regression.
+                line = raw.strip()
+                if line.startswith("#") or "--path-format" not in line:
+                    continue
+                offenders.append(f"{path.name}:{raw.strip()}")
+        assert offenders == [], (
+            f"--path-format=absolute needs git >= 2.31 and is silently wrong on "
+            f"Apple git 2.30.1 (KIT-0080): {offenders}"
+        )
+
+    def test_non_repo_still_skips_under_old_git(self, tmp_path):
+        """The absolutize step must not turn 'not a repo' into a wrong
+        answer: an empty rev-parse result joined onto DOCTOR_ROOT would
+        make every check confidently name the root itself."""
+        bin_dir = _old_git_bin(tmp_path)
+        plain = tmp_path / "not-a-repo"
+        plain.mkdir()
+        old = subprocess.run(
+            [BASH, str(DOCTOR_D / "70-core-bare.sh")],
+            env={**os.environ, "DOCTOR_ROOT": str(plain), **_with_old_git(bin_dir)},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert "DOCTOR:core-bare:SKIP:" in old.stdout, old.stdout
+
+
+class TestGitVersionFloorCheck:
+    """F4: the machine-readable half of the README's git floor."""
+
+    CHECK = "15-git-version.sh"
+
+    def _run(self, path_dir: Path | None = None):
+        env = {**os.environ}
+        if path_dir is not None:
+            env["PATH"] = str(path_dir)
+        return subprocess.run(
+            [BASH, str(DOCTOR_D / self.CHECK)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def _fake_git(self, base: Path, version_line: str) -> Path:
+        bin_dir = base / "fake-git-bin"
+        bin_dir.mkdir()
+        _stub_executable(
+            bin_dir / "git", f'#!/bin/bash\nprintf "%s\\n" "{version_line}"\n'
+        )
+        for tool in ("bash", "printf"):
+            real = shutil.which(tool)
+            if real:
+                (bin_dir / tool).symlink_to(real)
+        return bin_dir
+
+    def test_real_git_passes(self):
+        result = self._run()
+        assert "DOCTOR:git-version:PASS:" in result.stdout, result.stdout
+
+    def test_below_floor_warns_and_names_the_remedy(self, tmp_path):
+        bin_dir = self._fake_git(tmp_path, "git version 2.29.2")
+        result = self._run(bin_dir)
+        assert "DOCTOR:git-version:WARN:" in result.stdout, result.stdout
+        assert "2.29.2" in result.stdout
+        # The remedy must name the thing that works AND rule out the
+        # intuitive non-remedy (Apple's CLT ship 2.30.x by design).
+        assert "brew install git" in result.stdout
+        assert "xcode-select" in result.stdout
+
+    def test_apple_system_git_passes_now_that_resolvers_are_portable(self, tmp_path):
+        """KIT-0080 dropped the floor to 2.30 by making the resolvers
+        portable — 2.30.1 must NOT warn, or the check contradicts the
+        fix and cries wolf on every stock Mac."""
+        bin_dir = self._fake_git(tmp_path, "git version 2.30.1 (Apple Git-130)")
+        result = self._run(bin_dir)
+        assert "DOCTOR:git-version:PASS:" in result.stdout, result.stdout
+
+    def test_floor_boundary_exactly_at_the_floor_passes(self, tmp_path):
+        bin_dir = self._fake_git(tmp_path, "git version 2.30.0")
+        result = self._run(bin_dir)
+        assert "DOCTOR:git-version:PASS:" in result.stdout, result.stdout
+
+    def test_major_version_above_floor_passes(self, tmp_path):
+        bin_dir = self._fake_git(tmp_path, "git version 3.0.0")
+        result = self._run(bin_dir)
+        assert "DOCTOR:git-version:PASS:" in result.stdout, result.stdout
+
+    @pytest.mark.parametrize(
+        "version_line",
+        [
+            "totally not a version string",
+            "git version banana.7.1",
+            "git version 2",
+            "",
+        ],
+    )
+    def test_unparseable_version_warns_rather_than_guessing(
+        self, tmp_path, version_line
+    ):
+        """A version we cannot read must never be silently treated as
+        modern (or ancient) — that is the masking class this task is
+        about."""
+        bin_dir = self._fake_git(tmp_path, version_line)
+        result = self._run(bin_dir)
+        assert "DOCTOR:git-version:WARN:" in result.stdout, result.stdout
+        assert "cannot parse" in result.stdout
+
+    def test_git_absent_fails(self, tmp_path):
+        bin_dir = tmp_path / "no-git-bin"
+        bin_dir.mkdir()
+        for tool in ("bash", "printf"):
+            real = shutil.which(tool)
+            if real:
+                (bin_dir / tool).symlink_to(real)
+        result = self._run(bin_dir)
+        assert "DOCTOR:git-version:FAIL:" in result.stdout, result.stdout
+
+    def test_floor_agrees_with_the_readme_requirements_row(self):
+        """The human-readable and machine-readable floors must never
+        drift apart (F4's explicit requirement)."""
+        check_text = (DOCTOR_D / self.CHECK).read_text(encoding="utf-8")
+        major = re.search(r"^FLOOR_MAJOR=(\d+)", check_text, re.MULTILINE)
+        minor = re.search(r"^FLOOR_MINOR=(\d+)", check_text, re.MULTILINE)
+        assert major and minor, "check no longer declares its floor"
+        floor = f"{major.group(1)}.{minor.group(1)}"
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        row = [
+            ln for ln in readme.splitlines() if ln.startswith("|") and "**git**" in ln
+        ]
+        assert row, "README has no git Requirements row"
+        assert (
+            floor in row[0]
+        ), f"README git row does not state the doctor floor {floor}: {row[0]}"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2286,19 +2286,32 @@ class TestPortableGitResolutionUnderOldGit:
         assert "DOCTOR:worktree-audit:SKIP:" not in old.stdout, old.stdout
         assert old.stdout == modern.stdout, "verdict diverged between git versions"
 
-    def test_no_check_still_uses_the_unportable_flag(self):
-        """The whole class returns the moment one resolver reverts."""
+    def test_no_script_still_uses_the_unportable_flag(self):
+        """The whole class returns the moment one resolver reverts.
+
+        Scoped to ALL of scripts/, not just doctor.d: the bug's worst
+        two faces lived in scripts/local/ (the setup door's silent
+        preset miss and new-worktree.sh's hard death), so a guard that
+        only watched doctor.d would let the expensive half regress
+        silently (code-reviewer, this PR).
+        """
+        scripts_root = REPO_ROOT / "scripts"
         offenders = []
-        for path in sorted(DOCTOR_D.iterdir()):
-            if not path.is_file():
+        for path in sorted(scripts_root.rglob("*")):
+            if not path.is_file() or "__pycache__" in path.parts:
                 continue
-            for raw in path.read_text(encoding="utf-8").splitlines():
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            for raw in text.splitlines():
                 # Comments explaining the bug are expected and wanted;
                 # only an executable use is a regression.
                 line = raw.strip()
                 if line.startswith("#") or "--path-format" not in line:
                     continue
-                offenders.append(f"{path.name}:{raw.strip()}")
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{line}")
         assert offenders == [], (
             f"--path-format=absolute needs git >= 2.31 and is silently wrong on "
             f"Apple git 2.30.1 (KIT-0080): {offenders}"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -2167,7 +2168,11 @@ def _old_git_bin(base: Path) -> Path:
     bin_dir = base / "old-git-bin"
     bin_dir.mkdir()
     stub = bin_dir / "git"
-    stub.write_text(OLD_GIT_STUB.format(real=real), encoding="utf-8")
+    # shlex.quote: an unquoted REAL= assignment breaks the stub outright
+    # if git's path contains spaces (bash would run the second word as a
+    # command). Latent on the usual /usr/bin/git, real on a path like
+    # "/Applications/Xcode 16.app/..." (CodeRabbit, this PR).
+    stub.write_text(OLD_GIT_STUB.format(real=shlex.quote(real)), encoding="utf-8")
     stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return bin_dir
 

--- a/tests/test_new_worktree.py
+++ b/tests/test_new_worktree.py
@@ -19,6 +19,7 @@ pattern.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -216,7 +217,11 @@ def _old_git_path(base: Path) -> str:
     assert real, "git required for this fixture"
     bin_dir = base / "old-git-bin"
     bin_dir.mkdir()
-    _make_executable(bin_dir / "git", OLD_GIT_STUB.format(real=real))
+    # shlex.quote: an unquoted REAL= assignment breaks the stub outright
+    # if git's path contains spaces (bash would run the second word as a
+    # command) — same fix as the sibling fixture in test_doctor.py
+    # (CodeRabbit, this PR).
+    _make_executable(bin_dir / "git", OLD_GIT_STUB.format(real=shlex.quote(real)))
     return f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"
 
 

--- a/tests/test_new_worktree.py
+++ b/tests/test_new_worktree.py
@@ -19,6 +19,7 @@ pattern.
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -178,3 +179,136 @@ class TestProvisioning:
         wt = tmp_path / "ask-worktrees" / "KIT-1234"
         serena = (wt / ".serena" / "project.yml").read_text(encoding="utf-8")
         assert 'project_name: "kit&co-KIT-1234"' in serena
+
+
+# ─────────────────────────────────────────────────────────────────────
+# KIT-0080 / S4: the helper must resolve the primary clone on old git
+# ─────────────────────────────────────────────────────────────────────
+# `git rev-parse --path-format=absolute` needs git >= 2.31. Apple's
+# system git (2.30.1, stock on macOS) echoes the flag back as an output
+# line instead of consuming it, so PRIMARY_ROOT became garbage and the
+# line-42 guard hard-exited: worktree creation — the kit's DEFAULT
+# session topology — was dead on every stock Mac. CI runners ship modern
+# git, so this stub is the only coverage of that behavior here.
+
+OLD_GIT_STUB = """#!/bin/bash
+# Emulates git 2.30.x: --path-format=* is NOT consumed, it is echoed as
+# an output line; every other arg is answered by the real git.
+REAL={real}
+args=()
+echoes=()
+for a in "$@"; do
+    case "$a" in
+        --path-format=*) echoes+=("$a") ;;
+        *) args+=("$a") ;;
+    esac
+done
+if [ "${{#echoes[@]}}" -gt 0 ]; then
+    for e in "${{echoes[@]}}"; do printf '%s\\n' "$e"; done
+fi
+exec "$REAL" "${{args[@]}}"
+"""
+
+
+def _old_git_path(base: Path) -> str:
+    """A PATH string whose `git` mimics git 2.30.x flag handling."""
+    real = shutil.which("git")
+    assert real, "git required for this fixture"
+    bin_dir = base / "old-git-bin"
+    bin_dir.mkdir()
+    _make_executable(bin_dir / "git", OLD_GIT_STUB.format(real=real))
+    return f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"
+
+
+class TestOldGitResolution:
+    """S4: identical, correct resolution on both git generations."""
+
+    def test_stub_reproduces_the_230_flag_echo(self, tmp_path):
+        """Pin the stub itself — a stub that stopped emulating the bug
+        would make the test below vacuously green."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "--quiet", str(repo)], check=True, timeout=30)
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-dir",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, "PATH": _old_git_path(tmp_path)},
+        )
+        assert result.stdout.splitlines()[0] == "--path-format=absolute"
+        assert result.returncode == 0, "2.30.x exits 0 — that is what made it silent"
+
+    def test_helper_provisions_under_old_git(self, tmp_path):
+        """The whole helper runs green on 2.30.x: the resolution guard
+        never fires and the worktree lands in the primary's sibling
+        dir, exactly as on modern git."""
+        primary = _primary_fixture(tmp_path)
+        result = subprocess.run(
+            [
+                "bash",
+                str(primary / "scripts" / "local" / "new-worktree.sh"),
+                "KIT-0001",
+                "demo",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**os.environ, "PATH": _old_git_path(tmp_path)},
+        )
+        assert result.returncode == 0, (
+            f"S4 regressed — helper died on git 2.30.x\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        # The exact S4 failure signature.
+        assert "could not resolve primary clone root" not in result.stderr
+        assert "dirname:" not in result.stderr
+        assert (tmp_path / "ask-worktrees" / "KIT-0001").is_dir(), result.stdout
+
+    def test_resolution_matches_modern_git(self, tmp_path):
+        """Same helper, same fixture, both gits — the worktree must land
+        in the same place. A divergence here is the silent-wrong-answer
+        half of the bug (S3) rather than the hard-death half (S4)."""
+        modern_primary = _primary_fixture(tmp_path / "modern", primary_name="kit")
+        old_primary = _primary_fixture(tmp_path / "old", primary_name="kit")
+        for base in (tmp_path / "modern", tmp_path / "old"):
+            base.mkdir(exist_ok=True)
+
+        modern = _run_helper(modern_primary, "KIT-0002", "demo")
+        old = subprocess.run(
+            [
+                "bash",
+                str(old_primary / "scripts" / "local" / "new-worktree.sh"),
+                "KIT-0002",
+                "demo",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**os.environ, "PATH": _old_git_path(tmp_path)},
+        )
+        assert modern.returncode == 0, modern.stderr
+        assert old.returncode == 0, old.stderr
+        modern_wt = tmp_path / "modern" / "ask-worktrees" / "KIT-0002"
+        old_wt = tmp_path / "old" / "ask-worktrees" / "KIT-0002"
+        assert modern_wt.is_dir(), modern.stdout
+        assert old_wt.is_dir(), old.stdout
+
+    def test_helper_does_not_use_the_unportable_flag(self):
+        """The guard that makes the fix stick."""
+        offenders = [
+            line.strip()
+            for line in HELPER.read_text(encoding="utf-8").splitlines()
+            if "--path-format" in line and not line.strip().startswith("#")
+        ]
+        assert offenders == [], (
+            "--path-format=absolute needs git >= 2.31 and is silently wrong "
+            f"on Apple git 2.30.1 (KIT-0080): {offenders}"
+        )


### PR DESCRIPTION
## Summary

`git rev-parse --path-format=absolute` needs git ≥ 2.31. Apple's system git (2.30.1, stock on macOS) does **not** consume the flag — it echoes it back as the first output line and still **exits 0**. Every kit resolver built on it produced garbage, and CI could never catch it because Ubuntu runners ship modern git.

All four spec symptoms were **reproduced live** against `/usr/bin/git` 2.30.1, which is still present on this machine alongside the 2.55 Homebrew build. That made the real binary — not a stub — the oracle for this work.

| Symptom | Before (real 2.30.1) | After |
|---|---|---|
| **S1** stray stderr | `dirname: illegal option -- -` | clean, empty stderr |
| **S2** `test_doctor.py` | 8 failed / 152 passed | **160 passed** |
| **S3** preset home | `./agentive-config` (relative garbage) | correct absolute sibling |
| **S4** `new-worktree.sh` | died; default topology unusable | provisions normally |

## Changes

**F1 — all 6 resolution sites made portable** (the option the KIT-0083 session live-verified): drop the flag, take plain `--git-common-dir`/`--git-dir`, absolutize against the `-C` directory.

- `scripts/local/bootstrap` (S3), `scripts/local/new-worktree.sh` (S4), `scripts/core/project` (Python), `doctor.d/{55,70,90}`
- `.claude/commands/setup-preset.md` also instructed *agents* to run the unportable command — same bug, agent-executed. Fixed.

Two hazards found and guarded while implementing:

- **an empty rev-parse result must be rejected BEFORE the join** — `cd ""` is a silent no-op that would turn "not a repo" into a confident wrong answer. This is the same silent-wrong-answer class the task exists to kill, so it gets its own tests.
- **the doctor/door resolvers join by STRING, not `cd`+`pwd`** — `cd` resolves symlinked ancestors and would report physical paths (`/var` → `/private/var`), breaking the door/doctor equivalence invariant. `new-worktree.sh` deliberately keeps `cd`+`pwd` (its value creates files rather than being compared) and says so in a comment.

**F4 — new `doctor.d/15-git-version.sh`**: WARNs below the supported floor. Because F1 makes the resolvers portable, **the floor drops to 2.30** — the README Requirements row is updated to agree, and a test pins the two so they cannot drift. Portable by construction (`git --version` + bash string ops; no `sort -V`, no Homebrew-only tools).

**F3 — tests**: a stub git emulating 2.30.x flag handling is the only coverage of that behavior on a modern-git machine, plus a test pinning the stub itself so it cannot go vacuously green.

## Every guard-test was falsified

Per the handoff, each new guard was broken once and watched to fail — against the **pristine pre-fix code** (`git show HEAD~1:…`), not a hand-edit:

- reverting `90-config-home.sh` → reproduces S1's `dirname: illegal option -- -`
- reverting `70` / `55` → "verdict diverged between git versions" + S1
- reverting `new-worktree.sh` → "S4 regressed — helper died on git 2.30.x"
- removing the emptiness guard → non-repo SKIP tests fail
- reverting any `scripts/` file → the widened flag guard fails

## Test plan

- [x] `test_doctor.py`: **160 passed** on both gits (was 8 failed / 152 passed on 2.30.1)
- [x] `test_setup_door.py`: 109 passed on both gits, incl. the door/doctor equivalence test
- [x] `test_new_worktree.py`: 8 passed, incl. 3 new S4 tests running the real helper end-to-end under the stub
- [x] **Full fast suite: 886 passed on BOTH git 2.55 and real Apple git 2.30.1**
- [x] `./scripts/core/ci-check.sh` green (932 passed, 93% coverage)
- [x] `project doctor`: byte-identical output on both gits apart from the version it reports, empty stderr, exit unchanged

## Evaluator trio (run before this PR opened, per KIT-0035/KIT-0046)

`code-reviewer-fast` **PASS** · `code-reviewer` (o3) **CONCERNS** · `claude-code` **APPROVED**

Of o3's 5 findings, **1 was real and is fixed** (the regression guard only scanned `doctor.d`, so the `scripts/local/` half — the bug's most expensive face — could regress silently; now widened repo-wide and falsified). **4 were refuted by direct measurement** — filesystem-root `dirname` math (unchanged pre-existing code, and the arithmetic claim is wrong), `../.git` breaking the worktree comparison (git returns absolute paths from a linked worktree), MSYS 2.30 bypassing the floor (the fix is build-independent, so PASS is correct), and the ERR trap swallowing the exit code (measured: still exits 1).

Full triage with the disproving measurements: `.kit/context/reviews/KIT-0080-evaluator-review.md`.

## Notes

- The README floor moves **2.31 → 2.30**: stock macOS now works rather than being warned at. `xcode-select --install` does not help and the docs now say so — Apple's CLT ship 2.30.x by design.
- Out of scope per the handoff: KIT-ADR-0028 package extraction (this fix migrates there later), preset authoring, the resolved 8-vs-3 baseline history.

Task spec: `.kit/tasks/3-in-progress/KIT-0080-doctor-apple-git-230-incompat.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core path resolution for presets, doctor, bootstrap, and default worktree topology; mistakes would silently misprovision or block sessions, though the change is narrowly scoped with extensive regression tests and falsification notes.
> 
> **Overview**
> **Fixes silent and hard failures on stock macOS (Apple Git 2.30.1)** where `git rev-parse --path-format=absolute` is echoed as output instead of consumed, breaking preset home resolution, doctor checks, and `new-worktree.sh`.
> 
> All resolution sites now use plain `--git-common-dir` / `--git-dir` and absolutize against the `-C` directory, with **emptiness checks before joining** so empty rev-parse output cannot masquerade as a valid repo path. Doctor/door/bootstrap/`project` resolvers **string-join** relative paths (preserving logical paths on symlinked checkouts); `new-worktree.sh` keeps **`cd`+`pwd`** for filesystem operations and documents why.
> 
> Adds **`doctor.d/15-git-version.sh`** and lowers the documented supported floor to **git ≥ 2.30** (README + manifest), with a test pinning README and doctor agreement. **`.claude/commands/setup-preset.md`** is updated to the portable `cd "$(git rev-parse --git-common-dir)" && pwd` pattern and correct parent math for `agentive-config`.
> 
> **Tests:** a PATH stub emulates 2.30.x flag echo for CI; guards assert identical doctor verdicts, no `dirname:` stderr, no `./agentive-config` garbage, worktree helper success under old git, and **no executable `--path-format` anywhere under `scripts/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ee68b321c110661b7a7b4652ef9d2875015fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->