### PR TITLE
feat(KIT-0090): extract gitio + lifecycle into the agentive-kit package (PR 1 of 4)

### DIFF
--- a/.kit/context/KIT-0090-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0090-REVIEW-STARTER.md
@@ -1,0 +1,53 @@
+# KIT-0090 — PR 1 Review Starter
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/108
+**Branch**: `feature/KIT-0090-extract-scripts-package` (worktree
+`~/Github/ask-worktrees/KIT-0090`)
+**Scope**: PR 1 of 4 (KIT-ADR-0028 phase 1) — package skeleton +
+`gitio` + `lifecycle` + typed models + shim. **The task stays
+in-progress**: PRs 2–4 (doctor, evaluators/preflight/review-input/
+worktree lib, publish+dogfood) follow in this session.
+
+## Gate status
+
+- **Local suite**: 970 fast / full green at every push
+- **CI**: green on head `4690c73` via **manually dispatched** runs
+  (31128654133 on d0aa929, 31128839170 on 4690c73). ⚠️ The
+  `pull_request` event produced NO runs across four pushes — the known
+  KIT-0067-era anomaly. **The dispatched run on the branch is the CI
+  proof for any merge-go**; the PR's checks rollup will not show it.
+- **Bots**: BugBot round 1 pass; CodeRabbit 10 actionable + BugBot 2 +
+  CodeRabbit 2 follow-ups = **16 threads, all replied and resolved**
+  (14 taken with fixes/tests, 1 declined with reasoning
+  [domain-error-strategy rewrite — phase-1 behavior preservation], 1
+  reply-correction).
+- **Evaluator trio**: run BEFORE PR open (ordering rule) — 6 rounds;
+  dispositions in `.kit/context/reviews/KIT-0090-pr1-evaluator-review.md`,
+  including a recorded o3 oscillation (underscore boundary,
+  rounds 4↔5).
+
+## What a human reviewer should actually look at
+
+1. **Root discovery rule** (`agentive_kit/root.py`): `.kit/` +
+   `CLAUDE.md`, marker-independent — this admits the kit repo itself
+   (no kit-install region upstream). Confirm you're happy with that
+   rule as stable API.
+2. **KIT-0086 guard semantics** (`lifecycle.sync_coordination_metadata`):
+   `agent-handoffs.json` written only when branch == literally
+   `main`; undeterminable branch skips (fail-safe). Repos with a
+   non-`main` default branch would never auto-update the JSON —
+   accepted limitation, recorded.
+3. **One deliberate behavior change**: task-ID matching is now
+   boundary-anchored (`KIT-1` no longer matches `KIT-1234`); `-` and
+   `_` both count as separators.
+4. **Sequencing risk** (PR body ⚠️): consumers syncing `main` before
+   the PR-4 publish get lifecycle commands that instruct installing a
+   not-yet-published package. Merge PRs 1–4 close together, or accept
+   the window.
+
+## F6 closure state
+
+- KIT-0086 F1 (single-writer guard): **landed here**, verified by
+  mutation + byte-for-byte zero-diff test. F2 (drift WARN) → doctor
+  check in PR 2, where KIT-0086 closes by reference.
+- KIT-0079: PR 3 (evaluators module).

--- a/.kit/context/KIT-0090-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0090-REVIEW-STARTER.md
@@ -10,6 +10,10 @@ worktree lib, publish+dogfood) follow in this session.
 
 ## Gate status
 
+**Snapshot**: 2026-08-06. Figures below are as of the branch tip on
+that date; the CI-proof runs are named per commit, and any push after
+the last named commit needs a fresh dispatched run before merge.
+
 - **Local suite**: 970 fast / full green at every push
 - **CI**: green on head `4690c73` via **manually dispatched** runs
   (31128654133 on d0aa929, 31128839170 on 4690c73). ⚠️ The

--- a/.kit/context/reviews/KIT-0090-pr1-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0090-pr1-evaluator-review.md
@@ -1,0 +1,90 @@
+# KIT-0090 PR 1 — Evaluator Review Record
+
+**Task**: KIT-0090 extract-scripts-package, PR 1 (skeleton + gitio +
+lifecycle + shim)
+**Date**: 2026-08-06
+**Ordering**: trio run BEFORE PR open (KIT-0035/0046 rule)
+**Evaluators**: code-reviewer-fast (gemini-2.5-flash), code-reviewer
+(o3), claude-code
+**Rounds**: 5 (fast ×2, deep ×3, security ×1)
+
+## Final state
+
+- Full suite green at every round; 77 package tests + migrated
+  script-test coverage
+- All FAIL/CONCERNS findings dispositioned below — taken, refuted
+  with evidence, or declined with rationale
+- Deep-evaluator loop STOPPED at round 5 on oscillation (see below);
+  further rounds were re-litigating settled coins
+
+## Taken (fixed, with tests)
+
+| Round | Finding | Fix |
+|-------|---------|-----|
+| 1 (fast) | Missing `.kit/tasks/` crashes find/validate | Guard returns None / zero-checked report |
+| 1 (fast) | Non-UTF-8 task file crashes validate | Becomes a `StatusIssue` finding |
+| 2 (fast) | Shim dispatch untested at subprocess level | `TestLifecycleDelegation` (dogfood + loud-error paths) |
+| 3 (deep+sec) | Partial-ID substring match moves wrong file (`KIT-1` → `KIT-1234`) | Boundary-anchored match; publishing makes match semantics stable API |
+| 3 (deep) | Move fails when destination status folder absent | `mkdir(parents=True, exist_ok=True)` before move |
+| 3 (sec) | `re.sub` template could re-interpret status value | Lambda replacement |
+| 4 (deep) | `clean_git_env` stripped behavior vars (`GIT_SSH_COMMAND`, `GIT_EXEC_PATH`) | Narrowed to the location-override list (KIT-0043 class, legacy `_clean_git_env` parity) |
+| 4 (deep) | PermissionError in root walk → traceback on Python < 3.13 | `_is_project_root` swallows OSError, walk continues |
+| 4 (deep) | ssh:// remote form untested | Parametrized `derive_repo_url` test |
+| 5 (deep) | `_kit_lifecycle` masks a broken INSTALLED package as "not installed" | Catch `ModuleNotFoundError` only |
+
+## Evaluator oscillation — recorded deliberately
+
+Round 4 (o3): "underscore after the ID must block the match
+(`(?![0-9A-Za-z_])`)". Implemented. Round 5 (o3): the same block "can
+strand existing tasks" (`KIT-1234_sample.md` was findable under the
+legacy matcher) — a regression claim against its own round-4
+instruction. Round 5 wins on data compatibility: `_` is a separator
+like `-`; only alphanumeric run-on is the wrong-file hazard. Reverted
+to `(?![0-9A-Z])` with a test pinning `KIT-1234_sample.md` as found.
+Loop stopped here: the reviewer is oscillating on settled coins
+(hyphenated statuses re-raised twice, see Declined).
+
+## Refuted (verified against reality)
+
+- **"Unborn HEAD prints nothing on git ≥ 2.36"** (deep r3): verified
+  on git 2.55 — `git branch --show-current` prints the unborn branch
+  name; pinned by `test_unborn_branch_still_reports_name`.
+- **"`text=True` without capture raises ValueError"** (deep r3):
+  verified legal (`subprocess.run(['true'], text=True)` runs fine).
+- **"`_derive_repo_url` script copy untested"** (fast r1):
+  `TestDeriveRepoUrl` remains in tests/test_project_script.py covering
+  the script's live copy (kept for reconfigure; dies with the script).
+- **"git-absent-but-uv-present path untested"** (deep r4):
+  `test_cli_install_attempted_when_git_absent_but_uv_present` exists.
+- **"Lowercase suffix passes the ID boundary"** (deep r4): matching
+  runs on the uppercased name; pinned by
+  `test_lowercase_suffix_does_not_match`.
+- **"Symlinked cwd breaks `relative_to`"** (deep r5): impossible —
+  every path handed to `relative_to(project_dir)` is constructed from
+  `project_dir` itself.
+
+## Declined (with rationale)
+
+- **Hyphenated/custom statuses not matched** (deep r3, r5; fast r1):
+  the status vocabulary is the fixed `FOLDER_STATUS_MAP`; the regex is
+  legacy-identical, and custom-state support is a feature decision,
+  not extraction scope.
+- **`find_task_file` iteration order non-determinism** (fast r1/r2):
+  legacy-identical; only observable with duplicate IDs, which the
+  boundary fix already narrows.
+- **File locking for parallel moves** (deep r5): single-operator tool;
+  legacy-identical; a locking scheme is out of scope.
+- **Move-succeeded-but-status-stale still prints ✅** (deep r4):
+  legacy behavior; `TaskMove.status_field_updated` exposes it to
+  callers; revisit when the CLI grows structured output.
+- **Archive-folder moves** (sec r3, LOW): legacy carry-forward;
+  revisit in package API hardening.
+- **Hardcoded statuses in script help text** (fast r2): print_help
+  already hardcodes them; the script dies in phase 4.
+
+## Known blind spot note
+
+Evaluators cannot re-verify the PyPI `agentive` entry-point check from
+static analysis (claude-code, "Context Required") — verified manually
+2026-08-06: the `agentive` 0.0.144 wheel ships no entry_points.txt.
+Re-check before the PR-4 publish.

--- a/.kit/context/reviews/KIT-0090-pr1-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0090-pr1-evaluator-review.md
@@ -82,6 +82,14 @@ Loop stopped here: the reviewer is oscillating on settled coins
 - **Hardcoded statuses in script help text** (fast r2): print_help
   already hardcodes them; the script dies in phase 4.
 
+## Final gate pass
+
+Round 6 (fast, on the finished diff): CONCERNS citing only items
+already in this table — the refuted `text=True` ValueError claim and
+the declined help-text hardcoding (which the evaluator itself notes as
+"temporary by design"). No new findings; gate closed with all
+dispositions recorded.
+
 ## Known blind spot note
 
 Evaluators cannot re-verify the PyPI `agentive` entry-point check from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`agentive-kit` package skeleton — KIT-ADR-0028 phase 1, PR 1**
   (KIT-0090): `packages/agentive-kit/` with `src/agentive_kit/`
   modules `gitio` (single home for git invocations; KIT-0080's
-  portable resolvers with failure-path tests), `lifecycle`
-  (start/move/complete/validate + coordination-metadata sync), `root`
+  portable resolvers with failure-path tests), `lifecycle` (task
+  moves + validation + coordination-metadata sync; `start`/`complete`/
+  `block` are CLI shorthands over it), `root`
   (CWD-walk project discovery: nearest ancestor with `.kit/` +
   `CLAUDE.md`, loud refusal outside a kit repo), typed boundary models,
   and an `agentive` console entry (name verified collision-free on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agentive-kit` package skeleton — KIT-ADR-0028 phase 1, PR 1**
+  (KIT-0090): `packages/agentive-kit/` with `src/agentive_kit/`
+  modules `gitio` (single home for git invocations; KIT-0080's
+  portable resolvers with failure-path tests), `lifecycle`
+  (start/move/complete/validate + coordination-metadata sync), `root`
+  (CWD-walk project discovery: nearest ancestor with `.kit/` +
+  `CLAUDE.md`, loud refusal outside a kit repo), typed boundary models,
+  and an `agentive` console entry (name verified collision-free on
+  PyPI). `./scripts/core/project` delegates its lifecycle commands to
+  the package (installed copy first, in-repo source as the dogfood
+  fallback) and keeps its remaining commands package-free until their
+  extraction PRs. Per-module tests replace the migrated monolith
+  sections (KIT-0089 F3 direction).
+
 ### Changed
+
+- **`agent-handoffs.json` becomes single-writer** (KIT-0086 F1, landed
+  inside `agentive_kit.lifecycle` per KIT-0090 F6): lifecycle moves
+  write the shared coordination JSON only when the checkout is on
+  `main`; feature-branch (and undeterminable-branch) moves now produce
+  zero diff in it, ending the KIT-0084 / PR #105 squash-merge conflict
+  class. The task's own `HANDOFF-*.md` files are still rewritten on
+  every branch. The stale-path drift WARN (KIT-0086 F2) follows as a
+  doctor check in the doctor-migration PR.
 
 - **`.kit/context/` is legible again** (KIT-0077): the 100 handoffs,
   review starters, and session records belonging to tasks in a terminal

--- a/packages/agentive-kit/README.md
+++ b/packages/agentive-kit/README.md
@@ -1,8 +1,9 @@
 # agentive-kit
 
-Project lifecycle CLI for [agentive projects](https://github.com/movito/agentive-starter-kit):
-task status flow (`start`/`move`/`complete`), environment doctor,
-evaluator provisioning, preflight and review helpers.
+Project lifecycle CLI for [agentive projects](https://github.com/movito/agentive-starter-kit).
+Ships today: task status flow (`start`/`move`/`complete`/`block`/
+`validate`). Migrating in over the phase-1 PR series: environment
+doctor, evaluator provisioning, preflight and review helpers.
 
 **Pre-consumer-migration release.** This package is KIT-ADR-0028
 phase 1: it replaces the copy-distributed `scripts/core/` layer of the

--- a/packages/agentive-kit/README.md
+++ b/packages/agentive-kit/README.md
@@ -1,0 +1,32 @@
+# agentive-kit
+
+Project lifecycle CLI for [agentive projects](https://github.com/movito/agentive-starter-kit):
+task status flow (`start`/`move`/`complete`), environment doctor,
+evaluator provisioning, preflight and review helpers.
+
+**Pre-consumer-migration release.** This package is KIT-ADR-0028
+phase 1: it replaces the copy-distributed `scripts/core/` layer of the
+agentive-starter-kit. Existing projects keep working through their
+`./scripts/core/project` shim until phase 3 migrates them.
+
+## Install
+
+```bash
+uv tool install agentive-kit
+```
+
+## Use
+
+Run from anywhere inside a kit-made repository — the CLI walks up from
+the current directory to find the project root (a directory with both
+`.kit/` and `CLAUDE.md`) and refuses loudly anywhere else:
+
+```bash
+agentive start KIT-0001      # move a task to in-progress
+agentive move KIT-0001 done  # move a task to any status
+agentive validate            # check task Status fields match folders
+agentive version
+```
+
+The remaining subcommands (`doctor`, `install-evaluators`, …) migrate
+into this CLI over the phase-1 PR series.

--- a/packages/agentive-kit/pyproject.toml
+++ b/packages/agentive-kit/pyproject.toml
@@ -10,7 +10,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentive-kit"
-version = "0.1.0"
+# Single-sourced from agentive_kit.__version__ (CodeRabbit, PR #108) —
+# two hardcoded copies would drift.
+dynamic = ["version"]
 description = "Project lifecycle CLI for agentive projects — task status flow, environment doctor, evaluator provisioning"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -34,3 +36,6 @@ agentive = "agentive_kit.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.dynamic]
+version = { attr = "agentive_kit.__version__" }

--- a/packages/agentive-kit/pyproject.toml
+++ b/packages/agentive-kit/pyproject.toml
@@ -1,0 +1,36 @@
+# Packaging metadata for the agentive-kit distribution (KIT-ADR-0028
+# phase 1). This pyproject is deliberately SEPARATE from the repo-root
+# pyproject.toml: the root file doubles as the consumer-project template
+# (engine-consumer.sh / engine-export.sh copy it with a name rewrite),
+# so it can never carry this dist's name or package list.
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentive-kit"
+version = "0.1.0"
+description = "Project lifecycle CLI for agentive projects — task status flow, environment doctor, evaluator provisioning"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Fredrik Matheson" }]
+# Stdlib only, by design: the legacy script ran on bare python3 with no
+# third-party imports, and the package keeps that property so `uv tool
+# install agentive-kit` works in any environment.
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/movito/agentive-starter-kit"
+
+[project.scripts]
+# Console-script name `agentive` per KIT-ADR-0028. Verified 2026-08-06:
+# the existing PyPI dist `agentive` (0.0.144) ships no entry_points.txt,
+# so there is no console-script collision; import packages differ too
+# (`agentive` vs `agentive_kit`). Fallback name if a collision ever
+# appears: `akit`.
+agentive = "agentive_kit.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/agentive-kit/src/agentive_kit/__init__.py
+++ b/packages/agentive-kit/src/agentive_kit/__init__.py
@@ -1,0 +1,7 @@
+"""agentive-kit: project lifecycle CLI for agentive projects.
+
+KIT-ADR-0028 phase 1 — the versioned-package successor to the
+copy-distributed ``scripts/core/`` layer of agentive-starter-kit.
+"""
+
+__version__ = "0.1.0"

--- a/packages/agentive-kit/src/agentive_kit/cli.py
+++ b/packages/agentive-kit/src/agentive_kit/cli.py
@@ -64,6 +64,8 @@ def main(argv: list[str] | None = None) -> None:
 
     command = args[0].lower()
 
+    # membership: command-alias vocabulary checks, not identifier
+    # equality (same for the shorthand dict-key test below)
     if command in ("help", "-h", "--help"):
         print(_USAGE)
         sys.exit(0)
@@ -72,15 +74,18 @@ def main(argv: list[str] | None = None) -> None:
         print(f"agentive-kit v{agentive_kit.__version__}")
         sys.exit(0)
 
+    # Exact argument counts: surplus arguments are rejected, not
+    # silently ignored — a mistyped automation call must fail loudly
+    # (CodeRabbit, PR #108).
     if command == "move":
-        if len(args) < 3:
+        if len(args) != 3:
             print("Usage: agentive move <task-id> <status>")
             print("       agentive move ASK-0001 done")
             valid = ", ".join(lifecycle.STATUS_FOLDER_MAP.keys())
             print(f"       Valid statuses: {valid}")
             sys.exit(1)
         result = lifecycle.move_task(args[1], args[2], _project_root())
-        sys.exit(0 if result else 1)
+        sys.exit(0 if result and not result.status_update_failed else 1)
 
     # Shorthands for common moves
     shorthand_targets = {
@@ -89,15 +94,18 @@ def main(argv: list[str] | None = None) -> None:
         "block": "blocked",
     }
     if command in shorthand_targets:
-        if len(args) < 2:
+        if len(args) != 2:
             print(f"Usage: agentive {command} <task-id>")
             sys.exit(1)
         result = lifecycle.move_task(
             args[1], shorthand_targets[command], _project_root()
         )
-        sys.exit(0 if result else 1)
+        sys.exit(0 if result and not result.status_update_failed else 1)
 
     if command == "validate":
+        if len(args) != 1:
+            print("Usage: agentive validate")
+            sys.exit(1)
         report = lifecycle.validate_all_tasks(_project_root())
         sys.exit(0 if report.ok else 1)
 

--- a/packages/agentive-kit/src/agentive_kit/cli.py
+++ b/packages/agentive-kit/src/agentive_kit/cli.py
@@ -1,0 +1,111 @@
+"""Console entry point (``agentive``) for agentive-kit (KIT-0090 F2).
+
+Exposes the migrated subcommand surface; the remaining legacy commands
+(``doctor``, ``install-evaluators``, ``sync``, …) join it PR by PR
+through the phase-1 series, and ``./scripts/core/project`` stays the
+full surface in the meantime.
+
+Root discovery is the one deliberate behavior change from the legacy
+script: the CLI resolves the project from the CURRENT DIRECTORY (walk
+up to ``.kit/`` + ``CLAUDE.md``; see ``agentive_kit.root``) and refuses
+loudly outside a kit project — never operating on a guessed root.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import agentive_kit
+from agentive_kit import lifecycle
+from agentive_kit.root import RootNotFoundError, find_project_root
+
+_USAGE = f"""\
+agentive-kit v{agentive_kit.__version__}
+==================================
+
+Usage: agentive <command> [options]
+
+Task Management:
+  move <id> <status>   Move task to folder and update Status field
+  complete <id>        Move task to done (shorthand)
+  start <id>           Move task to in-progress (shorthand)
+  block <id>           Move task to blocked (shorthand)
+  validate             Validate all task statuses match folders
+
+Other:
+  help                 Show this help message
+  version              Show version information
+
+Valid statuses for 'move':
+  {', '.join(lifecycle.STATUS_FOLDER_MAP.keys())}
+
+Runs from anywhere inside a kit-made repository (the project root is
+discovered by walking up from the current directory). The commands not
+yet migrated from ./scripts/core/project remain available there.
+"""
+
+
+def _project_root() -> Path:
+    """Discover the project root or exit loudly (never guess)."""
+    try:
+        return find_project_root()
+    except RootNotFoundError as exc:
+        print(exc)
+        sys.exit(1)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = sys.argv[1:] if argv is None else argv
+
+    if not args:
+        print(_USAGE)
+        sys.exit(0)
+
+    command = args[0].lower()
+
+    if command in ("help", "-h", "--help"):
+        print(_USAGE)
+        sys.exit(0)
+
+    if command in ("version", "--version"):
+        print(f"agentive-kit v{agentive_kit.__version__}")
+        sys.exit(0)
+
+    if command == "move":
+        if len(args) < 3:
+            print("Usage: agentive move <task-id> <status>")
+            print("       agentive move ASK-0001 done")
+            valid = ", ".join(lifecycle.STATUS_FOLDER_MAP.keys())
+            print(f"       Valid statuses: {valid}")
+            sys.exit(1)
+        result = lifecycle.move_task(args[1], args[2], _project_root())
+        sys.exit(0 if result else 1)
+
+    # Shorthands for common moves
+    shorthand_targets = {
+        "start": "in-progress",
+        "complete": "done",
+        "block": "blocked",
+    }
+    if command in shorthand_targets:
+        if len(args) < 2:
+            print(f"Usage: agentive {command} <task-id>")
+            sys.exit(1)
+        result = lifecycle.move_task(
+            args[1], shorthand_targets[command], _project_root()
+        )
+        sys.exit(0 if result else 1)
+
+    if command == "validate":
+        report = lifecycle.validate_all_tasks(_project_root())
+        sys.exit(0 if report.ok else 1)
+
+    print(f"❌ Unknown command: {command}")
+    print("Run 'agentive help' for available commands.")
+    print("Commands not yet migrated remain in ./scripts/core/project.")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/agentive-kit/src/agentive_kit/gitio.py
+++ b/packages/agentive-kit/src/agentive_kit/gitio.py
@@ -41,16 +41,33 @@ from pathlib import Path
 GIT_TIMEOUT = 10
 
 
+# Location-override variables that make git ignore ``-C`` (the
+# KIT-0043 incident class). Only THESE are stripped — behavior vars a
+# custom install may need (GIT_SSH_COMMAND, GIT_EXEC_PATH,
+# GIT_CEILING_DIRECTORIES, credential settings) pass through untouched
+# (evaluator finding, PR 1 trio; the list matches the legacy script's
+# _clean_git_env).
+_LOCATION_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_COMMON_DIR",
+)
+
+
 def clean_git_env() -> dict[str, str]:
     """Environment with inherited GIT_* location vars stripped.
 
     Makes ``git -C`` authoritative: an ambient ``GIT_DIR`` /
     ``GIT_WORK_TREE`` (exported e.g. by pre-commit while running hooks)
     would otherwise override ``-C`` and point git at the wrong
-    repository (KIT-0043). Strips the whole ``GIT_`` prefix rather than
-    an allowlist — the same suite-wide rule tests/conftest.py applies.
+    repository (KIT-0043).
     """
-    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env = os.environ.copy()
+    for var in _LOCATION_VARS:
+        env.pop(var, None)
+    return env
 
 
 def run_git(

--- a/packages/agentive-kit/src/agentive_kit/gitio.py
+++ b/packages/agentive-kit/src/agentive_kit/gitio.py
@@ -1,0 +1,149 @@
+"""All git invocations for agentive-kit live in this module (KIT-0090 F1).
+
+One module, deliberately NOT a pluggable SCM interface (evaluation
+finding declined as YAGNI, recorded in the task spec): no other SCM is
+on any horizon, and a single-module boundary already buys the
+encapsulation an interface would. What the boundary is FOR is keeping
+the portability discipline greppable in one place — the KIT-0080
+incident class, where Apple's system git (2.30.1) silently mangled
+``--path-format=absolute`` output, was fixed by re-shipping the same
+pattern into several scripts; here it is fixed once.
+
+Portability rules (KIT-0080 — the documented floor is git >= 2.30):
+
+- Never pass ``--path-format=absolute`` to ``rev-parse``: git < 2.31
+  echoes the flag back as an output line and exits 0, so the caller
+  reads garbage. Use the plain form and absolutize against the ``-C``
+  directory ourselves.
+- Always scrub ambient ``GIT_*`` variables: pre-commit and hooks export
+  ``GIT_DIR``/``GIT_INDEX_FILE`` (absolute, in worktrees), which
+  override ``-C`` and silently point git at the WRONG repository
+  (the KIT-0043 incident class).
+- Bound every call with a timeout and close stdin: a wedged git
+  (credential prompt, hung filesystem) must fail the one call, not
+  hang the CLI.
+
+Error strategy: this is a leaf utility layer — helpers return ``None``
+(or a non-zero ``CompletedProcess``) on failure and never raise for
+environmental problems (git absent, not a repository, timeout).
+Callers decide loudness.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+# Seconds allowed for any single plumbing call (branch lookup,
+# rev-parse, remote read). Generous for plumbing, short enough that a
+# wedged git fails the command instead of hanging it.
+GIT_TIMEOUT = 10
+
+
+def clean_git_env() -> dict[str, str]:
+    """Environment with inherited GIT_* location vars stripped.
+
+    Makes ``git -C`` authoritative: an ambient ``GIT_DIR`` /
+    ``GIT_WORK_TREE`` (exported e.g. by pre-commit while running hooks)
+    would otherwise override ``-C`` and point git at the wrong
+    repository (KIT-0043). Strips the whole ``GIT_`` prefix rather than
+    an allowlist — the same suite-wide rule tests/conftest.py applies.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def run_git(
+    repo_dir: Path | str,
+    *args: str,
+    timeout: int = GIT_TIMEOUT,
+    capture: bool = True,
+) -> subprocess.CompletedProcess | None:
+    """Run ``git -C <repo_dir> <args>`` with the module's env/bounds.
+
+    Returns the ``CompletedProcess``, or ``None`` when git could not be
+    executed at all (binary absent, OS error, timeout). A git that ran
+    and failed is reported through ``returncode`` — the two failure
+    shapes are deliberately distinct so callers can tell "no git" from
+    "git said no".
+    """
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo_dir), *args],
+            capture_output=capture,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+            env=clean_git_env(),
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def current_branch(repo_dir: Path | str) -> str | None:
+    """Name of the checked-out branch, or ``None``.
+
+    ``None`` covers: not a git repository, git absent or wedged, and a
+    detached HEAD (``--show-current`` prints nothing there). Callers
+    that gate side effects on "am I on main?" (the KIT-0086
+    single-writer guard) treat ``None`` as NOT main — the fail-safe
+    direction: when the branch cannot be established, skip the write.
+    """
+    result = run_git(repo_dir, "branch", "--show-current")
+    if result is None or result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
+
+
+def git_common_dir(repo_dir: Path | str) -> Path | None:
+    """Absolute path of the repo's common git dir, worktree-safe.
+
+    KIT-0080: plain ``--git-common-dir`` (never ``--path-format=
+    absolute`` — see module docstring), absolutized here. Plain output
+    is RELATIVE to the ``-C`` directory (both old and new gits return a
+    bare ``.git`` from a primary clone), so it is anchored on
+    ``repo_dir`` — never on the process CWD.
+
+    No ``.resolve()``: that would follow symlinked ancestors and report
+    a PHYSICAL path, diverging from the bash resolvers this helper is
+    pinned equivalent to (tests/test_setup_door.py). ``os.path.normpath``
+    collapses the ``<root>/.git`` join without touching symlinks.
+
+    Returns ``None`` when ``repo_dir`` is not a git repository or git
+    is unavailable.
+    """
+    result = run_git(repo_dir, "rev-parse", "--git-common-dir")
+    if result is None or result.returncode != 0:
+        return None
+    common = result.stdout.strip()
+    if not common:
+        return None
+    return Path(os.path.normpath(Path(repo_dir) / common))
+
+
+def derive_repo_url(repo_dir: Path | str) -> str | None:
+    """GitHub-style repo path from ``origin``, e.g. ``github.com/o/r``.
+
+    Handles SSH (``git@github.com:owner/repo.git``) and HTTP(S) forms;
+    returns ``None`` for anything else (``ssh://``, ``git://``, local
+    paths) and on any git failure.
+    """
+    result = run_git(repo_dir, "remote", "get-url", "origin")
+    if result is None or result.returncode != 0:
+        return None
+
+    url = result.stdout.strip()
+    if not url:
+        return None
+
+    if url.startswith("git@"):
+        url = url.removeprefix("git@").replace(":", "/", 1)
+    elif url.startswith("https://"):
+        url = url.removeprefix("https://")
+    elif url.startswith("http://"):
+        url = url.removeprefix("http://")
+    else:
+        return None
+
+    return url.removesuffix(".git")

--- a/packages/agentive-kit/src/agentive_kit/lifecycle.py
+++ b/packages/agentive-kit/src/agentive_kit/lifecycle.py
@@ -56,6 +56,11 @@ HANDOFFS_WRITE_BRANCH = "main"
 def find_task_file(task_id: str, project_dir: Path) -> Path | None:
     """Find a task file by ID across all workflow folders."""
     tasks_dir = project_dir / ".kit" / "tasks"
+    # Root discovery guarantees .kit/ exists, but not .kit/tasks/ —
+    # a repo without it has no tasks to find, not a crash to raise
+    # (evaluator finding, PR 1 trio).
+    if not tasks_dir.is_dir():
+        return None
 
     # Normalize task ID (handle ASK-0001 or ASK-1)
     task_id_upper = task_id.upper()
@@ -232,6 +237,12 @@ def validate_all_tasks(project_dir: Path) -> ValidationReport:
     issues: list[StatusIssue] = []
     checked = 0
 
+    # Same guard as find_task_file: no tasks directory means nothing to
+    # validate — report zero checked rather than crash.
+    if not tasks_dir.is_dir():
+        print("✅ All 0 tasks have matching Status and folder")
+        return ValidationReport(checked=0, issues=[])
+
     for folder in tasks_dir.iterdir():
         if not folder.is_dir():
             continue
@@ -244,7 +255,13 @@ def validate_all_tasks(project_dir: Path) -> ValidationReport:
 
         for file in folder.glob("*.md"):
             checked += 1
-            content = file.read_text(encoding="utf-8")
+            try:
+                content = file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as e:
+                # An unreadable task file is a finding, not a crash —
+                # the same tolerance sync_coordination_metadata applies.
+                issues.append(StatusIssue(file.name, f"Unreadable file ({e})"))
+                continue
             match = re.search(r"\*\*Status\*\*:\s*(\w+(?:\s+\w+)?)", content)
 
             if not match:

--- a/packages/agentive-kit/src/agentive_kit/lifecycle.py
+++ b/packages/agentive-kit/src/agentive_kit/lifecycle.py
@@ -66,10 +66,11 @@ def find_task_file(task_id: str, project_dir: Path) -> Path | None:
     # not a carry-forward): the legacy substring test let a short ID
     # like "KIT-1" silently select KIT-1234's file and move the wrong
     # task. A file matches when its name IS the ID or starts with the
-    # ID followed by a non-alphanumeric separator; case-insensitive as
-    # before.
+    # ID followed by a non-word separator; case-insensitive as before
+    # (matching runs on the uppercased name, so [0-9A-Z_] covers every
+    # word character).
     task_id_upper = task_id.upper()
-    id_pattern = re.compile(re.escape(task_id_upper) + r"(?![0-9A-Z])")
+    id_pattern = re.compile(re.escape(task_id_upper) + r"(?![0-9A-Z_])")
 
     for folder in tasks_dir.iterdir():
         if not folder.is_dir():

--- a/packages/agentive-kit/src/agentive_kit/lifecycle.py
+++ b/packages/agentive-kit/src/agentive_kit/lifecycle.py
@@ -248,7 +248,15 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> TaskMove |
 
     sync_coordination_metadata(task_id, target_path.name, target_folder, project_dir)
 
-    print(f"✅ Task {task_id} is now {linear_status}")
+    if field_updated is None:
+        # No ✅ on a partial failure — the summary line must not
+        # contradict the warning above (BugBot, PR #108 round 2).
+        print(
+            f"⚠️  Task {task_id} moved to {target_folder}, "
+            "but its Status field was not updated"
+        )
+    else:
+        print(f"✅ Task {task_id} is now {linear_status}")
     return TaskMove(
         task_id=task_id,
         file_name=target_path.name,

--- a/packages/agentive-kit/src/agentive_kit/lifecycle.py
+++ b/packages/agentive-kit/src/agentive_kit/lifecycle.py
@@ -285,7 +285,17 @@ def validate_all_tasks(project_dir: Path) -> ValidationReport:
         print("✅ All 0 tasks have matching Status and folder")
         return ValidationReport(checked=0, issues=())
 
-    for folder in tasks_dir.iterdir():
+    try:
+        folders = sorted(tasks_dir.iterdir())
+    except OSError as e:
+        # is_dir() succeeding does not guarantee iterdir() can — an
+        # unreadable directory is a finding, not a crash (CodeRabbit,
+        # PR #108 round 3).
+        issue = StatusIssue(str(tasks_dir), f"Unreadable tasks directory ({e})")
+        print(f"❌ Found 1 status mismatches:\n\n  • {issue.file_name}: {issue.detail}")
+        return ValidationReport(checked=0, issues=(issue,))
+
+    for folder in folders:
         if not folder.is_dir():
             continue
         # membership: folder-name vocabulary checks against fixed

--- a/packages/agentive-kit/src/agentive_kit/lifecycle.py
+++ b/packages/agentive-kit/src/agentive_kit/lifecycle.py
@@ -62,14 +62,20 @@ def find_task_file(task_id: str, project_dir: Path) -> Path | None:
     if not tasks_dir.is_dir():
         return None
 
-    # Normalize task ID (handle ASK-0001 or ASK-1)
+    # Boundary-anchored match (evaluator finding, PR 1 trio — a fix,
+    # not a carry-forward): the legacy substring test let a short ID
+    # like "KIT-1" silently select KIT-1234's file and move the wrong
+    # task. A file matches when its name IS the ID or starts with the
+    # ID followed by a non-alphanumeric separator; case-insensitive as
+    # before.
     task_id_upper = task_id.upper()
+    id_pattern = re.compile(re.escape(task_id_upper) + r"(?![0-9A-Z])")
 
     for folder in tasks_dir.iterdir():
         if not folder.is_dir():
             continue
         for file in folder.glob("*.md"):
-            if task_id_upper in file.name.upper():
+            if id_pattern.match(file.name.upper()):
                 return file
     return None
 
@@ -78,9 +84,12 @@ def update_status_in_file(file_path: Path, new_status: str) -> bool:
     """Update the Status field in a task file."""
     try:
         content = file_path.read_text(encoding="utf-8")
+        # Replacement via lambda, not a template string: a status value
+        # containing backslashes or group refs must never be
+        # re-interpreted by re.sub (claude-code review, PR 1 trio).
         new_content = re.sub(
             r"(\*\*Status\*\*:\s*)(\w+(?:\s+\w+)?)",
-            f"\\1{new_status}",
+            lambda m: m.group(1) + new_status,
             content,
             count=1,
         )
@@ -203,6 +212,10 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> TaskMove |
     target_path = target_dir / task_file.name
 
     try:
+        # A valid status whose folder is absent (lean consumer layouts
+        # often skip 6-canceled/7-blocked) is created, not crashed into
+        # (evaluator finding, PR 1 trio).
+        target_dir.mkdir(parents=True, exist_ok=True)
         shutil.move(str(task_file), str(target_path))
         print(f"📁 Moved: {current_folder} → {target_folder}")
     except (OSError, shutil.Error) as e:

--- a/packages/agentive-kit/src/agentive_kit/lifecycle.py
+++ b/packages/agentive-kit/src/agentive_kit/lifecycle.py
@@ -83,15 +83,23 @@ def find_task_file(task_id: str, project_dir: Path) -> Path | None:
     return None
 
 
-def update_status_in_file(file_path: Path, new_status: str) -> bool:
-    """Update the Status field in a task file."""
+def update_status_in_file(file_path: Path, new_status: str) -> bool | None:
+    """Update the Status field in a task file.
+
+    Tri-state result (CodeRabbit, PR #108 — a failed update must be
+    distinguishable from a no-op): ``True`` = field rewritten,
+    ``False`` = field present and already correct, ``None`` = the
+    field could not be set (absent, unreadable, or unwritable).
+    """
     try:
         content = file_path.read_text(encoding="utf-8")
+        pattern = re.compile(r"(\*\*Status\*\*:\s*)(\w+(?:\s+\w+)?)")
+        if not pattern.search(content):
+            return None
         # Replacement via lambda, not a template string: a status value
         # containing backslashes or group refs must never be
         # re-interpreted by re.sub (claude-code review, PR 1 trio).
-        new_content = re.sub(
-            r"(\*\*Status\*\*:\s*)(\w+(?:\s+\w+)?)",
+        new_content = pattern.sub(
             lambda m: m.group(1) + new_status,
             content,
             count=1,
@@ -102,7 +110,7 @@ def update_status_in_file(file_path: Path, new_status: str) -> bool:
         return False
     except (OSError, UnicodeDecodeError) as e:
         print(f"❌ Error updating file: {e}")
-        return False
+        return None
 
 
 def sync_coordination_metadata(
@@ -179,6 +187,7 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> TaskMove |
     # Normalize target status
     target_lower = target_status.lower().replace("_", "-").replace(" ", "-")
 
+    # membership: dict-key vocabulary check, not identifier equality
     if target_lower not in STATUS_FOLDER_MAP:
         print(f"❌ Unknown status: {target_status}")
         print(f"   Valid statuses: {', '.join(STATUS_FOLDER_MAP.keys())}")
@@ -198,6 +207,8 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> TaskMove |
         print(f"ℹ️  Task already in {target_folder}")
         # Still update status field if needed
         field_updated = update_status_in_file(task_file, linear_status)
+        if field_updated is None:
+            print(f"⚠️  Status field not updated in {task_file.name}")
         # Re-running a move doubles as a repair action for metadata that
         # drifted out of sync with the task's folder.
         sync_coordination_metadata(task_id, task_file.name, target_folder, project_dir)
@@ -208,7 +219,8 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> TaskMove |
             to_folder=target_folder,
             status=linear_status,
             moved=False,
-            status_field_updated=field_updated,
+            status_field_updated=bool(field_updated),
+            status_update_failed=field_updated is None,
         )
 
     target_dir = project_dir / ".kit" / "tasks" / target_folder
@@ -228,6 +240,11 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> TaskMove |
     field_updated = update_status_in_file(target_path, linear_status)
     if field_updated:
         print(f"✏️  Updated: **Status**: {linear_status}")
+    elif field_updated is None:
+        # The file moved but its Status field could not be set — a
+        # partial failure, surfaced here and in the returned model so
+        # the CLI exits nonzero (CodeRabbit, PR #108).
+        print(f"⚠️  Status field not updated in {target_path.name}")
 
     sync_coordination_metadata(task_id, target_path.name, target_folder, project_dir)
 
@@ -239,7 +256,8 @@ def move_task(task_id: str, target_status: str, project_dir: Path) -> TaskMove |
         to_folder=target_folder,
         status=linear_status,
         moved=True,
-        status_field_updated=field_updated,
+        status_field_updated=bool(field_updated),
+        status_update_failed=field_updated is None,
     )
 
 
@@ -257,11 +275,13 @@ def validate_all_tasks(project_dir: Path) -> ValidationReport:
     # validate — report zero checked rather than crash.
     if not tasks_dir.is_dir():
         print("✅ All 0 tasks have matching Status and folder")
-        return ValidationReport(checked=0, issues=[])
+        return ValidationReport(checked=0, issues=())
 
     for folder in tasks_dir.iterdir():
         if not folder.is_dir():
             continue
+        # membership: folder-name vocabulary checks against fixed
+        # sets, not identifier equality
         if folder.name in ["8-archive", "9-reference"]:
             continue
         if folder.name not in FOLDER_STATUS_MAP:
@@ -300,4 +320,4 @@ def validate_all_tasks(project_dir: Path) -> ValidationReport:
         print("\nTo fix, use: ./scripts/core/project move <task-id> <status>")
     else:
         print(f"✅ All {checked} tasks have matching Status and folder")
-    return ValidationReport(checked=checked, issues=issues)
+    return ValidationReport(checked=checked, issues=tuple(issues))

--- a/packages/agentive-kit/src/agentive_kit/lifecycle.py
+++ b/packages/agentive-kit/src/agentive_kit/lifecycle.py
@@ -66,11 +66,13 @@ def find_task_file(task_id: str, project_dir: Path) -> Path | None:
     # not a carry-forward): the legacy substring test let a short ID
     # like "KIT-1" silently select KIT-1234's file and move the wrong
     # task. A file matches when its name IS the ID or starts with the
-    # ID followed by a non-word separator; case-insensitive as before
-    # (matching runs on the uppercased name, so [0-9A-Z_] covers every
-    # word character).
+    # ID followed by a separator. Only alphanumeric continuation is a
+    # boundary violation — '-' AND '_' both count as separators, so
+    # trees named KIT-1234_sample.md (findable under the legacy
+    # matcher) stay findable. Case-insensitive as before; matching
+    # runs on the uppercased name, so [0-9A-Z] covers every letter.
     task_id_upper = task_id.upper()
-    id_pattern = re.compile(re.escape(task_id_upper) + r"(?![0-9A-Z_])")
+    id_pattern = re.compile(re.escape(task_id_upper) + r"(?![0-9A-Z])")
 
     for folder in tasks_dir.iterdir():
         if not folder.is_dir():

--- a/packages/agentive-kit/src/agentive_kit/lifecycle.py
+++ b/packages/agentive-kit/src/agentive_kit/lifecycle.py
@@ -1,0 +1,270 @@
+"""Task lifecycle: status moves, validation, coordination metadata.
+
+Extracted verbatim-in-behavior from ``scripts/core/project`` (KIT-0090
+F1); the existing test suite is the spec. One deliberate behavior
+change rides the extraction per KIT-0090 F6: the KIT-0086 single-writer
+guard on ``agent-handoffs.json`` (see ``sync_coordination_metadata``).
+
+Error strategy: CLI layer — failures print a clear message and return
+a falsy value; they never raise (matching the legacy script, and
+``patterns.yml`` → ``error_strategies``).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+from agentive_kit import gitio
+from agentive_kit.models import (
+    MetadataSyncNote,
+    StatusIssue,
+    TaskMove,
+    ValidationReport,
+)
+
+# Status to folder mapping
+STATUS_FOLDER_MAP = {
+    "backlog": "1-backlog",
+    "todo": "2-todo",
+    "in-progress": "3-in-progress",
+    "in-review": "4-in-review",
+    "done": "5-done",
+    "canceled": "6-canceled",
+    "blocked": "7-blocked",
+}
+
+# Folder to Linear-native status mapping
+FOLDER_STATUS_MAP = {
+    "1-backlog": "Backlog",
+    "2-todo": "Todo",
+    "3-in-progress": "In Progress",
+    "4-in-review": "In Review",
+    "5-done": "Done",
+    "6-canceled": "Canceled",
+    "7-blocked": "Blocked",
+}
+
+# The one branch on which lifecycle commands may write the shared
+# coordination JSON (KIT-0086 F1): the planner runs lifecycle moves on
+# main; every other writer is a feature-branch session, and those stop
+# touching the file entirely.
+HANDOFFS_WRITE_BRANCH = "main"
+
+
+def find_task_file(task_id: str, project_dir: Path) -> Path | None:
+    """Find a task file by ID across all workflow folders."""
+    tasks_dir = project_dir / ".kit" / "tasks"
+
+    # Normalize task ID (handle ASK-0001 or ASK-1)
+    task_id_upper = task_id.upper()
+
+    for folder in tasks_dir.iterdir():
+        if not folder.is_dir():
+            continue
+        for file in folder.glob("*.md"):
+            if task_id_upper in file.name.upper():
+                return file
+    return None
+
+
+def update_status_in_file(file_path: Path, new_status: str) -> bool:
+    """Update the Status field in a task file."""
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        new_content = re.sub(
+            r"(\*\*Status\*\*:\s*)(\w+(?:\s+\w+)?)",
+            f"\\1{new_status}",
+            content,
+            count=1,
+        )
+        if new_content != content:
+            file_path.write_text(new_content, encoding="utf-8")
+            return True
+        return False
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"❌ Error updating file: {e}")
+        return False
+
+
+def sync_coordination_metadata(
+    task_id: str, file_name: str, target_folder: str, project_dir: Path
+) -> list[MetadataSyncNote]:
+    """Rewrite the moved task's path in coordination metadata (KIT-0040 F2).
+
+    A status move changes the task file's numbered folder, stranding
+    stale paths in ``.kit/context/agent-handoffs.json`` and the task's
+    ``HANDOFF-*.md`` files. Only strings matching
+    ``.kit/tasks/<status-folder>/<this task's file name>`` are
+    rewritten — nothing else is touched. Failures warn and never block
+    the already completed move (CLI-layer error strategy).
+
+    KIT-0086 single-writer guard (F1, closed by reference here): the
+    shared ``agent-handoffs.json`` is written ONLY when this checkout
+    is on ``main`` — the planner is its single writer, and
+    feature-branch lifecycle moves must produce zero diff in it (the
+    KIT-0084 / PR #105 squash-merge conflict class). An undeterminable
+    branch (not a git repo, detached HEAD, git absent) skips the write
+    too: fail-safe over fail-open. The task's own ``HANDOFF-*.md``
+    files are same-branch artifacts with no cross-branch writer, so
+    they are rewritten regardless of branch. Stale-path drift in the
+    skipped JSON is surfaced by a doctor check (KIT-0086 F2), not here.
+    """
+    notes: list[MetadataSyncNote] = []
+    context_dir = project_dir / ".kit" / "context"
+    if not context_dir.is_dir():
+        return notes
+
+    pattern = re.compile(r"\.kit/tasks/[0-9]+-[a-z-]+/" + re.escape(file_name))
+    new_path = f".kit/tasks/{target_folder}/{file_name}"
+
+    handoffs_json = context_dir / "agent-handoffs.json"
+    targets = []
+    if gitio.current_branch(project_dir) == HANDOFFS_WRITE_BRANCH:
+        targets.append(handoffs_json)
+    else:
+        notes.append(
+            MetadataSyncNote(
+                path=handoffs_json,
+                action="skipped",
+                detail=f"not on {HANDOFFS_WRITE_BRANCH} — planner owns this file",
+            )
+        )
+    targets.extend(sorted(context_dir.glob(f"{task_id.upper()}-HANDOFF-*.md")))
+    for meta_file in targets:
+        if not meta_file.is_file():
+            continue
+        try:
+            content = meta_file.read_text(encoding="utf-8")
+            updated = pattern.sub(new_path, content)
+            if updated != content:
+                meta_file.write_text(updated, encoding="utf-8")
+                rel = meta_file.relative_to(project_dir)
+                print(f"🔗 Updated task path in {rel}")
+                notes.append(MetadataSyncNote(path=meta_file, action="updated"))
+        except (OSError, UnicodeDecodeError) as e:
+            # UnicodeDecodeError is a ValueError, not an OSError — a
+            # non-UTF-8 coordination file must warn, not break the move.
+            print(f"⚠️  Could not update {meta_file.name}: {e}")
+            notes.append(
+                MetadataSyncNote(path=meta_file, action="warned", detail=str(e))
+            )
+    return notes
+
+
+def move_task(task_id: str, target_status: str, project_dir: Path) -> TaskMove | None:
+    """Move a task to a new folder and update its Status field.
+
+    Returns a :class:`TaskMove` (truthy) on success, ``None`` on any
+    failure — callers that only need pass/fail keep working unchanged.
+    """
+    # Normalize target status
+    target_lower = target_status.lower().replace("_", "-").replace(" ", "-")
+
+    if target_lower not in STATUS_FOLDER_MAP:
+        print(f"❌ Unknown status: {target_status}")
+        print(f"   Valid statuses: {', '.join(STATUS_FOLDER_MAP.keys())}")
+        return None
+
+    target_folder = STATUS_FOLDER_MAP[target_lower]
+    linear_status = FOLDER_STATUS_MAP[target_folder]
+
+    task_file = find_task_file(task_id, project_dir)
+    if not task_file:
+        print(f"❌ Task not found: {task_id}")
+        return None
+
+    current_folder = task_file.parent.name
+
+    if current_folder == target_folder:
+        print(f"ℹ️  Task already in {target_folder}")
+        # Still update status field if needed
+        field_updated = update_status_in_file(task_file, linear_status)
+        # Re-running a move doubles as a repair action for metadata that
+        # drifted out of sync with the task's folder.
+        sync_coordination_metadata(task_id, task_file.name, target_folder, project_dir)
+        return TaskMove(
+            task_id=task_id,
+            file_name=task_file.name,
+            from_folder=current_folder,
+            to_folder=target_folder,
+            status=linear_status,
+            moved=False,
+            status_field_updated=field_updated,
+        )
+
+    target_dir = project_dir / ".kit" / "tasks" / target_folder
+    target_path = target_dir / task_file.name
+
+    try:
+        shutil.move(str(task_file), str(target_path))
+        print(f"📁 Moved: {current_folder} → {target_folder}")
+    except (OSError, shutil.Error) as e:
+        print(f"❌ Error moving file: {e}")
+        return None
+
+    field_updated = update_status_in_file(target_path, linear_status)
+    if field_updated:
+        print(f"✏️  Updated: **Status**: {linear_status}")
+
+    sync_coordination_metadata(task_id, target_path.name, target_folder, project_dir)
+
+    print(f"✅ Task {task_id} is now {linear_status}")
+    return TaskMove(
+        task_id=task_id,
+        file_name=target_path.name,
+        from_folder=current_folder,
+        to_folder=target_folder,
+        status=linear_status,
+        moved=True,
+        status_field_updated=field_updated,
+    )
+
+
+def validate_all_tasks(project_dir: Path) -> ValidationReport:
+    """Validate all task files have matching Status and folder.
+
+    Returns a :class:`ValidationReport`; check ``report.ok`` for
+    pass/fail (the report object itself is always truthy).
+    """
+    tasks_dir = project_dir / ".kit" / "tasks"
+    issues: list[StatusIssue] = []
+    checked = 0
+
+    for folder in tasks_dir.iterdir():
+        if not folder.is_dir():
+            continue
+        if folder.name in ["8-archive", "9-reference"]:
+            continue
+        if folder.name not in FOLDER_STATUS_MAP:
+            continue
+
+        expected_status = FOLDER_STATUS_MAP[folder.name]
+
+        for file in folder.glob("*.md"):
+            checked += 1
+            content = file.read_text(encoding="utf-8")
+            match = re.search(r"\*\*Status\*\*:\s*(\w+(?:\s+\w+)?)", content)
+
+            if not match:
+                issues.append(StatusIssue(file.name, "No Status field found"))
+                continue
+
+            actual_status = match.group(1).strip()
+            if actual_status != expected_status:
+                issues.append(
+                    StatusIssue(
+                        file.name,
+                        f"Status '{actual_status}' != folder '{expected_status}'",
+                    )
+                )
+
+    if issues:
+        print(f"❌ Found {len(issues)} status mismatches:\n")
+        for issue in issues:
+            print(f"  • {issue.file_name}: {issue.detail}")
+        print("\nTo fix, use: ./scripts/core/project move <task-id> <status>")
+    else:
+        print(f"✅ All {checked} tasks have matching Status and folder")
+    return ValidationReport(checked=checked, issues=issues)

--- a/packages/agentive-kit/src/agentive_kit/models.py
+++ b/packages/agentive-kit/src/agentive_kit/models.py
@@ -24,6 +24,12 @@ class TaskMove:
     status: str  # Linear-native status label, e.g. "In Progress"
     moved: bool  # False when the task was already in the target folder
     status_field_updated: bool
+    # True when the Status field could NOT be set (absent, unreadable,
+    # unwritable) even though the file move itself succeeded — a
+    # partial failure the CLI reports with a nonzero exit (CodeRabbit,
+    # PR #108). Distinct from status_field_updated=False, which also
+    # covers "already correct, nothing to do".
+    status_update_failed: bool = False
 
 
 @dataclass(frozen=True)
@@ -39,7 +45,10 @@ class ValidationReport:
     """Outcome of a full task-status validation (lifecycle → CLI)."""
 
     checked: int
-    issues: list[StatusIssue] = field(default_factory=list)
+    # A tuple, so frozen=True actually means immutable — a list field
+    # would let callers mutate .issues and flip .ok (CodeRabbit,
+    # PR #108).
+    issues: tuple[StatusIssue, ...] = field(default_factory=tuple)
 
     @property
     def ok(self) -> bool:

--- a/packages/agentive-kit/src/agentive_kit/models.py
+++ b/packages/agentive-kit/src/agentive_kit/models.py
@@ -1,0 +1,55 @@
+"""Typed models for data crossing module boundaries (KIT-0090 F1).
+
+The arch evaluation's accepted finding: internal contracts should be
+readable and testable — explicit dataclasses, not loose dicts. Kept
+deliberately small: a model earns its place here only when the value
+actually crosses a module boundary or is emitted by the CLI; purely
+local intermediates stay local.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TaskMove:
+    """Outcome of a task status move (lifecycle → CLI)."""
+
+    task_id: str
+    file_name: str
+    from_folder: str
+    to_folder: str
+    status: str  # Linear-native status label, e.g. "In Progress"
+    moved: bool  # False when the task was already in the target folder
+    status_field_updated: bool
+
+
+@dataclass(frozen=True)
+class StatusIssue:
+    """One task file whose Status field disagrees with its folder."""
+
+    file_name: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Outcome of a full task-status validation (lifecycle → CLI)."""
+
+    checked: int
+    issues: list[StatusIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+@dataclass(frozen=True)
+class MetadataSyncNote:
+    """One coordination-metadata file touched (or skipped) by a move."""
+
+    path: Path
+    action: str  # "updated" | "skipped" | "warned"
+    detail: str = ""

--- a/packages/agentive-kit/src/agentive_kit/models.py
+++ b/packages/agentive-kit/src/agentive_kit/models.py
@@ -26,10 +26,10 @@ class TaskMove:
     status_field_updated: bool
     # True when the Status field could NOT be set (absent, unreadable,
     # unwritable), regardless of whether a move occurred — the
-    # already-in-place repair path sets it too. A partial failure the
-    # CLI reports with a nonzero exit (CodeRabbit, PR #108). Distinct
-    # from status_field_updated=False, which also covers "already
-    # correct, nothing to do".
+    # already-in-place repair path sets it too. The CLI reports this
+    # partial failure with a nonzero exit (CodeRabbit, PR #108). This
+    # is distinct from status_field_updated=False, which also covers
+    # "already correct, nothing to do".
     status_update_failed: bool = False
 
 

--- a/packages/agentive-kit/src/agentive_kit/models.py
+++ b/packages/agentive-kit/src/agentive_kit/models.py
@@ -25,10 +25,11 @@ class TaskMove:
     moved: bool  # False when the task was already in the target folder
     status_field_updated: bool
     # True when the Status field could NOT be set (absent, unreadable,
-    # unwritable) even though the file move itself succeeded — a
-    # partial failure the CLI reports with a nonzero exit (CodeRabbit,
-    # PR #108). Distinct from status_field_updated=False, which also
-    # covers "already correct, nothing to do".
+    # unwritable), regardless of whether a move occurred — the
+    # already-in-place repair path sets it too. A partial failure the
+    # CLI reports with a nonzero exit (CodeRabbit, PR #108). Distinct
+    # from status_field_updated=False, which also covers "already
+    # correct, nothing to do".
     status_update_failed: bool = False
 
 

--- a/packages/agentive-kit/src/agentive_kit/root.py
+++ b/packages/agentive-kit/src/agentive_kit/root.py
@@ -62,6 +62,21 @@ def find_project_root(start: Path | None = None) -> Path:
         start = Path.cwd()
     current = Path(os.path.abspath(start))
     for candidate in (current, *current.parents):
-        if (candidate / ".kit").is_dir() and (candidate / "CLAUDE.md").is_file():
+        if _is_project_root(candidate):
             return candidate
     raise RootNotFoundError(current)
+
+
+def _is_project_root(candidate: Path) -> bool:
+    """True when ``candidate`` carries both root markers.
+
+    An ancestor the process cannot stat (locked-down container, odd
+    NFS mount) reads as "not a root" and the walk continues — pathlib
+    propagates ``PermissionError`` from ``is_dir``/``is_file`` on
+    Python < 3.13, and a traceback is never the right refusal
+    (evaluator finding, PR 1 trio).
+    """
+    try:
+        return (candidate / ".kit").is_dir() and (candidate / "CLAUDE.md").is_file()
+    except OSError:
+        return False

--- a/packages/agentive-kit/src/agentive_kit/root.py
+++ b/packages/agentive-kit/src/agentive_kit/root.py
@@ -1,0 +1,67 @@
+"""Project-root discovery for a globally installed CLI (KIT-0090 F2).
+
+The legacy ``scripts/core/project`` resolved the project from its own
+file location (``Path(__file__).resolve().parent.parent.parent``) —
+correct for a repo-resident script, meaningless for a tool installed
+with ``uv tool install``. The package resolves from the CURRENT
+DIRECTORY instead: walk upward until a directory looks like a kit
+project root, and refuse loudly when none does. Never operate on a
+guessed root.
+
+What counts as a kit project root: a directory containing BOTH a
+``.kit/`` directory and a ``CLAUDE.md`` file. Every bootstrapped
+consumer (single or planning shape) has both, and so does the
+agentive-starter-kit repo itself — which must dogfood this package
+(KIT-0090 F5) but, being the upstream rather than a bootstrapped
+consumer, carries no ``kit-install`` marker region in its CLAUDE.md.
+That is why the marker alone is NOT the discovery test; the marker
+stays what it always was — the shape/profile record that doctor reads
+once a root is found.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+class RootNotFoundError(Exception):
+    """Raised when no kit project root exists at or above the start dir.
+
+    ``str(exc)`` is the full user-facing refusal message, ready to
+    print — callers should not need to compose their own.
+    """
+
+    def __init__(self, start: Path):
+        self.start = start
+        super().__init__(
+            f"❌ Not inside an agentive project: {start}\n"
+            "   Searched this directory and every parent for a project\n"
+            "   root (a directory containing both .kit/ and CLAUDE.md)\n"
+            "   and found none. Run this command from inside a kit-made\n"
+            "   repository, or create one first."
+        )
+
+
+def find_project_root(start: Path | None = None) -> Path:
+    """Walk up from ``start`` (default: CWD) to the nearest project root.
+
+    Returns the first ancestor (including ``start`` itself) that
+    contains both a ``.kit/`` directory and a ``CLAUDE.md`` file.
+    Raises :class:`RootNotFoundError` at the filesystem root.
+
+    The start path is resolved first so the walk terminates even when
+    invoked through a relative path or a symlinked working directory;
+    a worktree checkout needs nothing special — it carries the full
+    tree, so the walk finds its own root, never the primary clone's.
+    """
+    if start is None:
+        # Path.cwd() raises FileNotFoundError if the CWD was deleted
+        # from under the process — let that propagate; there is no
+        # sensible root to discover from a nonexistent directory.
+        start = Path.cwd()
+    current = Path(os.path.abspath(start))
+    for candidate in (current, *current.parents):
+        if (candidate / ".kit").is_dir() and (candidate / "CLAUDE.md").is_file():
+            return candidate
+    raise RootNotFoundError(current)

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -2321,7 +2321,9 @@ except Exception as e:
         sys.exit(0)
 
     elif command == "move":
-        # Move task to new status folder (delegates to agentive_kit)
+        # Move task to new status folder (delegates to agentive_kit).
+        # Exit is nonzero on a PARTIAL failure too (moved but Status
+        # field not set) — TaskMove.status_update_failed carries it.
         if len(sys.argv) < 4:
             print("Usage: ./scripts/core/project move <task-id> <status>")
             print("       ./scripts/core/project move ASK-0001 done")
@@ -2333,7 +2335,7 @@ except Exception as e:
         task_id = sys.argv[2]
         target_status = sys.argv[3]
         success = _kit_lifecycle().move_task(task_id, target_status, project_dir)
-        sys.exit(0 if success else 1)
+        sys.exit(0 if (success and not success.status_update_failed) else 1)
 
     elif command == "complete":
         # Shorthand for moving to done
@@ -2342,7 +2344,7 @@ except Exception as e:
             sys.exit(1)
         task_id = sys.argv[2]
         success = _kit_lifecycle().move_task(task_id, "done", project_dir)
-        sys.exit(0 if success else 1)
+        sys.exit(0 if (success and not success.status_update_failed) else 1)
 
     elif command == "start":
         # Shorthand for moving to in-progress
@@ -2351,7 +2353,7 @@ except Exception as e:
             sys.exit(1)
         task_id = sys.argv[2]
         success = _kit_lifecycle().move_task(task_id, "in-progress", project_dir)
-        sys.exit(0 if success else 1)
+        sys.exit(0 if (success and not success.status_update_failed) else 1)
 
     elif command == "block":
         # Shorthand for moving to blocked
@@ -2360,7 +2362,7 @@ except Exception as e:
             sys.exit(1)
         task_id = sys.argv[2]
         success = _kit_lifecycle().move_task(task_id, "blocked", project_dir)
-        sys.exit(0 if success else 1)
+        sys.exit(0 if (success and not success.status_update_failed) else 1)
 
     elif command == "validate":
         # Validate all task statuses match folders

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -283,195 +283,52 @@ def _ensure_adversarial_cli(project_dir):
         print('     export PATH="$HOME/.local/bin:$PATH"')
 
 
-# Status to folder mapping
-STATUS_FOLDER_MAP = {
-    "backlog": "1-backlog",
-    "todo": "2-todo",
-    "in-progress": "3-in-progress",
-    "in-review": "4-in-review",
-    "done": "5-done",
-    "canceled": "6-canceled",
-    "blocked": "7-blocked",
-}
-
-# Folder to Linear-native status mapping
-FOLDER_STATUS_MAP = {
-    "1-backlog": "Backlog",
-    "2-todo": "Todo",
-    "3-in-progress": "In Progress",
-    "4-in-review": "In Review",
-    "5-done": "Done",
-    "6-canceled": "Canceled",
-    "7-blocked": "Blocked",
-}
+# ── Task lifecycle: extracted to the agentive-kit package (KIT-0090) ────────
+# The status maps, find/move/validate functions and the coordination-
+# metadata sync now live in agentive_kit.lifecycle — including the
+# KIT-0086 single-writer guard (agent-handoffs.json is written only on
+# main). This script delegates so there is exactly ONE implementation.
 
 
-def find_task_file(task_id: str, project_dir: Path) -> Path | None:
-    """Find a task file by ID across all workflow folders."""
-    tasks_dir = project_dir / ".kit" / "tasks"
+def _kit_lifecycle():
+    """Import agentive_kit.lifecycle, bootstrapping from the in-repo source.
 
-    # Normalize task ID (handle ASK-0001 or ASK-1)
-    task_id_upper = task_id.upper()
+    Resolution order: an installed agentive-kit first (the phase-3 end
+    state), then the kit repo's own packages/agentive-kit/src tree (the
+    dogfood path — works with no install at all, on bare python3).
+    Fails loud with the install command when neither exists: a consumer
+    checkout that synced this script before migrating to the package
+    (KIT-ADR-0028 phase 3) must get an instruction, not a traceback.
 
-    for folder in tasks_dir.iterdir():
-        if not folder.is_dir():
-            continue
-        for file in folder.glob("*.md"):
-            if task_id_upper in file.name.upper():
-                return file
-    return None
-
-
-def update_status_in_file(file_path: Path, new_status: str) -> bool:
-    """Update the Status field in a task file."""
-    try:
-        content = file_path.read_text()
-        # Replace Status field
-        new_content = re.sub(
-            r"(\*\*Status\*\*:\s*)(\w+(?:\s+\w+)?)",
-            f"\\1{new_status}",
-            content,
-            count=1,
-        )
-        if new_content != content:
-            file_path.write_text(new_content)
-            return True
-        return False
-    except Exception as e:
-        print(f"❌ Error updating file: {e}")
-        return False
-
-
-def _sync_coordination_metadata(
-    task_id: str, file_name: str, target_folder: str, project_dir: Path
-) -> None:
-    """Rewrite the moved task's path in coordination metadata (KIT-0040 F2).
-
-    A status move changes the task file's numbered folder, stranding stale
-    paths in .kit/context/agent-handoffs.json (details_link/handoff_file
-    values) and the task's HANDOFF-*.md files; CodeRabbit flags the drift
-    on every move. Only strings matching
-    .kit/tasks/<status-folder>/<this task's file name> are rewritten —
-    nothing else is touched. Failures warn and never block the already
-    completed move (CLI-layer error strategy).
+    Lazy on purpose: only the lifecycle commands need the package, so
+    setup/doctor/sync/install-evaluators keep working package-free
+    until their own extraction PRs.
     """
-    context_dir = project_dir / ".kit" / "context"
-    if not context_dir.is_dir():
-        return
-
-    pattern = re.compile(r"\.kit/tasks/[0-9]+-[a-z-]+/" + re.escape(file_name))
-    new_path = f".kit/tasks/{target_folder}/{file_name}"
-
-    targets = [context_dir / "agent-handoffs.json"]
-    targets.extend(sorted(context_dir.glob(f"{task_id.upper()}-HANDOFF-*.md")))
-    for meta_file in targets:
-        if not meta_file.is_file():
-            continue
-        try:
-            content = meta_file.read_text(encoding="utf-8")
-            updated = pattern.sub(new_path, content)
-            if updated != content:
-                meta_file.write_text(updated, encoding="utf-8")
-                rel = meta_file.relative_to(project_dir)
-                print(f"🔗 Updated task path in {rel}")
-        except (OSError, UnicodeDecodeError) as e:
-            # UnicodeDecodeError is a ValueError, not an OSError — a
-            # non-UTF-8 coordination file must warn, not break the move.
-            print(f"⚠️  Could not update {meta_file.name}: {e}")
-
-
-def move_task(task_id: str, target_status: str, project_dir: Path) -> bool:
-    """Move a task to a new folder and update its Status field."""
-    # Normalize target status
-    target_lower = target_status.lower().replace("_", "-").replace(" ", "-")
-
-    if target_lower not in STATUS_FOLDER_MAP:
-        print(f"❌ Unknown status: {target_status}")
-        print(f"   Valid statuses: {', '.join(STATUS_FOLDER_MAP.keys())}")
-        return False
-
-    target_folder = STATUS_FOLDER_MAP[target_lower]
-    linear_status = FOLDER_STATUS_MAP[target_folder]
-
-    # Find the task file
-    task_file = find_task_file(task_id, project_dir)
-    if not task_file:
-        print(f"❌ Task not found: {task_id}")
-        return False
-
-    # Get current folder
-    current_folder = task_file.parent.name
-
-    if current_folder == target_folder:
-        print(f"ℹ️  Task already in {target_folder}")
-        # Still update status field if needed
-        update_status_in_file(task_file, linear_status)
-        # Re-running a move doubles as a repair action for metadata that
-        # drifted out of sync with the task's folder.
-        _sync_coordination_metadata(task_id, task_file.name, target_folder, project_dir)
-        return True
-
-    # Move file
-    target_dir = project_dir / ".kit" / "tasks" / target_folder
-    target_path = target_dir / task_file.name
-
     try:
-        shutil.move(str(task_file), str(target_path))
-        print(f"📁 Moved: {current_folder} → {target_folder}")
-    except Exception as e:
-        print(f"❌ Error moving file: {e}")
-        return False
+        from agentive_kit import lifecycle
 
-    # Update status field
-    if update_status_in_file(target_path, linear_status):
-        print(f"✏️  Updated: **Status**: {linear_status}")
+        return lifecycle
+    except ImportError:
+        pass
+    pkg_src = (
+        Path(__file__).resolve().parent.parent.parent
+        / "packages"
+        / "agentive-kit"
+        / "src"
+    )
+    if pkg_src.is_dir() and str(pkg_src) not in sys.path:
+        sys.path.insert(0, str(pkg_src))
+        try:
+            from agentive_kit import lifecycle
 
-    _sync_coordination_metadata(task_id, target_path.name, target_folder, project_dir)
-
-    print(f"✅ Task {task_id} is now {linear_status}")
-    return True
-
-
-def validate_all_tasks(project_dir: Path) -> bool:
-    """Validate all task files have matching Status and folder."""
-    tasks_dir = project_dir / ".kit" / "tasks"
-    errors = []
-    checked = 0
-
-    for folder in tasks_dir.iterdir():
-        if not folder.is_dir():
-            continue
-        if folder.name in ["8-archive", "9-reference"]:
-            continue
-        if folder.name not in FOLDER_STATUS_MAP:
-            continue
-
-        expected_status = FOLDER_STATUS_MAP[folder.name]
-
-        for file in folder.glob("*.md"):
-            checked += 1
-            content = file.read_text()
-            match = re.search(r"\*\*Status\*\*:\s*(\w+(?:\s+\w+)?)", content)
-
-            if not match:
-                errors.append(f"{file.name}: No Status field found")
-                continue
-
-            actual_status = match.group(1).strip()
-            if actual_status != expected_status:
-                errors.append(
-                    f"{file.name}: Status '{actual_status}' != folder '{expected_status}'"
-                )
-
-    if errors:
-        print(f"❌ Found {len(errors)} status mismatches:\n")
-        for error in errors:
-            print(f"  • {error}")
-        print(f"\nTo fix, use: ./scripts/core/project move <task-id> <status>")
-        return False
-
-    print(f"✅ All {checked} tasks have matching Status and folder")
-    return True
+            return lifecycle
+        except ImportError:
+            pass
+    print("❌ agentive-kit is not installed")
+    print("   Task lifecycle commands live in the agentive-kit package")
+    print("   (KIT-ADR-0028 phase 1). Install it:")
+    print("     uv tool install agentive-kit")
+    sys.exit(1)
 
 
 def _derive_repo_url(project_dir: Path) -> str | None:
@@ -2460,15 +2317,18 @@ except Exception as e:
         sys.exit(0)
 
     elif command == "move":
-        # Move task to new status folder
+        # Move task to new status folder (delegates to agentive_kit)
         if len(sys.argv) < 4:
             print("Usage: ./scripts/core/project move <task-id> <status>")
             print("       ./scripts/core/project move ASK-0001 done")
-            print(f"       Valid statuses: {', '.join(STATUS_FOLDER_MAP.keys())}")
+            print(
+                "       Valid statuses: backlog, todo, in-progress, "
+                "in-review, done, canceled, blocked"
+            )
             sys.exit(1)
         task_id = sys.argv[2]
         target_status = sys.argv[3]
-        success = move_task(task_id, target_status, project_dir)
+        success = _kit_lifecycle().move_task(task_id, target_status, project_dir)
         sys.exit(0 if success else 1)
 
     elif command == "complete":
@@ -2477,7 +2337,7 @@ except Exception as e:
             print("Usage: ./scripts/core/project complete <task-id>")
             sys.exit(1)
         task_id = sys.argv[2]
-        success = move_task(task_id, "done", project_dir)
+        success = _kit_lifecycle().move_task(task_id, "done", project_dir)
         sys.exit(0 if success else 1)
 
     elif command == "start":
@@ -2486,7 +2346,7 @@ except Exception as e:
             print("Usage: ./scripts/core/project start <task-id>")
             sys.exit(1)
         task_id = sys.argv[2]
-        success = move_task(task_id, "in-progress", project_dir)
+        success = _kit_lifecycle().move_task(task_id, "in-progress", project_dir)
         sys.exit(0 if success else 1)
 
     elif command == "block":
@@ -2495,13 +2355,13 @@ except Exception as e:
             print("Usage: ./scripts/core/project block <task-id>")
             sys.exit(1)
         task_id = sys.argv[2]
-        success = move_task(task_id, "blocked", project_dir)
+        success = _kit_lifecycle().move_task(task_id, "blocked", project_dir)
         sys.exit(0 if success else 1)
 
     elif command == "validate":
         # Validate all task statuses match folders
-        success = validate_all_tasks(project_dir)
-        sys.exit(0 if success else 1)
+        report = _kit_lifecycle().validate_all_tasks(project_dir)
+        sys.exit(0 if report.ok else 1)
 
     elif command == "reconfigure":
         # Reconfigure project files with correct identity

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -304,11 +304,15 @@ def _kit_lifecycle():
     setup/doctor/sync/install-evaluators keep working package-free
     until their own extraction PRs.
     """
+    # ModuleNotFoundError only — an INSTALLED agentive-kit that fails
+    # to import for any other reason (broken install, missing symbol)
+    # must surface its real error, not a false "not installed"
+    # instruction (evaluator round 5).
     try:
         from agentive_kit import lifecycle
 
         return lifecycle
-    except ImportError:
+    except ModuleNotFoundError:
         pass
     pkg_src = (
         Path(__file__).resolve().parent.parent.parent
@@ -322,7 +326,7 @@ def _kit_lifecycle():
             from agentive_kit import lifecycle
 
             return lifecycle
-        except ImportError:
+        except ModuleNotFoundError:
             pass
     print("❌ agentive-kit is not installed")
     print("   Task lifecycle commands live in the agentive-kit package")

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -2324,7 +2324,9 @@ except Exception as e:
         # Move task to new status folder (delegates to agentive_kit).
         # Exit is nonzero on a PARTIAL failure too (moved but Status
         # field not set) — TaskMove.status_update_failed carries it.
-        if len(sys.argv) < 4:
+        if len(sys.argv) != 4:
+            # != not <: surplus arguments are a usage error, never
+            # silently dropped (BugBot, PR #108 round 2)
             print("Usage: ./scripts/core/project move <task-id> <status>")
             print("       ./scripts/core/project move ASK-0001 done")
             print(
@@ -2339,7 +2341,7 @@ except Exception as e:
 
     elif command == "complete":
         # Shorthand for moving to done
-        if len(sys.argv) < 3:
+        if len(sys.argv) != 3:
             print("Usage: ./scripts/core/project complete <task-id>")
             sys.exit(1)
         task_id = sys.argv[2]
@@ -2348,7 +2350,7 @@ except Exception as e:
 
     elif command == "start":
         # Shorthand for moving to in-progress
-        if len(sys.argv) < 3:
+        if len(sys.argv) != 3:
             print("Usage: ./scripts/core/project start <task-id>")
             sys.exit(1)
         task_id = sys.argv[2]
@@ -2357,7 +2359,7 @@ except Exception as e:
 
     elif command == "block":
         # Shorthand for moving to blocked
-        if len(sys.argv) < 3:
+        if len(sys.argv) != 3:
             print("Usage: ./scripts/core/project block <task-id>")
             sys.exit(1)
         task_id = sys.argv[2]
@@ -2366,6 +2368,9 @@ except Exception as e:
 
     elif command == "validate":
         # Validate all task statuses match folders
+        if len(sys.argv) != 2:
+            print("Usage: ./scripts/core/project validate")
+            sys.exit(1)
         report = _kit_lifecycle().validate_all_tasks(project_dir)
         sys.exit(0 if report.ok else 1)
 

--- a/tests/agentive_kit/test_cli.py
+++ b/tests/agentive_kit/test_cli.py
@@ -1,0 +1,119 @@
+"""Tests for agentive_kit.cli — the ``agentive`` console entry.
+
+The CLI's one behavioral difference from the legacy script is root
+discovery (KIT-0090 F2): it resolves the project by walking up from the
+current directory and refuses loudly outside a kit repo. The lifecycle
+behavior itself is covered in test_lifecycle.py; here we test the
+dispatch surface and the discovery wiring.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+pytest.importorskip(
+    "agentive_kit", reason="agentive-kit package source present only in the kit repo"
+)
+
+from agentive_kit import cli  # noqa: E402
+
+TASK_FILE = "KIT-1234-sample-task.md"
+
+
+def make_kit_tree(tmp_path, branch="main"):
+    tasks = tmp_path / ".kit" / "tasks"
+    for folder in ("2-todo", "3-in-progress", "5-done", "7-blocked"):
+        (tasks / folder).mkdir(parents=True)
+    (tasks / "2-todo" / TASK_FILE).write_text("**Status**: Todo\n", encoding="utf-8")
+    (tmp_path / "CLAUDE.md").write_text("# Project\n", encoding="utf-8")
+    if branch is not None:
+        subprocess.run(
+            ["git", "init", "-q", "-b", branch, str(tmp_path)],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+    return tmp_path
+
+
+def run_cli(args):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(args)
+    return exc_info.value.code
+
+
+class TestDispatch:
+    def test_no_args_prints_usage(self, capsys):
+        assert run_cli([]) == 0
+        out = capsys.readouterr().out
+        assert "Usage: agentive" in out
+
+    def test_help_exits_zero(self, capsys):
+        assert run_cli(["help"]) == 0
+        assert "Task Management" in capsys.readouterr().out
+
+    def test_version_prints_package_version(self, capsys):
+        import agentive_kit
+
+        assert run_cli(["version"]) == 0
+        assert f"agentive-kit v{agentive_kit.__version__}" in capsys.readouterr().out
+
+    def test_unknown_command_exits_one(self, capsys):
+        assert run_cli(["frobnicate"]) == 1
+        out = capsys.readouterr().out
+        assert "Unknown command" in out
+        # Not-yet-migrated commands still have a home; the error says so.
+        assert "scripts/core/project" in out
+
+    def test_move_usage_error(self, capsys):
+        assert run_cli(["move", "KIT-1234"]) == 1
+        assert "Usage: agentive move" in capsys.readouterr().out
+
+    def test_start_usage_error(self, capsys):
+        assert run_cli(["start"]) == 1
+        assert "Usage: agentive start" in capsys.readouterr().out
+
+
+class TestRootDiscoveryWiring:
+    def test_start_from_subdirectory_moves_task(self, tmp_path, monkeypatch, capsys):
+        root = make_kit_tree(tmp_path)
+        nested = root / "docs" / "deep"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        assert run_cli(["start", "KIT-1234"]) == 0
+
+        moved = root / ".kit" / "tasks" / "3-in-progress" / TASK_FILE
+        assert moved.exists()
+        assert "In Progress" in capsys.readouterr().out
+
+    def test_complete_and_block_shorthands(self, tmp_path, monkeypatch):
+        root = make_kit_tree(tmp_path)
+        monkeypatch.chdir(root)
+        assert run_cli(["complete", "KIT-1234"]) == 0
+        assert (root / ".kit" / "tasks" / "5-done" / TASK_FILE).exists()
+        assert run_cli(["block", "KIT-1234"]) == 0
+        assert (root / ".kit" / "tasks" / "7-blocked" / TASK_FILE).exists()
+
+    def test_validate_exit_codes(self, tmp_path, monkeypatch):
+        root = make_kit_tree(tmp_path)
+        monkeypatch.chdir(root)
+        assert run_cli(["validate"]) == 0
+        wrong = root / ".kit" / "tasks" / "5-done" / "KIT-0003-wrong.md"
+        wrong.write_text("**Status**: Todo\n", encoding="utf-8")
+        assert run_cli(["validate"]) == 1
+
+    def test_outside_kit_repo_refuses_loudly(self, tmp_path, monkeypatch, capsys):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        monkeypatch.chdir(plain)
+        assert run_cli(["validate"]) == 1
+        assert "Not inside an agentive project" in capsys.readouterr().out
+
+    def test_failed_move_exits_one(self, tmp_path, monkeypatch, capsys):
+        root = make_kit_tree(tmp_path)
+        monkeypatch.chdir(root)
+        assert run_cli(["start", "KIT-9999"]) == 1
+        assert "Task not found" in capsys.readouterr().out

--- a/tests/agentive_kit/test_cli.py
+++ b/tests/agentive_kit/test_cli.py
@@ -75,6 +75,16 @@ class TestDispatch:
         assert run_cli(["start"]) == 1
         assert "Usage: agentive start" in capsys.readouterr().out
 
+    def test_surplus_arguments_rejected(self, capsys):
+        # CodeRabbit (PR #108): surplus args are a usage error, never
+        # silently ignored — a mistyped automation call must fail loud.
+        assert run_cli(["start", "KIT-1234", "extra"]) == 1
+        assert "Usage: agentive start" in capsys.readouterr().out
+        assert run_cli(["move", "KIT-1234", "done", "extra"]) == 1
+        assert "Usage: agentive move" in capsys.readouterr().out
+        assert run_cli(["validate", "extra"]) == 1
+        assert "Usage: agentive validate" in capsys.readouterr().out
+
 
 class TestRootDiscoveryWiring:
     def test_start_from_subdirectory_moves_task(self, tmp_path, monkeypatch, capsys):
@@ -117,3 +127,13 @@ class TestRootDiscoveryWiring:
         monkeypatch.chdir(root)
         assert run_cli(["start", "KIT-9999"]) == 1
         assert "Task not found" in capsys.readouterr().out
+
+    def test_partial_failure_exits_one(self, tmp_path, monkeypatch, capsys):
+        # Moved but Status field unset → nonzero exit (CodeRabbit,
+        # PR #108).
+        root = make_kit_tree(tmp_path)
+        task = root / ".kit" / "tasks" / "2-todo" / TASK_FILE
+        task.write_text("# no status header\n", encoding="utf-8")
+        monkeypatch.chdir(root)
+        assert run_cli(["start", "KIT-1234"]) == 1
+        assert "Status field not updated" in capsys.readouterr().out

--- a/tests/agentive_kit/test_gitio.py
+++ b/tests/agentive_kit/test_gitio.py
@@ -1,0 +1,172 @@
+"""Tests for agentive_kit.gitio — the package's single git boundary.
+
+Ports the KIT-0080 portability discipline and PR #107's failure-path
+lesson (the KIT-0080 retro: the one-liner fix was verified on the happy
+path only — so the failure paths get explicit tests here): git absent,
+not a repository, nonexistent directory, ambient GIT_* leakage.
+
+Migrates TestDeriveRepoUrl from tests/test_project_script.py (KIT-0090
+F3: per-module tests move with their code).
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+pytest.importorskip(
+    "agentive_kit", reason="agentive-kit package source present only in the kit repo"
+)
+
+from agentive_kit import gitio  # noqa: E402
+
+
+def _git(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def init_repo(path, branch="main", commit=True):
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", "-b", branch, str(path)],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    if commit:
+        _git(
+            path,
+            "-c",
+            "user.email=test@test",
+            "-c",
+            "user.name=test",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        )
+    return path
+
+
+class TestCurrentBranch:
+    def test_main(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        assert gitio.current_branch(repo) == "main"
+
+    def test_feature_branch(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        _git(repo, "checkout", "-q", "-b", "feature/KIT-0000-x")
+        assert gitio.current_branch(repo) == "feature/KIT-0000-x"
+
+    def test_unborn_branch_still_reports_name(self, tmp_path):
+        # A fresh init with no commits: HEAD is an unborn symref, and
+        # `branch --show-current` still prints the name (git >= 2.22).
+        repo = init_repo(tmp_path / "repo", commit=False)
+        assert gitio.current_branch(repo) == "main"
+
+    def test_detached_head_is_none(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        _git(repo, "checkout", "-q", "--detach")
+        assert gitio.current_branch(repo) is None
+
+    def test_non_repo_is_none(self, tmp_path):
+        assert gitio.current_branch(tmp_path) is None
+
+    def test_git_unfindable_is_none(self, tmp_path, monkeypatch):
+        empty = tmp_path / "empty-path"
+        empty.mkdir()
+        monkeypatch.setenv("PATH", str(empty))
+        assert gitio.current_branch(tmp_path) is None
+
+
+class TestRunGit:
+    def test_nonexistent_dir_fails_without_raising(self, tmp_path):
+        # PR #107 class: resolvers must fail clean, not crash, when the
+        # directory they anchor on is gone.
+        result = gitio.run_git(tmp_path / "missing", "status")
+        assert result is not None
+        assert result.returncode != 0
+
+    def test_ambient_git_dir_is_scrubbed(self, tmp_path, monkeypatch):
+        # The KIT-0043 incident class: pre-commit exports GIT_DIR, which
+        # overrides -C and silently points git at the WRONG repo. The
+        # scrub makes -C authoritative.
+        repo_a = init_repo(tmp_path / "a")
+        repo_b = init_repo(tmp_path / "b", branch="other")
+        monkeypatch.setenv("GIT_DIR", str(repo_a / ".git"))
+        assert gitio.current_branch(repo_b) == "other"
+
+    def test_clean_git_env_strips_all_git_vars(self, monkeypatch):
+        monkeypatch.setenv("GIT_DIR", "/somewhere/.git")
+        monkeypatch.setenv("GIT_WORK_TREE", "/somewhere")
+        monkeypatch.setenv("GIT_INDEX_FILE", "/somewhere/index")
+        env = gitio.clean_git_env()
+        assert not any(k.startswith("GIT_") for k in env)
+
+
+class TestGitCommonDir:
+    def test_primary_clone(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        assert gitio.git_common_dir(repo) == repo / ".git"
+
+    def test_worktree_points_at_primary(self, tmp_path):
+        primary = init_repo(tmp_path / "primary")
+        wt = tmp_path / "wt"
+        _git(primary, "worktree", "add", "-q", str(wt), "-b", "wt-branch")
+        assert gitio.git_common_dir(wt) == primary / ".git"
+
+    def test_anchors_on_repo_dir_not_cwd(self, tmp_path, monkeypatch):
+        # KIT-0080: plain --git-common-dir output is RELATIVE to -C (a
+        # bare ".git" from a primary clone) — it must be absolutized
+        # against the repo dir, never the process CWD.
+        repo = init_repo(tmp_path / "repo")
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        assert gitio.git_common_dir(repo) == repo / ".git"
+
+    def test_non_repo_is_none(self, tmp_path):
+        assert gitio.git_common_dir(tmp_path) is None
+
+
+class TestDeriveRepoUrl:
+    """Migrated from tests/test_project_script.py (KIT-0090 F3)."""
+
+    def test_ssh_url(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        _git(repo, "remote", "add", "origin", "git@github.com:owner/repo.git")
+        assert gitio.derive_repo_url(repo) == "github.com/owner/repo"
+
+    def test_https_url(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        _git(repo, "remote", "add", "origin", "https://github.com/owner/repo.git")
+        assert gitio.derive_repo_url(repo) == "github.com/owner/repo"
+
+    def test_https_url_without_dot_git(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        _git(repo, "remote", "add", "origin", "https://github.com/owner/repo")
+        assert gitio.derive_repo_url(repo) == "github.com/owner/repo"
+
+    def test_http_url(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        _git(repo, "remote", "add", "origin", "http://github.com/owner/repo.git")
+        assert gitio.derive_repo_url(repo) == "github.com/owner/repo"
+
+    def test_no_remote(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        assert gitio.derive_repo_url(repo) is None
+
+    def test_no_git_repo(self, tmp_path):
+        assert gitio.derive_repo_url(tmp_path) is None
+
+    def test_unrecognized_url_format_returns_none(self, tmp_path):
+        repo = init_repo(tmp_path / "repo")
+        _git(repo, "remote", "add", "origin", "git://github.com/owner/repo.git")
+        assert gitio.derive_repo_url(repo) is None

--- a/tests/agentive_kit/test_gitio.py
+++ b/tests/agentive_kit/test_gitio.py
@@ -103,12 +103,24 @@ class TestRunGit:
         monkeypatch.setenv("GIT_DIR", str(repo_a / ".git"))
         assert gitio.current_branch(repo_b) == "other"
 
-    def test_clean_git_env_strips_all_git_vars(self, monkeypatch):
+    def test_clean_git_env_strips_location_vars(self, monkeypatch):
         monkeypatch.setenv("GIT_DIR", "/somewhere/.git")
         monkeypatch.setenv("GIT_WORK_TREE", "/somewhere")
         monkeypatch.setenv("GIT_INDEX_FILE", "/somewhere/index")
         env = gitio.clean_git_env()
-        assert not any(k.startswith("GIT_") for k in env)
+        assert "GIT_DIR" not in env
+        assert "GIT_WORK_TREE" not in env
+        assert "GIT_INDEX_FILE" not in env
+
+    def test_clean_git_env_preserves_behavior_vars(self, monkeypatch):
+        # Only location overrides are the KIT-0043 class; a custom
+        # install's SSH/exec-path settings must survive (evaluator
+        # finding, PR 1 trio).
+        monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i /key")
+        monkeypatch.setenv("GIT_EXEC_PATH", "/opt/git/libexec")
+        env = gitio.clean_git_env()
+        assert env["GIT_SSH_COMMAND"] == "ssh -i /key"
+        assert env["GIT_EXEC_PATH"] == "/opt/git/libexec"
 
 
 class TestGitCommonDir:
@@ -166,7 +178,15 @@ class TestDeriveRepoUrl:
     def test_no_git_repo(self, tmp_path):
         assert gitio.derive_repo_url(tmp_path) is None
 
-    def test_unrecognized_url_format_returns_none(self, tmp_path):
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "git://github.com/owner/repo.git",
+            "ssh://git@github.com/owner/repo.git",
+            "/local/path/repo.git",
+        ],
+    )
+    def test_unrecognized_url_format_returns_none(self, tmp_path, url):
         repo = init_repo(tmp_path / "repo")
-        _git(repo, "remote", "add", "origin", "git://github.com/owner/repo.git")
+        _git(repo, "remote", "add", "origin", url)
         assert gitio.derive_repo_url(repo) is None

--- a/tests/agentive_kit/test_lifecycle.py
+++ b/tests/agentive_kit/test_lifecycle.py
@@ -264,6 +264,20 @@ class TestTaskIdBoundaryMatch:
         found = lifecycle.find_task_file("kit-1234", tmp_path)
         assert found is not None
 
+    def test_lowercase_suffix_does_not_match(self, tmp_path):
+        # Matching runs on the uppercased name, so a lowercase run-on
+        # suffix is a boundary violation like any other.
+        make_project(tmp_path)
+        runon = tmp_path / ".kit" / "tasks" / "2-todo" / "KIT-9876foo.md"
+        runon.write_text("**Status**: Todo\n", encoding="utf-8")
+        assert lifecycle.find_task_file("KIT-9876", tmp_path) is None
+
+    def test_underscore_suffix_does_not_match(self, tmp_path):
+        make_project(tmp_path)
+        runon = tmp_path / ".kit" / "tasks" / "2-todo" / "KIT-9876_x.md"
+        runon.write_text("**Status**: Todo\n", encoding="utf-8")
+        assert lifecycle.find_task_file("KIT-9876", tmp_path) is None
+
     def test_bare_id_file_matches(self, tmp_path):
         make_project(tmp_path)
         bare = tmp_path / ".kit" / "tasks" / "2-todo" / "KIT-7777.md"

--- a/tests/agentive_kit/test_lifecycle.py
+++ b/tests/agentive_kit/test_lifecycle.py
@@ -380,6 +380,26 @@ class TestMissingTasksDir:
         assert report.checked == 0
         assert "All 0 tasks" in capsys.readouterr().out
 
+    def test_validate_unreadable_tasks_dir_is_a_finding(self, tmp_path, monkeypatch):
+        # is_dir() succeeding does not guarantee iterdir() can —
+        # CodeRabbit (PR #108 round 3): an unreadable directory is a
+        # finding, not a crash.
+        import pathlib
+
+        make_project(tmp_path)
+        tasks_dir = tmp_path / ".kit" / "tasks"
+        real_iterdir = pathlib.Path.iterdir
+
+        def failing_iterdir(self):
+            if self == tasks_dir:
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_iterdir(self)
+
+        monkeypatch.setattr(pathlib.Path, "iterdir", failing_iterdir)
+        report = lifecycle.validate_all_tasks(tmp_path)
+        assert not report.ok
+        assert "Unreadable tasks directory" in report.issues[0].detail
+
 
 class TestValidateAllTasks:
     def test_all_matching_reports_ok(self, tmp_path, capsys):

--- a/tests/agentive_kit/test_lifecycle.py
+++ b/tests/agentive_kit/test_lifecycle.py
@@ -272,11 +272,17 @@ class TestTaskIdBoundaryMatch:
         runon.write_text("**Status**: Todo\n", encoding="utf-8")
         assert lifecycle.find_task_file("KIT-9876", tmp_path) is None
 
-    def test_underscore_suffix_does_not_match(self, tmp_path):
+    def test_underscore_is_a_separator_not_a_boundary_violation(self, tmp_path):
+        # KIT-1234_sample.md was findable under the legacy substring
+        # matcher; '_' is a separator like '-', and blocking it would
+        # strand existing files on upgrade (evaluator rounds 4/5
+        # disagreed here — round 5's data-compatibility argument wins).
         make_project(tmp_path)
-        runon = tmp_path / ".kit" / "tasks" / "2-todo" / "KIT-9876_x.md"
-        runon.write_text("**Status**: Todo\n", encoding="utf-8")
-        assert lifecycle.find_task_file("KIT-9876", tmp_path) is None
+        sep = tmp_path / ".kit" / "tasks" / "2-todo" / "KIT-9876_sample.md"
+        sep.write_text("**Status**: Todo\n", encoding="utf-8")
+        found = lifecycle.find_task_file("KIT-9876", tmp_path)
+        assert found is not None
+        assert found.name == "KIT-9876_sample.md"
 
     def test_bare_id_file_matches(self, tmp_path):
         make_project(tmp_path)

--- a/tests/agentive_kit/test_lifecycle.py
+++ b/tests/agentive_kit/test_lifecycle.py
@@ -1,0 +1,269 @@
+"""Tests for agentive_kit.lifecycle — task moves, validation, metadata sync.
+
+Migrates TestMoveTaskMetadataSync from tests/test_project_script.py
+(KIT-0090 F3) and extends it for the KIT-0086 single-writer guard,
+which lands INSIDE the extracted module (KIT-0090 F6):
+``agent-handoffs.json`` is written only when the checkout is on main;
+feature-branch moves must produce zero diff in it. The task's own
+``HANDOFF-*.md`` files are rewritten on every branch.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+pytest.importorskip(
+    "agentive_kit", reason="agentive-kit package source present only in the kit repo"
+)
+
+from agentive_kit import lifecycle  # noqa: E402
+
+TASK_FILE = "KIT-1234-sample-task.md"
+
+
+def _git(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def make_project(tmp_path, branch=None):
+    """Build a minimal kit task tree; on a git branch when asked.
+
+    ``branch=None`` leaves the directory a plain (non-git) tree — the
+    fail-safe case for the handoffs guard.
+    """
+    tasks = tmp_path / ".kit" / "tasks"
+    for folder in ("2-todo", "3-in-progress", "5-done"):
+        (tasks / folder).mkdir(parents=True)
+    task = tasks / "2-todo" / TASK_FILE
+    task.write_text("# Task\n\n**Status**: Todo\n", encoding="utf-8")
+
+    context = tmp_path / ".kit" / "context"
+    context.mkdir(parents=True)
+    handoffs = {
+        "planner": {
+            "status": "handoff_ready",
+            "current_task": "KIT-1234",
+            "details_link": f".kit/tasks/2-todo/{TASK_FILE}",
+            "handoff_file": ".kit/context/KIT-1234-HANDOFF-feature-developer.md",
+        },
+        "other-agent": {
+            "status": "idle",
+            "current_task": None,
+            "details_link": ".kit/tasks/2-todo/KIT-0002-unrelated-task.md",
+        },
+    }
+    (context / "agent-handoffs.json").write_text(
+        json.dumps(handoffs, indent=2) + "\n", encoding="utf-8"
+    )
+    (context / "KIT-1234-HANDOFF-feature-developer.md").write_text(
+        f"# Handoff\n\n**Task**: `.kit/tasks/2-todo/{TASK_FILE}`\n",
+        encoding="utf-8",
+    )
+
+    if branch is not None:
+        subprocess.run(
+            ["git", "init", "-q", "-b", branch, str(tmp_path)],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+    return context
+
+
+class TestHandoffsSingleWriterGuard:
+    """KIT-0086 F1, closed by reference here (KIT-0090 F6)."""
+
+    def test_move_on_main_rewrites_handoffs_json(self, tmp_path):
+        context = make_project(tmp_path, branch="main")
+
+        assert lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        assert data["planner"]["details_link"] == (
+            f".kit/tasks/3-in-progress/{TASK_FILE}"
+        )
+
+    def test_move_on_feature_branch_leaves_handoffs_json_untouched(self, tmp_path):
+        context = make_project(tmp_path, branch="feature/KIT-1234-sample")
+        before = (context / "agent-handoffs.json").read_bytes()
+
+        assert lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+
+        # Zero diff — the KIT-0086 acceptance criterion, byte-for-byte.
+        assert (context / "agent-handoffs.json").read_bytes() == before
+        # The task's own handoff file is a same-branch artifact and IS
+        # rewritten.
+        handoff_md = (context / "KIT-1234-HANDOFF-feature-developer.md").read_text(
+            encoding="utf-8"
+        )
+        assert f".kit/tasks/3-in-progress/{TASK_FILE}" in handoff_md
+        assert "2-todo" not in handoff_md
+
+    def test_move_in_non_git_tree_skips_handoffs_json(self, tmp_path):
+        # Branch undeterminable (not a repo) → fail-safe: skip the
+        # write, exactly as on a feature branch.
+        context = make_project(tmp_path, branch=None)
+        before = (context / "agent-handoffs.json").read_bytes()
+
+        assert lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+
+        assert (context / "agent-handoffs.json").read_bytes() == before
+
+    def test_skip_is_reported_in_sync_notes(self, tmp_path):
+        make_project(tmp_path, branch="feature/x")
+        notes = lifecycle.sync_coordination_metadata(
+            "KIT-1234", TASK_FILE, "3-in-progress", tmp_path
+        )
+        skipped = [n for n in notes if n.action == "skipped"]
+        assert len(skipped) == 1
+        assert skipped[0].path.name == "agent-handoffs.json"
+
+
+class TestMoveTaskMetadataSync:
+    """KIT-0040 F2 behavior, preserved through the extraction — all on
+    main, where the JSON write is legitimate."""
+
+    def test_move_rewrites_handoffs_json_and_handoff_file(self, tmp_path):
+        context = make_project(tmp_path, branch="main")
+
+        assert lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        assert data["planner"]["details_link"] == (
+            f".kit/tasks/3-in-progress/{TASK_FILE}"
+        )
+        handoff_md = (context / "KIT-1234-HANDOFF-feature-developer.md").read_text(
+            encoding="utf-8"
+        )
+        assert f".kit/tasks/3-in-progress/{TASK_FILE}" in handoff_md
+        assert "2-todo" not in handoff_md
+
+    def test_move_leaves_other_tasks_untouched(self, tmp_path):
+        context = make_project(tmp_path, branch="main")
+
+        assert lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        # The unrelated task's (stale-looking) path must be preserved.
+        assert data["other-agent"]["details_link"] == (
+            ".kit/tasks/2-todo/KIT-0002-unrelated-task.md"
+        )
+
+    def test_move_without_context_dir_still_succeeds(self, tmp_path):
+        tasks = tmp_path / ".kit" / "tasks"
+        for folder in ("2-todo", "3-in-progress"):
+            (tasks / folder).mkdir(parents=True)
+        (tasks / "2-todo" / TASK_FILE).write_text(
+            "**Status**: Todo\n", encoding="utf-8"
+        )
+
+        assert lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+        assert (tasks / "3-in-progress" / TASK_FILE).exists()
+
+    def test_rerun_in_same_folder_repairs_stale_metadata(self, tmp_path):
+        # Metadata drifted while the task is already in place: re-running
+        # the move acts as a repair and rewrites the stale path.
+        context = make_project(tmp_path, branch="main")
+        task = tmp_path / ".kit" / "tasks" / "2-todo" / TASK_FILE
+        moved = tmp_path / ".kit" / "tasks" / "3-in-progress" / TASK_FILE
+        task.rename(moved)
+
+        result = lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+        assert result
+        assert result.moved is False
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        assert data["planner"]["details_link"] == (
+            f".kit/tasks/3-in-progress/{TASK_FILE}"
+        )
+
+    def test_second_move_rewrites_again(self, tmp_path):
+        context = make_project(tmp_path, branch="main")
+
+        assert lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+        assert lifecycle.move_task("KIT-1234", "done", tmp_path)
+
+        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
+        assert data["planner"]["details_link"] == f".kit/tasks/5-done/{TASK_FILE}"
+
+    def test_non_utf8_metadata_warns_but_move_succeeds(self, tmp_path, capsys):
+        # A corrupted (non-UTF-8) coordination file must warn, never
+        # break the already completed move (UnicodeDecodeError is a
+        # ValueError, not an OSError).
+        context = make_project(tmp_path, branch="main")
+        (context / "agent-handoffs.json").write_bytes(b"\xff\xfe broken")
+
+        assert lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+
+        out = capsys.readouterr().out
+        assert "Could not update agent-handoffs.json" in out
+        # The parseable handoff file was still rewritten.
+        handoff_md = (context / "KIT-1234-HANDOFF-feature-developer.md").read_text(
+            encoding="utf-8"
+        )
+        assert f".kit/tasks/3-in-progress/{TASK_FILE}" in handoff_md
+
+
+class TestMoveTask:
+    def test_unknown_status_returns_none(self, tmp_path, capsys):
+        make_project(tmp_path)
+        assert lifecycle.move_task("KIT-1234", "bogus", tmp_path) is None
+        assert "Unknown status" in capsys.readouterr().out
+
+    def test_task_not_found_returns_none(self, tmp_path, capsys):
+        make_project(tmp_path)
+        assert lifecycle.move_task("KIT-9999", "done", tmp_path) is None
+        assert "Task not found" in capsys.readouterr().out
+
+    def test_move_returns_typed_outcome(self, tmp_path):
+        make_project(tmp_path)
+        result = lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+        assert result.task_id == "KIT-1234"
+        assert result.file_name == TASK_FILE
+        assert result.from_folder == "2-todo"
+        assert result.to_folder == "3-in-progress"
+        assert result.status == "In Progress"
+        assert result.moved is True
+        assert result.status_field_updated is True
+
+    def test_status_field_updated_in_moved_file(self, tmp_path):
+        make_project(tmp_path)
+        lifecycle.move_task("KIT-1234", "done", tmp_path)
+        moved = tmp_path / ".kit" / "tasks" / "5-done" / TASK_FILE
+        assert "**Status**: Done" in moved.read_text(encoding="utf-8")
+
+
+class TestValidateAllTasks:
+    def test_all_matching_reports_ok(self, tmp_path, capsys):
+        make_project(tmp_path)
+        report = lifecycle.validate_all_tasks(tmp_path)
+        assert report.ok
+        assert report.checked == 1
+        assert "matching Status and folder" in capsys.readouterr().out
+
+    def test_mismatch_reported(self, tmp_path, capsys):
+        make_project(tmp_path)
+        wrong = tmp_path / ".kit" / "tasks" / "5-done" / "KIT-0003-wrong.md"
+        wrong.write_text("**Status**: Todo\n", encoding="utf-8")
+        report = lifecycle.validate_all_tasks(tmp_path)
+        assert not report.ok
+        assert len(report.issues) == 1
+        assert report.issues[0].file_name == "KIT-0003-wrong.md"
+        assert "status mismatches" in capsys.readouterr().out
+
+    def test_missing_status_field_reported(self, tmp_path):
+        make_project(tmp_path)
+        bad = tmp_path / ".kit" / "tasks" / "2-todo" / "KIT-0004-nostatus.md"
+        bad.write_text("# No status here\n", encoding="utf-8")
+        report = lifecycle.validate_all_tasks(tmp_path)
+        assert not report.ok
+        assert "No Status field found" in report.issues[0].detail

--- a/tests/agentive_kit/test_lifecycle.py
+++ b/tests/agentive_kit/test_lifecycle.py
@@ -242,6 +242,48 @@ class TestMoveTask:
         assert "**Status**: Done" in moved.read_text(encoding="utf-8")
 
 
+class TestTaskIdBoundaryMatch:
+    """Evaluator finding, PR 1 trio (deliberate fix over the legacy
+    substring test): a short ID must never select a longer ID's file."""
+
+    def test_short_id_does_not_match_longer_id(self, tmp_path, capsys):
+        make_project(tmp_path)  # contains KIT-1234-sample-task.md
+        assert lifecycle.move_task("KIT-1", "done", tmp_path) is None
+        assert "Task not found" in capsys.readouterr().out
+        # KIT-1234's file was not touched.
+        assert (tmp_path / ".kit" / "tasks" / "2-todo" / TASK_FILE).exists()
+
+    def test_full_id_still_matches(self, tmp_path):
+        make_project(tmp_path)
+        found = lifecycle.find_task_file("KIT-1234", tmp_path)
+        assert found is not None
+        assert found.name == TASK_FILE
+
+    def test_match_is_case_insensitive(self, tmp_path):
+        make_project(tmp_path)
+        found = lifecycle.find_task_file("kit-1234", tmp_path)
+        assert found is not None
+
+    def test_bare_id_file_matches(self, tmp_path):
+        make_project(tmp_path)
+        bare = tmp_path / ".kit" / "tasks" / "2-todo" / "KIT-7777.md"
+        bare.write_text("**Status**: Todo\n", encoding="utf-8")
+        found = lifecycle.find_task_file("KIT-7777", tmp_path)
+        assert found is not None
+        assert found.name == "KIT-7777.md"
+
+
+class TestMissingTargetFolder:
+    """Evaluator finding, PR 1 trio: a valid status whose folder is
+    absent (lean layouts skip 6-canceled/7-blocked) is created."""
+
+    def test_move_creates_absent_status_folder(self, tmp_path):
+        make_project(tmp_path)  # creates only 2-todo/3-in-progress/5-done
+        result = lifecycle.move_task("KIT-1234", "blocked", tmp_path)
+        assert result
+        assert (tmp_path / ".kit" / "tasks" / "7-blocked" / TASK_FILE).exists()
+
+
 class TestMissingTasksDir:
     """Evaluator findings, PR 1 trio: a repo without .kit/tasks/ (root
     discovery only guarantees .kit/) reports cleanly instead of

--- a/tests/agentive_kit/test_lifecycle.py
+++ b/tests/agentive_kit/test_lifecycle.py
@@ -253,7 +253,12 @@ class TestMoveTask:
         assert result  # the file did move
         assert result.status_update_failed is True
         assert result.status_field_updated is False
-        assert "Status field not updated" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "Status field not updated" in out
+        # The summary line must not contradict the warning (BugBot,
+        # PR #108 round 2): no ✅ on a partial failure.
+        assert "✅ Task" not in out
+        assert "⚠️  Task KIT-1234 moved to 3-in-progress" in out
 
     def test_unwritable_status_is_partial_failure(self, tmp_path, monkeypatch):
         import pathlib

--- a/tests/agentive_kit/test_lifecycle.py
+++ b/tests/agentive_kit/test_lifecycle.py
@@ -242,6 +242,28 @@ class TestMoveTask:
         assert "**Status**: Done" in moved.read_text(encoding="utf-8")
 
 
+class TestMissingTasksDir:
+    """Evaluator findings, PR 1 trio: a repo without .kit/tasks/ (root
+    discovery only guarantees .kit/) reports cleanly instead of
+    crashing with FileNotFoundError."""
+
+    def test_find_task_file_returns_none(self, tmp_path):
+        (tmp_path / ".kit").mkdir()
+        assert lifecycle.find_task_file("KIT-1234", tmp_path) is None
+
+    def test_move_task_reports_not_found(self, tmp_path, capsys):
+        (tmp_path / ".kit").mkdir()
+        assert lifecycle.move_task("KIT-1234", "done", tmp_path) is None
+        assert "Task not found" in capsys.readouterr().out
+
+    def test_validate_reports_zero_checked(self, tmp_path, capsys):
+        (tmp_path / ".kit").mkdir()
+        report = lifecycle.validate_all_tasks(tmp_path)
+        assert report.ok
+        assert report.checked == 0
+        assert "All 0 tasks" in capsys.readouterr().out
+
+
 class TestValidateAllTasks:
     def test_all_matching_reports_ok(self, tmp_path, capsys):
         make_project(tmp_path)
@@ -259,6 +281,17 @@ class TestValidateAllTasks:
         assert len(report.issues) == 1
         assert report.issues[0].file_name == "KIT-0003-wrong.md"
         assert "status mismatches" in capsys.readouterr().out
+
+    def test_non_utf8_task_file_is_a_finding_not_a_crash(self, tmp_path):
+        # Evaluator finding, PR 1 trio: an unreadable task file must
+        # surface as a validation issue, matching the tolerance the
+        # metadata sync already has for corrupted coordination files.
+        make_project(tmp_path)
+        bad = tmp_path / ".kit" / "tasks" / "2-todo" / "KIT-0005-binary.md"
+        bad.write_bytes(b"\xff\xfe broken")
+        report = lifecycle.validate_all_tasks(tmp_path)
+        assert not report.ok
+        assert any("Unreadable file" in i.detail for i in report.issues)
 
     def test_missing_status_field_reported(self, tmp_path):
         make_project(tmp_path)

--- a/tests/agentive_kit/test_lifecycle.py
+++ b/tests/agentive_kit/test_lifecycle.py
@@ -241,6 +241,56 @@ class TestMoveTask:
         moved = tmp_path / ".kit" / "tasks" / "5-done" / TASK_FILE
         assert "**Status**: Done" in moved.read_text(encoding="utf-8")
 
+    def test_missing_status_field_is_partial_failure(self, tmp_path, capsys):
+        # CodeRabbit (PR #108): a move whose Status field cannot be set
+        # must be visible as a partial failure, not a clean success.
+        make_project(tmp_path)
+        task = tmp_path / ".kit" / "tasks" / "2-todo" / TASK_FILE
+        task.write_text("# Task with no status header\n", encoding="utf-8")
+
+        result = lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+
+        assert result  # the file did move
+        assert result.status_update_failed is True
+        assert result.status_field_updated is False
+        assert "Status field not updated" in capsys.readouterr().out
+
+    def test_unwritable_status_is_partial_failure(self, tmp_path, monkeypatch):
+        import pathlib
+
+        make_project(tmp_path)
+        real_write = pathlib.Path.write_text
+
+        def failing_write(self, *args, **kwargs):
+            if self.name == TASK_FILE:
+                raise OSError(30, "Read-only file system", str(self))
+            return real_write(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "write_text", failing_write)
+        result = lifecycle.move_task("KIT-1234", "in-progress", tmp_path)
+        assert result
+        assert result.status_update_failed is True
+
+
+class TestUpdateStatusTriState:
+    def test_updated_returns_true(self, tmp_path):
+        f = tmp_path / "t.md"
+        f.write_text("**Status**: Todo\n", encoding="utf-8")
+        assert lifecycle.update_status_in_file(f, "Done") is True
+
+    def test_already_correct_returns_false(self, tmp_path):
+        f = tmp_path / "t.md"
+        f.write_text("**Status**: Done\n", encoding="utf-8")
+        assert lifecycle.update_status_in_file(f, "Done") is False
+
+    def test_absent_field_returns_none(self, tmp_path):
+        f = tmp_path / "t.md"
+        f.write_text("# no header\n", encoding="utf-8")
+        assert lifecycle.update_status_in_file(f, "Done") is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert lifecycle.update_status_in_file(tmp_path / "gone.md", "Done") is None
+
 
 class TestTaskIdBoundaryMatch:
     """Evaluator finding, PR 1 trio (deliberate fix over the legacy

--- a/tests/agentive_kit/test_root.py
+++ b/tests/agentive_kit/test_root.py
@@ -76,6 +76,17 @@ class TestDiscovery:
         monkeypatch.chdir(nested)
         assert find_project_root() == root
 
+    def test_symlinked_start_dir(self, tmp_path):
+        # A symlinked working directory walks its LOGICAL parents
+        # (os.path.abspath does not resolve symlinks), so the root is
+        # reported on the symlink side — matching what the user typed.
+        root = make_kit_root(tmp_path / "real")
+        link = tmp_path / "link"
+        link.symlink_to(root, target_is_directory=True)
+        sub = link / "docs"
+        (root / "docs").mkdir()
+        assert find_project_root(sub) == link
+
     def test_relative_start_path(self, tmp_path, monkeypatch):
         root = make_kit_root(tmp_path)
         nested = root / "a"

--- a/tests/agentive_kit/test_root.py
+++ b/tests/agentive_kit/test_root.py
@@ -128,6 +128,26 @@ class TestRefusal:
         with pytest.raises(RootNotFoundError):
             find_project_root(tmp_path)
 
+    def test_permission_error_reads_as_not_a_root(self, tmp_path, monkeypatch):
+        # pathlib propagates PermissionError from is_dir/is_file on
+        # Python < 3.13 — an unstattable ancestor must not turn the
+        # friendly refusal into a traceback, nor stop the walk before
+        # a real root above it.
+        import pathlib
+
+        root = make_kit_root(tmp_path)
+        blocked = root / "locked"
+        blocked.mkdir()
+        real_is_dir = pathlib.Path.is_dir
+
+        def guarded_is_dir(self, **kwargs):
+            if self == blocked / ".kit":
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_is_dir(self, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "is_dir", guarded_is_dir)
+        assert find_project_root(blocked) == root
+
     def test_partial_markers_do_not_stop_the_walk(self, tmp_path):
         # A child with only one marker must not shadow a real root above.
         root = make_kit_root(tmp_path)

--- a/tests/agentive_kit/test_root.py
+++ b/tests/agentive_kit/test_root.py
@@ -1,0 +1,126 @@
+"""Tests for agentive_kit.root — CWD-walk project-root discovery.
+
+KIT-0090 F2 calls this the highest-risk behavioral change of the
+extraction: a globally installed CLI must resolve the project from the
+current directory (never from its own install location) and refuse
+loudly outside a kit repo — never operate on a guessed root.
+
+Discovery rule under test: the nearest ancestor with BOTH a ``.kit/``
+directory and a ``CLAUDE.md`` file. The kit-install marker region is
+deliberately NOT required — the agentive-starter-kit repo itself must
+be discoverable (F5 dogfood) and, being the upstream rather than a
+bootstrapped consumer, carries no marker.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "agentive_kit", reason="agentive-kit package source present only in the kit repo"
+)
+
+from agentive_kit.root import RootNotFoundError, find_project_root  # noqa: E402
+
+
+def make_kit_root(base: Path) -> Path:
+    """Give ``base`` the two markers that make it a kit project root."""
+    (base / ".kit").mkdir(parents=True, exist_ok=True)
+    (base / "CLAUDE.md").write_text("# Project\n", encoding="utf-8")
+    return base
+
+
+class TestDiscovery:
+    def test_finds_root_from_root_itself(self, tmp_path):
+        root = make_kit_root(tmp_path)
+        assert find_project_root(root) == root
+
+    def test_finds_root_from_nested_subdir(self, tmp_path):
+        root = make_kit_root(tmp_path)
+        nested = root / "scripts" / "core" / "doctor.d"
+        nested.mkdir(parents=True)
+        assert find_project_root(nested) == root
+
+    def test_nearest_root_wins(self, tmp_path):
+        outer = make_kit_root(tmp_path)
+        inner = make_kit_root(outer / "vendor" / "other-project")
+        start = inner / "docs"
+        start.mkdir()
+        assert find_project_root(start) == inner
+
+    def test_planning_shape_repo_found(self, tmp_path):
+        # A split-pair planning repo has .kit/ and CLAUDE.md but no
+        # pyproject/tests/venv — discovery must not require any of those.
+        root = make_kit_root(tmp_path)
+        (root / ".kit" / "tasks" / "2-todo").mkdir(parents=True)
+        assert find_project_root(root / ".kit" / "tasks") == root
+
+    def test_worktree_checkout_found(self, tmp_path):
+        # A linked worktree carries the full tree with .git as a FILE —
+        # discovery reads only .kit/ + CLAUDE.md, so the worktree's own
+        # root wins and the primary clone is never consulted.
+        root = make_kit_root(tmp_path / "wt")
+        (root / ".git").write_text(
+            "gitdir: /elsewhere/.git/worktrees/wt\n", encoding="utf-8"
+        )
+        sub = root / "src"
+        sub.mkdir()
+        assert find_project_root(sub) == root
+
+    def test_default_start_is_cwd(self, tmp_path, monkeypatch):
+        root = make_kit_root(tmp_path)
+        nested = root / "a" / "b"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        assert find_project_root() == root
+
+    def test_relative_start_path(self, tmp_path, monkeypatch):
+        root = make_kit_root(tmp_path)
+        nested = root / "a"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+        assert find_project_root(Path(".")) == root
+
+
+class TestRefusal:
+    def test_refuses_outside_kit_repo(self, tmp_path):
+        plain = tmp_path / "not-a-kit-project"
+        plain.mkdir()
+        with pytest.raises(RootNotFoundError) as exc_info:
+            find_project_root(plain)
+        message = str(exc_info.value)
+        assert "Not inside an agentive project" in message
+        assert str(plain) in message
+        assert ".kit/ and CLAUDE.md" in message
+
+    def test_claude_md_alone_not_enough(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("# Docs\n", encoding="utf-8")
+        with pytest.raises(RootNotFoundError):
+            find_project_root(tmp_path)
+
+    def test_kit_dir_alone_not_enough(self, tmp_path):
+        (tmp_path / ".kit").mkdir()
+        with pytest.raises(RootNotFoundError):
+            find_project_root(tmp_path)
+
+    def test_kit_as_file_not_enough(self, tmp_path):
+        (tmp_path / ".kit").write_text("", encoding="utf-8")
+        (tmp_path / "CLAUDE.md").write_text("# P\n", encoding="utf-8")
+        with pytest.raises(RootNotFoundError):
+            find_project_root(tmp_path)
+
+    def test_claude_md_as_dir_not_enough(self, tmp_path):
+        (tmp_path / ".kit").mkdir()
+        (tmp_path / "CLAUDE.md").mkdir()
+        with pytest.raises(RootNotFoundError):
+            find_project_root(tmp_path)
+
+    def test_partial_markers_do_not_stop_the_walk(self, tmp_path):
+        # A child with only one marker must not shadow a real root above.
+        root = make_kit_root(tmp_path)
+        half = root / "docs"
+        half.mkdir()
+        (half / "CLAUDE.md").write_text("# Sub\n", encoding="utf-8")
+        assert find_project_root(half) == root

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Shared pytest fixtures and utilities for the agentive-starter-kit test suite.
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -16,6 +17,19 @@ import pytest
 
 # Project root for locating real files used by test fixtures
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# agentive-kit package source (KIT-0090): put the in-repo package on
+# sys.path so tests/agentive_kit/ runs without an installed agentive-kit
+# — the same dogfood path scripts/core/project uses. Inside the kit repo
+# this insert deliberately wins over any installed copy (kit tests must
+# test the kit's own source). No-op in consumer checkouts (dir absent);
+# the package tests also module-skip there. Lives HERE and not in a
+# tests/agentive_kit/conftest.py: a second file named conftest.py would
+# race this one for sys.modules["conftest"] and break the
+# `from conftest import ...` lines in sibling test modules.
+_PKG_SRC = PROJECT_ROOT / "packages" / "agentive-kit" / "src"
+if _PKG_SRC.is_dir() and str(_PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(_PKG_SRC))
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -1001,6 +1001,21 @@ class TestLifecycleDelegation:
         assert result.returncode == 0, result.stdout + result.stderr
         assert "matching Status and folder" in result.stdout
 
+    def test_surplus_arguments_are_usage_errors(self, kit_tree_with_package):
+        # BugBot (PR #108 round 2): the script shim must reject surplus
+        # args exactly like the package CLI does.
+        tree = kit_tree_with_package
+        for args in (
+            ("start", "KIT-1234", "extra"),
+            ("move", "KIT-1234", "done", "extra"),
+            ("validate", "extra"),
+        ):
+            result = self._run(tree, *args)
+            assert result.returncode == 1, args
+            assert "Usage:" in result.stdout, args
+        # And the task did not move.
+        assert (tree / ".kit" / "tasks" / "2-todo" / "KIT-1234-sample.md").exists()
+
     def test_missing_package_fails_loud_with_install_command(self, tmp_path):
         # A consumer that synced the delegating script before phase 3
         # (no installed CLI, no packages/ tree) must get the exact

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -972,12 +972,13 @@ class TestLifecycleDelegation:
     def kit_tree_with_package(self, tmp_path):
         """A project tree carrying the script AND the package source —
         the dogfood path (_kit_lifecycle's in-repo fallback)."""
+        pkg_src = Path(__file__).parent.parent / "packages" / "agentive-kit" / "src"
+        if not pkg_src.is_dir():
+            # Skip decided BEFORE any tree building (CodeRabbit, PR #108)
+            pytest.skip("agentive-kit package source present only in the kit repo")
         core = tmp_path / "scripts" / "core"
         core.mkdir(parents=True)
         shutil.copy(_script_path, core / "project")
-        pkg_src = Path(__file__).parent.parent / "packages" / "agentive-kit" / "src"
-        if not pkg_src.is_dir():
-            pytest.skip("agentive-kit package source present only in the kit repo")
         shutil.copytree(pkg_src, tmp_path / "packages" / "agentive-kit" / "src")
         tasks = tmp_path / ".kit" / "tasks"
         for folder in ("2-todo", "3-in-progress"):
@@ -1004,6 +1005,19 @@ class TestLifecycleDelegation:
         # A consumer that synced the delegating script before phase 3
         # (no installed CLI, no packages/ tree) must get the exact
         # install instruction, never a traceback.
+        #
+        # Guard (CodeRabbit, PR #108): once agentive-kit is pip-
+        # installed into this interpreter (the PR-4 dogfood switch),
+        # the script's FIRST import branch succeeds and this test's
+        # premise is gone — probe the subprocess view and skip then.
+        probe = subprocess.run(
+            [sys.executable, "-c", "import agentive_kit"],
+            capture_output=True,
+            timeout=60,
+            cwd=tmp_path,
+        )
+        if probe.returncode == 0:
+            pytest.skip("agentive-kit is installed in this interpreter")
         core = tmp_path / "scripts" / "core"
         core.mkdir(parents=True)
         shutil.copy(_script_path, core / "project")
@@ -1013,9 +1027,6 @@ class TestLifecycleDelegation:
             capture_output=True,
             text=True,
             timeout=60,
-            # Hide the real repo's installed/importable copy if any:
-            # an empty PYTHONPATH plus tmp cwd leaves only the script's
-            # own fallback chain.
             cwd=tmp_path,
         )
         assert result.returncode == 1

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -5,7 +5,6 @@ Focus: install-evaluators command with mocked subprocess calls.
 """
 
 import importlib.util
-import json
 import os
 import re
 import shutil
@@ -951,123 +950,9 @@ class TestVerifyIdentityLeaks:
         assert count == 0
 
 
-class TestMoveTaskMetadataSync:
-    """KIT-0040 F2: task moves rewrite the task's path in coordination
-    metadata (agent-handoffs.json + HANDOFF files) instead of stranding
-    stale numbered-folder paths."""
-
-    TASK_FILE = "KIT-1234-sample-task.md"
-
-    def _setup_project(self, tmp_path):
-        tasks = tmp_path / ".kit" / "tasks"
-        for folder in ("2-todo", "3-in-progress", "5-done"):
-            (tasks / folder).mkdir(parents=True)
-        task = tasks / "2-todo" / self.TASK_FILE
-        task.write_text("# Task\n\n**Status**: Todo\n", encoding="utf-8")
-
-        context = tmp_path / ".kit" / "context"
-        context.mkdir(parents=True)
-        handoffs = {
-            "planner": {
-                "status": "handoff_ready",
-                "current_task": "KIT-1234",
-                "details_link": f".kit/tasks/2-todo/{self.TASK_FILE}",
-                "handoff_file": ".kit/context/KIT-1234-HANDOFF-feature-developer.md",
-            },
-            "other-agent": {
-                "status": "idle",
-                "current_task": None,
-                "details_link": ".kit/tasks/2-todo/KIT-0002-unrelated-task.md",
-            },
-        }
-        (context / "agent-handoffs.json").write_text(
-            json.dumps(handoffs, indent=2) + "\n", encoding="utf-8"
-        )
-        (context / "KIT-1234-HANDOFF-feature-developer.md").write_text(
-            f"# Handoff\n\n**Task**: `.kit/tasks/2-todo/{self.TASK_FILE}`\n",
-            encoding="utf-8",
-        )
-        return context
-
-    def test_move_rewrites_handoffs_json_and_handoff_file(self, tmp_path):
-        context = self._setup_project(tmp_path)
-
-        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
-
-        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
-        assert data["planner"]["details_link"] == (
-            f".kit/tasks/3-in-progress/{self.TASK_FILE}"
-        )
-        handoff_md = (context / "KIT-1234-HANDOFF-feature-developer.md").read_text(
-            encoding="utf-8"
-        )
-        assert f".kit/tasks/3-in-progress/{self.TASK_FILE}" in handoff_md
-        assert "2-todo" not in handoff_md
-
-    def test_move_leaves_other_tasks_untouched(self, tmp_path):
-        context = self._setup_project(tmp_path)
-
-        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
-
-        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
-        # The unrelated task's (stale-looking) path must be preserved.
-        assert data["other-agent"]["details_link"] == (
-            ".kit/tasks/2-todo/KIT-0002-unrelated-task.md"
-        )
-
-    def test_move_without_context_dir_still_succeeds(self, tmp_path):
-        tasks = tmp_path / ".kit" / "tasks"
-        for folder in ("2-todo", "3-in-progress"):
-            (tasks / folder).mkdir(parents=True)
-        (tasks / "2-todo" / self.TASK_FILE).write_text(
-            "**Status**: Todo\n", encoding="utf-8"
-        )
-
-        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
-        assert (tasks / "3-in-progress" / self.TASK_FILE).exists()
-
-    def test_rerun_in_same_folder_repairs_stale_metadata(self, tmp_path):
-        # Metadata drifted while the task is already in place: re-running
-        # the move acts as a repair and rewrites the stale path.
-        context = self._setup_project(tmp_path)
-        task = tmp_path / ".kit" / "tasks" / "2-todo" / self.TASK_FILE
-        moved = tmp_path / ".kit" / "tasks" / "3-in-progress" / self.TASK_FILE
-        task.rename(moved)
-
-        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
-
-        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
-        assert data["planner"]["details_link"] == (
-            f".kit/tasks/3-in-progress/{self.TASK_FILE}"
-        )
-
-    def test_second_move_rewrites_again(self, tmp_path):
-        context = self._setup_project(tmp_path)
-
-        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
-        assert _project_module.move_task("KIT-1234", "done", tmp_path)
-
-        data = json.loads((context / "agent-handoffs.json").read_text(encoding="utf-8"))
-        assert data["planner"]["details_link"] == (
-            f".kit/tasks/5-done/{self.TASK_FILE}"
-        )
-
-    def test_non_utf8_metadata_warns_but_move_succeeds(self, tmp_path, capsys):
-        # A corrupted (non-UTF-8) coordination file must warn, never
-        # break the already completed move (UnicodeDecodeError is a
-        # ValueError, not an OSError).
-        context = self._setup_project(tmp_path)
-        (context / "agent-handoffs.json").write_bytes(b"\xff\xfe broken")
-
-        assert _project_module.move_task("KIT-1234", "in-progress", tmp_path)
-
-        out = capsys.readouterr().out
-        assert "Could not update agent-handoffs.json" in out
-        # The parseable handoff file was still rewritten.
-        handoff_md = (context / "KIT-1234-HANDOFF-feature-developer.md").read_text(
-            encoding="utf-8"
-        )
-        assert f".kit/tasks/3-in-progress/{self.TASK_FILE}" in handoff_md
+# TestMoveTaskMetadataSync migrated to tests/agentive_kit/test_lifecycle.py
+# (KIT-0090 F3): move_task and the coordination-metadata sync now live in
+# the agentive-kit package, including the KIT-0086 single-writer guard.
 
 
 class TestFixtureHonesty:

--- a/tests/test_project_script.py
+++ b/tests/test_project_script.py
@@ -955,6 +955,74 @@ class TestVerifyIdentityLeaks:
 # the agentive-kit package, including the KIT-0086 single-writer guard.
 
 
+class TestLifecycleDelegation:
+    """KIT-0090 PR 1: the script's lifecycle commands delegate to the
+    agentive-kit package — the dispatch itself needs subprocess-level
+    coverage (evaluator finding, PR 1 trio)."""
+
+    def _run(self, tree, *args):
+        return subprocess.run(
+            [sys.executable, str(tree / "scripts" / "core" / "project"), *args],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    @pytest.fixture
+    def kit_tree_with_package(self, tmp_path):
+        """A project tree carrying the script AND the package source —
+        the dogfood path (_kit_lifecycle's in-repo fallback)."""
+        core = tmp_path / "scripts" / "core"
+        core.mkdir(parents=True)
+        shutil.copy(_script_path, core / "project")
+        pkg_src = Path(__file__).parent.parent / "packages" / "agentive-kit" / "src"
+        if not pkg_src.is_dir():
+            pytest.skip("agentive-kit package source present only in the kit repo")
+        shutil.copytree(pkg_src, tmp_path / "packages" / "agentive-kit" / "src")
+        tasks = tmp_path / ".kit" / "tasks"
+        for folder in ("2-todo", "3-in-progress"):
+            (tasks / folder).mkdir(parents=True)
+        (tasks / "2-todo" / "KIT-1234-sample.md").write_text(
+            "**Status**: Todo\n", encoding="utf-8"
+        )
+        return tmp_path
+
+    def test_start_delegates_and_moves(self, kit_tree_with_package):
+        tree = kit_tree_with_package
+        result = self._run(tree, "start", "KIT-1234")
+        assert result.returncode == 0, result.stdout + result.stderr
+        moved = tree / ".kit" / "tasks" / "3-in-progress" / "KIT-1234-sample.md"
+        assert moved.exists()
+        assert "In Progress" in result.stdout
+
+    def test_validate_delegates(self, kit_tree_with_package):
+        result = self._run(kit_tree_with_package, "validate")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "matching Status and folder" in result.stdout
+
+    def test_missing_package_fails_loud_with_install_command(self, tmp_path):
+        # A consumer that synced the delegating script before phase 3
+        # (no installed CLI, no packages/ tree) must get the exact
+        # install instruction, never a traceback.
+        core = tmp_path / "scripts" / "core"
+        core.mkdir(parents=True)
+        shutil.copy(_script_path, core / "project")
+        (tmp_path / ".kit" / "tasks" / "2-todo").mkdir(parents=True)
+        result = subprocess.run(
+            [sys.executable, str(core / "project"), "validate"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            # Hide the real repo's installed/importable copy if any:
+            # an empty PYTHONPATH plus tmp cwd leaves only the script's
+            # own fallback chain.
+            cwd=tmp_path,
+        )
+        assert result.returncode == 1
+        assert "uv tool install agentive-kit" in result.stdout
+        assert "Traceback" not in result.stderr
+
+
 class TestFixtureHonesty:
     """The A02 guard (KIT-0068): every path a fixture models must exist
     in the real repo tree. A fixture built on the pre-v0.4.0 layout


### PR DESCRIPTION
## Summary

KIT-ADR-0028 phase 1, PR 1 of the 4-PR plan in [KIT-0090](.kit/tasks/3-in-progress/KIT-0090-extract-scripts-package.md): package skeleton + `gitio` + `lifecycle` + typed models + shim.

- **New `packages/agentive-kit/` dist** (src layout, stdlib-only): `gitio` (all git invocations; KIT-0080 portable patterns with failure-path tests), `lifecycle` (moves/validation/metadata sync), `root` (CWD-walk discovery), `models` (typed boundary dataclasses), `cli` (console entry `agentive`)
- **`scripts/core/project`** delegates lifecycle commands to the package (installed copy → in-repo source → loud `uv tool install` instruction); every other command stays package-free until its extraction PR
- **KIT-0086 F1 lands inside the extracted module** (F6): `agent-handoffs.json` written only on `main`; feature-branch moves produce zero diff (guard verified by mutation). The F2 drift-WARN follows as a doctor check in PR 2, where KIT-0086 closes by reference
- **Tests migrate with the split** (F3 / KIT-0089): `TestMoveTaskMetadataSync` → `tests/agentive_kit/test_lifecycle.py`; new per-module tests (77) for root/gitio/lifecycle/cli

## Recorded design decisions

1. **Dist metadata lives under `packages/agentive-kit/`, not the repo root** — the root `pyproject.toml` is the consumer-project template the door engines copy with only a name rewrite; it cannot carry the dist's name or package list (engines are out of scope this phase).
2. **Root discovery rule (F2)**: nearest ancestor with `.kit/` dir + `CLAUDE.md` file. Marker-only discovery would exclude the kit repo itself (the upstream carries no `kit-install` region) and break F5 dogfooding. Tested: nested dirs, worktrees, planning-shape repos, symlinked cwd, permission-blocked ancestors, non-kit refusal.
3. **Console script `agentive`** — the PyPI `agentive` dist (0.0.144) ships no entry_points.txt; no collision (re-check at PR-4 publish).
4. **The legacy script keeps file-location root resolution** — it is repo-resident by definition; the installed CLI uses CWD-walk. Both paths tested. Full shim conversion is PR 4.
5. **Deliberate temporary duplication**: `_derive_repo_url` stays in the script (reconfigure must work package-free for consumers until phase 3) with `TestDeriveRepoUrl` still covering it; `gitio.derive_repo_url` is the canonical copy going forward.
6. **One deliberate behavior fix beyond extraction**: `find_task_file` now requires an ID boundary (legacy substring let `KIT-1` silently move KIT-1234's file). Publishing makes match semantics stable API — evaluator-convergent across three rounds.

## ⚠️ Sequencing risk (flagging per handoff instruction)

A consumer that runs `project sync` against `main` between this merge and the PR-4 publish receives a script whose **lifecycle commands** (only) fail with the `uv tool install agentive-kit` instruction for a not-yet-published package. Doctor/sync/setup/install-evaluators keep working. Mitigation options if this window matters: consumers sync from release tags, or merge PRs 1–4 close together.

## Evaluator gate (run before PR open, per ordering rule)

Six rounds (fast ×3, deep/o3 ×3, claude-code ×1). All findings dispositioned — 10 taken with tests, 6 refuted with evidence, 6 declined with rationale; deep-evaluator loop stopped when o3 reversed its own round-4 instruction (underscore boundary) in round 5. Full table: `.kit/context/reviews/KIT-0090-pr1-evaluator-review.md`.

## Test plan

- [x] Full suite green in worktree (`987+` passed; fast-hook 960 at last commit)
- [x] Guard tests verified by mutation (KIT-0086 guard, root discovery rule)
- [x] `ci-check.sh` green locally
- [x] Shim smoke-tested: `project validate` via package on bare python3; CLI from a subdirectory
- [ ] CI green on GitHub
- [ ] Bot reviews triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core task lifecycle and coordination metadata writes with a sequencing window where synced consumers may see install instructions before PyPI publish; behavior changes (main-only handoffs JSON, ID matching) affect everyday workflow commands.
> 
> **Overview**
> **KIT-ADR-0028 phase 1 (PR 1/4)** adds a new stdlib-only `packages/agentive-kit/` distribution with `gitio`, `lifecycle`, `root`, typed `models`, and an `agentive` CLI entry point. Task move/validate logic moves out of the monolithic `scripts/core/project` script into `agentive_kit.lifecycle`; the script now lazy-imports via `_kit_lifecycle()` (installed package → in-repo `packages/agentive-kit/src` → loud `uv tool install` error).
> 
> The installed CLI discovers project roots by walking up for **both** `.kit/` and `CLAUDE.md` (not file-location–based like the legacy script). **KIT-0086 F1** lands in `sync_coordination_metadata`: `agent-handoffs.json` updates only on branch `main`; feature or unknown branches skip with zero JSON diff while per-task `HANDOFF-*.md` files still update.
> 
> **Deliberate behavior fixes:** task ID lookup is boundary-anchored so `KIT-1` cannot match `KIT-1234`; partial moves (file moved but Status not updated) exit nonzero; surplus CLI args are rejected. Tests migrate to `tests/agentive_kit/` with shim subprocess coverage in `TestLifecycleDelegation`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5966ddbc184bcbcc3ea398fff2100f26ef179f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->