### PR TITLE
feat(KIT-0090): migrate doctor into agentive-kit — PR 2 of 4 (stacked on #108)

### DIFF
--- a/.kit/context/reviews/KIT-0090-pr2-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0090-pr2-evaluator-review.md
@@ -1,0 +1,28 @@
+# KIT-0090 PR 2 — Evaluator Review Record
+
+**PR**: #109 (stacked on #108) — doctor migration
+**Date**: 2026-08-06
+**Ordering**: trio run BEFORE PR open
+
+## Rounds
+
+- **code-reviewer-fast**: CONCERNS — .env quote-handling robustness
+  (pre-existing check behavior, extraction-neutral: declined),
+  `_check_declared` regex strictness (legacy-identical, pinned by
+  tests: declined), `_kit_doctor`-absent path untested (superseded by
+  the inline-fallback design below).
+- **code-reviewer (o3)**: FAIL — packaged checks may ship without
+  exec bits in pip/sdist installs and the driver FAILed them.
+  **Taken** (adf5b96): suffix-interpreter fallback for the packaged
+  checks dir only; repo-local `doctor.d`/`--dir=` keep the strict
+  pinned contract. Secondary items were repeats from PR 1 dispositions.
+
+## Post-open CI finding (the real catch of this PR)
+
+The dispatched CI run on adf5b96 FAILED: door E2E tests bootstrap
+fresh consumer targets whose copied script delegated `doctor` to a
+package they don't carry. Fix: the script keeps its inline driver as a
+FALLBACK when no package is importable (package canonical; recorded
+duplication, dies with the script in phase 4). Lesson recorded for the
+retro: the pre-commit fast hook deselects the door E2E tests — run the
+FULL suite after any script-delegation change.

--- a/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md
+++ b/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md
@@ -88,7 +88,10 @@ What should the next agent do with this?
 3. **Review git status**: Ensure all changes committed
 4. **Create handoff document** in `.kit/context/`
 5. **Update `.kit/context/agent-handoffs.json`** with task completion
-6. **Stage and commit** handoff + agent-handoffs.json update
+   — **on `main` only**: the planner is the file's single writer
+   (KIT-0086); branch sessions never edit it, and `project move`
+   skips it automatically off-main since KIT-0090 PR 1
+6. **Stage and commit** the handoff (+ the JSON update when on main)
 7. **Push to remote repository**
 8. **Notify the user** (or the planner) with the PR link and status
 
@@ -101,7 +104,7 @@ What should the next agent do with this?
 - Include test metrics in handoff (before/after pass rates)
 - Document any known issues or limitations honestly
 - Provide clear next steps for the user or reviewing agent
-- Update agent-handoffs.json status to "task_complete"
+- Update agent-handoffs.json status to "task_complete" (planner, on main — KIT-0086)
 
 ### ❌ DON'T:
 - Don't mark task complete if tests are failing

--- a/.kit/context/workflows/WORKTREE-WORKFLOW.md
+++ b/.kit/context/workflows/WORKTREE-WORKFLOW.md
@@ -33,9 +33,9 @@ branches from fresh `origin/main`, so this ordering means it carries
 the `3-in-progress` task file from birth — created the other way round,
 it carries a stale `2-todo` file and fails its own
 validate-task-status hook. The same ordering keeps
-`agent-handoffs.json` churn off feature branches, which the KIT-0086
-interim discipline independently requires: one ordering satisfies both
-rules.
+`agent-handoffs.json` churn off feature branches — and since
+KIT-0090 PR 1 the KIT-0086 single-writer guard enforces it in code:
+`project move` skips the JSON on any branch other than main.
 
 > **KIT-0080 note**: `new-worktree.sh` hard-fails on stock macOS git
 > (2.30.1) until KIT-0080 lands. The portable equivalent is plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extraction PRs. Per-module tests replace the migrated monolith
   sections (KIT-0089 F3 direction).
 
+- **Doctor migrated into `agentive-kit`** (KIT-0090 PR 2): the driver,
+  kit-install record reader, config-home resolution and preset
+  comparison now live in `agentive_kit.doctor`; `./scripts/core/project
+  doctor` delegates (same fallback chain as the lifecycle commands).
+  Per-check decision recorded: all checks remain executable files run
+  by the driver — the executable contract is the tested public seam —
+  and the check set also ships as package data for post-phase-2
+  installs (repo-local `doctor.d` wins whenever present). New check
+  `35-handoffs-paths.py` (KIT-0086 F2): WARNs on stale task paths in
+  `agent-handoffs.json` without reintroducing a second writer.
+  Workflow docs updated to the single-writer rule (KIT-0086 F3).
+
 ### Changed
 
 - **`agent-handoffs.json` becomes single-writer** (KIT-0086 F1, landed

--- a/packages/agentive-kit/pyproject.toml
+++ b/packages/agentive-kit/pyproject.toml
@@ -37,5 +37,12 @@ agentive = "agentive_kit.cli:main"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+# The doctor check set ships as executable data files run by the
+# driver (per-check decision recorded in agentive_kit/doctor/
+# __init__.py) — the repo-local scripts/core/doctor.d wins when
+# present.
+agentive_kit = ["doctor/checks/*"]
+
 [tool.setuptools.dynamic]
 version = { attr = "agentive_kit.__version__" }

--- a/packages/agentive-kit/src/agentive_kit/doctor/__init__.py
+++ b/packages/agentive-kit/src/agentive_kit/doctor/__init__.py
@@ -43,7 +43,18 @@ def default_checks_dir(project_dir: Path) -> Path:
     local = project_dir / "scripts" / "core" / "doctor.d"
     if local.is_dir():
         return local
-    return Path(__file__).resolve().parent / "checks"
+    return PACKAGED_CHECKS_DIR
+
+
+# Single definition so the driver can recognize the packaged set.
+PACKAGED_CHECKS_DIR = Path(__file__).resolve().parent / "checks"
+
+# Interpreter fallback for packaged checks only: pip/sdist installs may
+# drop the execute bit (deep evaluator, PR 2 — a wheel usually keeps
+# it, an sdist build usually does not), and packaged checks must not
+# FAIL for a packaging artifact. Repo-local doctor.d and --dir= keep
+# the strict executability contract the tests pin.
+_CHECK_INTERPRETERS = {".py": [sys.executable], ".sh": ["bash"]}
 
 
 def _normalize_bots(raw):
@@ -575,13 +586,21 @@ def cmd_doctor(args, project_dir):
             )
             verdicts.append("SKIP")
             continue
+        argv = [str(check)]
         if not os.access(check, os.X_OK):
-            print(f"DOCTOR:{name}:FAIL:check file is not executable")
-            verdicts.append("FAIL")
-            continue
+            interp = (
+                _CHECK_INTERPRETERS.get(check.suffix)
+                if doctor_dir == PACKAGED_CHECKS_DIR
+                else None
+            )
+            if interp is None:
+                print(f"DOCTOR:{name}:FAIL:check file is not executable")
+                verdicts.append("FAIL")
+                continue
+            argv = [*interp, str(check)]
         try:
             result = subprocess.run(
-                [str(check)],
+                argv,
                 cwd=project_dir,
                 env=env,
                 capture_output=True,

--- a/packages/agentive-kit/src/agentive_kit/doctor/__init__.py
+++ b/packages/agentive-kit/src/agentive_kit/doctor/__init__.py
@@ -1,0 +1,649 @@
+"""Environment doctor: driver, install-record reader, preset comparison.
+
+Extracted verbatim-in-behavior from ``scripts/core/project`` (KIT-0090
+PR 2); the existing test suite (tests/test_doctor.py drives the real
+driver through the ``--dir=`` seam) is the spec.
+
+Per-check migration decision (KIT-0090 F1, recorded): ALL 12 checks —
+shell and Python alike — REMAIN executable files run by this driver.
+The executable-file contract (emit ``DOCTOR:<name>:<verdict>:<detail>``
+lines, receive ``DOCTOR_ROOT``) is a public seam: the whole doctor
+test suite, consumer repos' synced check sets, and the ``--dir=``
+override all depend on it, and rewriting checks as Python modules
+would buy no behavior for that churn. A copy of the check set ships as
+package data (``agentive_kit/doctor/checks/``) so a globally installed
+CLI can doctor a repo whose synced copies are gone after phase 2; the
+repo-local ``scripts/core/doctor.d`` wins whenever present, so today's
+behavior is byte-identical.
+
+The kit-install record reader lives here too (shape/profile/bots —
+KIT-0048/0050/0056); the legacy script deliberately KEEPS its own copy
+for ``cmd_sync`` (sync must work package-free for consumers until
+phase 3 — recorded duplication, dies with the script in phase 4).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from agentive_kit import gitio
+
+
+def default_checks_dir(project_dir: Path) -> Path:
+    """Resolve the check set: repo-local doctor.d, else packaged copy.
+
+    The repo-local set wins whenever present (phase-1 repos all carry
+    it, so behavior is unchanged); the packaged copy exists for
+    post-phase-2 installs. ``--dir=`` overrides both.
+    """
+    local = project_dir / "scripts" / "core" / "doctor.d"
+    if local.is_dir():
+        return local
+    return Path(__file__).resolve().parent / "checks"
+
+
+def _normalize_bots(raw):
+    """Canonical form of a bots declaration, or None when invalid.
+
+    Valid: ``none`` alone, or a non-empty subset of
+    {coderabbit, bugbot} (any order/duplication/case, comma- or
+    space-separated; normalized to canonical lowercase order — the
+    same tolerance as the door's normalize_bots and the preflight
+    reader, so one declaration can never be valid to one reader and
+    invalid to another). Shared by the record reader and the
+    ``--against-preset`` comparison so the two can never disagree on
+    what a declaration means (KIT-0056).
+    """
+    tokens = raw.replace(",", " ").lower().split()
+    if not tokens:
+        return None
+    for token in tokens:
+        # membership: vocabulary check, not identifier equality
+        if token not in ("coderabbit", "bugbot", "none"):
+            return None
+    if "none" in tokens:
+        return "none" if len(tokens) == 1 else None
+    return " ".join(t for t in ("coderabbit", "bugbot") if t in tokens)
+
+
+def _doctor_install(project_dir):
+    """Read the installation's shape+profile+bots record (KIT-0048
+    F2/F3, extended by KIT-0050 F4 and KIT-0056 F1 — one reader,
+    never two).
+
+    The record lives in CLAUDE.md's ``kit-install`` KIT-LOCAL region and
+    kit_markers.py is its only reader (N4: one extract, runtime-read, no
+    cache). Returns ``(shape, profile, bots, errors)`` where ``errors``
+    is a list of ``(record, detail)`` pairs, ``record`` in
+    {"shape-record", "profile-record", "bots-record"}:
+
+    - anything absent (kit_markers, CLAUDE.md, region) ->
+      ("single", "python", None, []) — back-compat: absent means
+      today's single shape with the Python toolchain, never an error;
+    - a readable record: shape in {single, planning}; a missing
+      profile: line defaults by shape (single -> python,
+      planning -> none — the KIT-0050 back-compat rule); a missing
+      bots: line is None — "both bots expected", the pre-KIT-0056
+      default, never an error;
+    - malformed/unknown value or unreadable record -> the affected
+      value(s) are None and ``errors`` carries the detail — the caller
+      runs the FULL check set AND emits a DOCTOR:<record>:FAIL line —
+      fail loud while staying maximally diagnostic, never silently
+      fall back.
+    """
+    kit_markers = project_dir / "scripts" / "local" / "kit_markers.py"
+    claude_md = project_dir / "CLAUDE.md"
+    if not kit_markers.exists() or not claude_md.exists():
+        return "single", "python", None, []
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(kit_markers),
+                "extract",
+                str(claude_md),
+                "kit-install",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        detail = f"shape record unreadable ({exc.__class__.__name__})"
+        return None, None, None, [("shape-record", detail)]
+    if result.returncode != 0:
+        # kit_markers exits 1 with this exact stderr for a missing region
+        # (absent = single, back-compat). ANY other failure — crash, bad
+        # interpreter, argv error — is an unreadable record and must fail
+        # loud, not silently fall back (o3 review).
+        if "region not found" in result.stderr:
+            return "single", "python", None, []
+        detail = result.stderr.strip().splitlines()
+        return (
+            None,
+            None,
+            None,
+            [
+                (
+                    "shape-record",
+                    "kit_markers extract failed "
+                    f"(exit {result.returncode}: "
+                    f"{detail[0] if detail else 'no stderr'})",
+                )
+            ],
+        )
+    raw_shape = None
+    raw_profile = None
+    raw_bots = None
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("shape:") and raw_shape is None:
+            raw_shape = stripped.partition(":")[2].strip()
+        elif stripped.startswith("profile:") and raw_profile is None:
+            raw_profile = stripped.partition(":")[2].strip()
+        elif stripped.startswith("bots:") and raw_bots is None:
+            raw_bots = stripped.partition(":")[2].strip()
+
+    errors = []
+    shape = None
+    if raw_shape is None:
+        errors.append(
+            (
+                "shape-record",
+                "kit-install region present but has no shape: line — "
+                "running the full check set",
+            )
+        )
+    elif raw_shape == "single" or raw_shape == "planning":
+        shape = raw_shape
+    else:
+        errors.append(
+            (
+                "shape-record",
+                f"unknown shape '{raw_shape}' in kit-install region — "
+                "expected single|planning; running the full check set",
+            )
+        )
+
+    profile = None
+    if raw_profile is None:
+        # Absent profile defaults by shape; with the shape itself
+        # unreadable there is no default to derive — profile stays None
+        # (run everything) without a second error line for one cause.
+        if shape == "single":
+            profile = "python"
+        elif shape == "planning":
+            profile = "none"
+    elif raw_profile == "python" or raw_profile == "none":
+        if shape is None:
+            # An unreadable shape poisons the profile too: a profile's
+            # legality is shape-dependent (planning forces none), so
+            # honoring one from a record whose shape cannot be trusted
+            # could SKIP checks the shape-record FAIL just promised to
+            # run. profile stays None — run everything (BugBot, PR #80).
+            pass
+        elif raw_profile == "python" and shape == "planning":
+            # The P3 matrix pairing, hard-coded as in KIT-0048: planning
+            # forces none. Honoring the illegal combination would run
+            # toolchain checks a planning repo cannot satisfy; silently
+            # coercing would drop what the record says — fail loud.
+            errors.append(
+                (
+                    "profile-record",
+                    "profile 'python' is not legal for shape 'planning' "
+                    "(planning forces none) — running the full check set",
+                )
+            )
+        else:
+            profile = raw_profile
+    else:
+        errors.append(
+            (
+                "profile-record",
+                f"unknown profile '{raw_profile}' in kit-install region — "
+                "expected python|none; running the full check set",
+            )
+        )
+
+    # bots declaration (KIT-0056): independent of shape/profile — it
+    # scopes no doctor checks, only the preflight gates and the
+    # --against-preset comparison. Absent = None = both bots expected.
+    # An invalid value fails loud (F4): a typo'd declaration silently
+    # read as "declared absent" could SKIP gates it should not.
+    bots = None
+    if raw_bots is not None:
+        bots = _normalize_bots(raw_bots)
+        if bots is None:
+            errors.append(
+                (
+                    "bots-record",
+                    f"invalid bots declaration '{raw_bots}' in kit-install "
+                    "region — expected 'none' or a subset of: "
+                    "coderabbit bugbot",
+                )
+            )
+    return shape, profile, bots, errors
+
+
+def _check_declared(check_path, keyword):
+    """Tokens a doctor.d check declares via its `# <keyword>:` header
+    line — keyword is "shapes" (KIT-0048) or "profiles" (KIT-0050 F5);
+    the two declarations share one mechanism by design.
+
+    Returns a set of tokens, or None when the check declares nothing —
+    an undeclared OR empty declaration runs everywhere (never silently
+    skipped; o3 review: an empty set would skip the check in every
+    shape forever). Case-insensitive; scanned over the first 30 lines,
+    which covers long banners without picking up documentation strings
+    deep in a check body (convention: the header sits right under the
+    shebang).
+    """
+    try:
+        text = check_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    head = "\n".join(text.splitlines()[:30])
+    # [^\S\n] = horizontal whitespace only — \s would slurp the newline
+    # of an empty declaration and capture the NEXT line as tokens
+    match = re.search(
+        r"^#[^\S\n]*" + keyword + r":[^\S\n]*(.*)$",
+        head,
+        re.MULTILINE | re.IGNORECASE,
+    )
+    if match:
+        # lowercase the tokens too — IGNORECASE only covers the keyword,
+        # and '# Shapes: Single' must match shape 'single' (CodeRabbit)
+        declared = {token.lower() for token in match.group(1).split()}
+        return declared or None
+    return None
+
+
+def _config_home(project_dir):
+    """Locate the operator config home (KIT-0058, ADR-0027 P7
+    amendment): the visible sibling
+    ``<primary-clone-parent>/agentive-config`` of this checkout,
+    resolved worktree-safely via ``--git-common-dir``.
+    ``AGENTIVE_KIT_CONFIG_DIR`` is the ONLY override — an override,
+    never a search chain. Mirrors the door's ``config_home()``; the
+    equivalence test in tests/test_setup_door.py pins the two so the
+    door and doctor can never disagree on the path. Returns None when
+    the checkout is not a git repository (no sibling to name).
+
+    Anchoring note (BugBot, PR #91): each resolver anchors to ITS OWN
+    checkout — the door to the kit clone, doctor to the project it
+    diagnoses. The two name the same folder exactly when kit and
+    project share a parent (the documented sibling layout); a consumer
+    checkout has no pointer to the kit clone's local path, so the
+    kit's parent is not computable from here. When the layouts
+    diverge, the override pins the real location, and every output
+    line below names the resolved path so the anchor is visible.
+    """
+    override = os.environ.get("AGENTIVE_KIT_CONFIG_DIR")
+    if override:
+        # leading-~ expansion mirrors the bash resolvers (env files can
+        # carry a literal tilde the shell never expanded)
+        return Path(override).expanduser()
+    # Delegated to gitio.git_common_dir — the KIT-0080 portable
+    # resolution (plain --git-common-dir, GIT_* location-var scrub,
+    # anchored on project_dir) lives in ONE place since PR 1.
+    common_dir = gitio.git_common_dir(project_dir)
+    if common_dir is None:
+        return None
+    # KIT-0080: plain --git-common-dir, absolutized here. The
+    # --path-format=absolute form needs git >= 2.31; Apple's system git
+    # (2.30.1) echoes the flag back as an output line and exits 0, so
+    # `common` became "--path-format=absolute\n<path>" and the home
+    # resolved to garbage. Plain output is RELATIVE to the -C directory
+    # (both gits return a bare ".git" from a primary clone), so anchor
+    # it on project_dir — never on the process cwd. `/` already discards
+    # the left operand when `common` is absolute.
+    #
+    # No .resolve(): that would follow symlinked ancestors and report a
+    # PHYSICAL path, diverging from the bash resolvers this function is
+    # pinned equivalent to (tests/test_setup_door.py). os.path.normpath
+    # collapses the "<root>/.git" join without touching symlinks.
+    # Two levels: `joined` is <primary-clone>/.git, so .parent is the
+    # clone root and .parent.parent its PARENT, where the visible
+    # agentive-config sibling lives.
+    return common_dir.parent.parent / "agentive-config"
+
+
+def _print_preset_comparison(shape, profile, bots, record_errors, project_dir):
+    """`doctor --against-preset` (KIT-0056 F8, ADR-0027 P7): compare
+    the project's kit-install record against the operator preset at
+    ``<kit-parent>/agentive-config/preset`` (KIT-0058;
+    ``AGENTIVE_KIT_CONFIG_DIR`` overrides the location).
+
+    INFO-only by design: divergence is reported as
+    ``PRESET:<field>:INFO:<detail>`` lines and NEVER as WARN/FAIL, and
+    the doctor exit code is never affected — a deliberately-lean
+    project is not wrong. Doctor validates the RECORD (the DOCTOR:
+    lines above); the preset is only a comparison baseline. The
+    PRESET: prefix keeps these lines out of DOCTOR: parsers entirely.
+
+    Keys other than shape/profile/bots are ignored here by design:
+    the door owns the preset-key vocabulary (unknown keys WARN there);
+    duplicating its key list in this comparator would be a second
+    source of truth that drifts. Structural faults shared with the
+    door's parser (malformed lines, duplicate keys) do get reported —
+    as INFO, with the comparison skipped whole.
+    """
+    home = _config_home(project_dir)
+    print()
+    if home is None:
+        print(
+            f"PRESET:comparison:INFO:cannot locate the config home "
+            f"({project_dir} is not a git clone) — nothing to compare"
+        )
+        return
+    preset_path = home / "preset"
+    if not preset_path.is_file():
+        print(
+            f"PRESET:comparison:INFO:no preset found at {preset_path} — "
+            "nothing to compare (the path anchors to this project's "
+            "primary-clone parent; set AGENTIVE_KIT_CONFIG_DIR if your "
+            "config home lives beside the kit clone elsewhere)"
+        )
+        return
+    try:
+        preset_lines = preset_path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        print(
+            f"PRESET:comparison:INFO:preset unreadable "
+            f"({exc.__class__.__name__}) — comparison skipped"
+        )
+        return
+    preset_values = {}
+    for lineno, line in enumerate(preset_lines, 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            # loud, names the line, and skips the WHOLE comparison — a
+            # partial read could report agreement on fields it never
+            # parsed (the masking class, record-reader face)
+            print(
+                f"PRESET:comparison:INFO:preset malformed at line {lineno} "
+                f"('{stripped}') — fix {preset_path}; comparison skipped"
+            )
+            return
+        key, _, value = stripped.partition(":")
+        key = key.strip()
+        if key in preset_values:
+            # same duplicate rule as the door's load_preset — silently
+            # letting the last value win could compare against a value
+            # the door would refuse to load
+            print(
+                f"PRESET:comparison:INFO:duplicate preset key '{key}' at "
+                f"line {lineno} — fix {preset_path}; comparison skipped"
+            )
+            return
+        preset_values[key] = value.strip()
+
+    if shape is None or profile is None:
+        print(
+            "PRESET:comparison:INFO:kit-install record unreadable "
+            "(see the DOCTOR record FAIL lines) — comparison skipped"
+        )
+        return
+
+    bots_errored = any(record == "bots-record" for record, _ in record_errors)
+    record_values = {
+        "shape": shape,
+        "profile": profile,
+        # absent bots line = both expected (the pre-KIT-0056 default)
+        "bots": bots if bots is not None else "coderabbit bugbot",
+    }
+    defaulted = {"bots": bots is None}
+    # Vocabulary checks mirror the door's validate_values: a preset
+    # value the door would refuse to install must read as malformed
+    # preset data here, never as legitimate divergence (CodeRabbit).
+    valid_vocab = {
+        "shape": ("single", "planning"),
+        "profile": ("python", "none"),
+    }
+    if (
+        preset_values.get("shape") == "planning"
+        and preset_values.get("profile") == "python"
+    ):
+        print(
+            "PRESET:comparison:INFO:preset declares an illegal pair "
+            "(planning forces profile none) — fix the preset; "
+            "shape/profile comparison skipped"
+        )
+        preset_values.pop("shape", None)
+        preset_values.pop("profile", None)
+    compared = 0
+    divergences = 0
+    for key in ("shape", "profile", "bots"):
+        preset_val = preset_values.get(key, "")
+        if not preset_val:
+            continue
+        # membership: dict-key + vocabulary checks, not identifier
+        # equality (the same construct the legacy script used)
+        if key in valid_vocab and preset_val not in valid_vocab[key]:  # noqa: DK003
+            print(
+                f"PRESET:{key}:INFO:preset {key} value invalid "
+                f"('{preset_val}') — {key} comparison skipped"
+            )
+            continue
+        if key == "bots":
+            if bots_errored:
+                print(
+                    "PRESET:bots:INFO:recorded bots declaration is invalid "
+                    "(see DOCTOR:bots-record above) — bots comparison skipped"
+                )
+                continue
+            normalized = _normalize_bots(preset_val)
+            if normalized is None:
+                print(
+                    f"PRESET:bots:INFO:preset bots value invalid "
+                    f"('{preset_val}') — bots comparison skipped"
+                )
+                continue
+            preset_val = normalized
+        compared += 1
+        if preset_val != record_values[key]:
+            suffix = (
+                " (defaulted — no line in the record)" if defaulted.get(key) else ""
+            )
+            print(
+                f"PRESET:{key}:INFO:record has '{record_values[key]}'{suffix}, "
+                f"preset says '{preset_val}' — informational only, a "
+                "deliberately-lean project is not wrong"
+            )
+            divergences += 1
+    if compared == 0:
+        print(
+            "PRESET:comparison:INFO:preset answers none of the comparable "
+            "fields (shape/profile/bots) — nothing to compare"
+        )
+    elif divergences == 0:
+        print(
+            f"PRESET:comparison:INFO:record matches the preset on all "
+            f"{compared} compared field(s)"
+        )
+
+
+def cmd_doctor(args, project_dir):
+    """`project doctor`: run all doctor.d environment checks (ADR-0027 P4).
+
+    Composable driver: every executable in scripts/core/doctor.d/ runs;
+    a failing check never short-circuits its siblings (the fail-fast-
+    masking lesson from the sync workflow). Checks emit
+    ``DOCTOR:<name>:<verdict>:<detail>`` lines — <name> and <verdict>
+    are colon-free tokens, <detail> is everything after the third colon
+    (parsers split on the first three colons only, exactly like the
+    preflight GATE: format). Verdicts: PASS, WARN, FAIL, SKIP.
+
+    Exit-code contract (F3 — driver errors never overload 0/1):
+      0  every check PASS or SKIP
+      1  at least one FAIL
+      2  warnings only (no FAIL)
+      3  driver/usage error (unknown flag, doctor.d missing or empty)
+
+    Read-only (N3): the driver and every check diagnose the environment;
+    they never mutate config, env, or the working tree.
+    """
+    doctor_dir = default_checks_dir(project_dir)
+    against_preset = False
+    for arg in args:
+        # An empty value would resolve Path("") to the cwd and silently
+        # diagnose the wrong tree — usage error instead (BugBot round 6).
+        if arg == "--against-preset":
+            # KIT-0056 F8: compare the record against the operator
+            # preset, INFO-only (see _print_preset_comparison).
+            against_preset = True
+        elif arg.startswith("--dir="):
+            # test/advanced seam: run a different check set (resolve now —
+            # checks run with a different cwd, so relative would break)
+            value = arg.partition("=")[2]
+            if not value:
+                print("❌ --dir= requires a path")
+                return 3
+            doctor_dir = Path(value).resolve()
+        elif arg.startswith("--root="):
+            # diagnose another checkout (e.g. the primary clone from a
+            # worktree); checks receive it as DOCTOR_ROOT
+            value = arg.partition("=")[2]
+            if not value:
+                print("❌ --root= requires a path")
+                return 3
+            project_dir = Path(value).resolve()
+            if not project_dir.is_dir():
+                print(f"❌ --root is not a directory: {project_dir}")
+                return 3
+        else:
+            print(f"Unknown option: {arg}")
+            print(
+                "Usage: ./scripts/core/project doctor "
+                "[--dir=<checks-dir>] [--root=<checkout>] [--against-preset]"
+            )
+            return 3
+
+    if not doctor_dir.is_dir():
+        print(f"❌ doctor checks directory not found: {doctor_dir}")
+        return 3
+    # dotfiles (.DS_Store & friends) are never checks — everything else
+    # in doctor.d/ is held to the check contract
+    checks = sorted(
+        p for p in doctor_dir.iterdir() if p.is_file() and not p.name.startswith(".")
+    )
+    if not checks:
+        print(f"❌ no checks found in {doctor_dir}")
+        return 3
+
+    # Per-shape inclusion (KIT-0048, fills the P2 seam) and per-profile
+    # inclusion (KIT-0050 F5): checks declare their shapes/profiles in
+    # `# shapes:` / `# profiles:` headers; the driver reads the install
+    # record once and stays otherwise declaration-driven. A malformed
+    # record runs everything AND fails loud via the record lines below.
+    shape, profile, bots, record_errors = _doctor_install(project_dir)
+
+    # Scrub ambient GIT_* so a leaked GIT_DIR (the KIT-0043 incident
+    # class — e.g. doctor invoked from a pre-commit hook in a worktree)
+    # cannot redirect git-facing checks at the wrong repository.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["DOCTOR_ROOT"] = str(project_dir)
+    verdicts = []
+    for record, detail in record_errors:
+        print(f"DOCTOR:{record}:FAIL:{detail}")
+        verdicts.append("FAIL")
+    for check in checks:
+        name = check.name
+        declared = _check_declared(check, "shapes")
+        if shape is not None and declared is not None and shape not in declared:
+            print(
+                f"DOCTOR:{name}:SKIP:not applicable to shape '{shape}' "
+                f"(check declares: {' '.join(sorted(declared))})"
+            )
+            verdicts.append("SKIP")
+            continue
+        declared_profiles = _check_declared(check, "profiles")
+        if (
+            profile is not None
+            and declared_profiles is not None
+            and profile not in declared_profiles
+        ):
+            print(
+                f"DOCTOR:{name}:SKIP:not applicable to profile '{profile}' "
+                f"(check declares: {' '.join(sorted(declared_profiles))})"
+            )
+            verdicts.append("SKIP")
+            continue
+        if not os.access(check, os.X_OK):
+            print(f"DOCTOR:{name}:FAIL:check file is not executable")
+            verdicts.append("FAIL")
+            continue
+        try:
+            result = subprocess.run(
+                [str(check)],
+                cwd=project_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"DOCTOR:{name}:FAIL:check timed out after 30s")
+            verdicts.append("FAIL")
+            continue
+        except OSError as exc:
+            print(f"DOCTOR:{name}:FAIL:check failed to run ({exc.__class__.__name__})")
+            verdicts.append("FAIL")
+            continue
+
+        emitted = False
+        for line in result.stdout.splitlines():
+            if not line.startswith("DOCTOR:"):
+                continue
+            parts = line.split(":", 3)
+            # F1 field contract: exactly DOCTOR:<name>:<verdict>:<detail>
+            # with non-empty name and detail — an incomplete record must
+            # not be able to count as a pass (CodeRabbit round 2)
+            malformed = len(parts) < 4 or not parts[1] or not parts[3].strip()
+            verdict = parts[2] if len(parts) >= 3 else ""
+            # membership: verdict vocabulary check, not identifier equality
+            if malformed or verdict not in ("PASS", "WARN", "FAIL", "SKIP"):
+                # malformed line: surface it, count it as a failure
+                print(line)
+                verdicts.append("FAIL")
+                emitted = True
+                continue
+            print(line)
+            verdicts.append(verdict)
+            emitted = True
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+        if not emitted:
+            print(
+                f"DOCTOR:{name}:FAIL:check produced no DOCTOR line "
+                f"(exit {result.returncode})"
+            )
+            verdicts.append("FAIL")
+        elif result.returncode != 0:
+            # a check that emitted lines but then crashed may have lost
+            # its remaining concerns — surface the crash, don't let an
+            # early PASS line mask it (fast-v2 review finding)
+            print(
+                f"DOCTOR:{name}:FAIL:check exited {result.returncode} "
+                "after emitting output — remaining concerns may be lost"
+            )
+            verdicts.append("FAIL")
+
+    fails = verdicts.count("FAIL")
+    warns = verdicts.count("WARN")
+    passes = verdicts.count("PASS")
+    skips = verdicts.count("SKIP")
+    print(f"\nDoctor: {passes} pass, {warns} warn, {fails} fail, {skips} skip")
+    if against_preset:
+        _print_preset_comparison(shape, profile, bots, record_errors, project_dir)
+    if fails:
+        return 1
+    if warns:
+        return 2
+    return 0

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/10-gh-auth.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/10-gh-auth.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: gh installed AND authenticated.
+#
+# Incident (KIT-ADR-0027 Context): verify-setup.sh marked `gh` as
+# "optional" while the entire bot/CI loop (pr checks, review threads,
+# preflight gates) runs through it — backbone-first inverts that.
+#
+# Contract: emits DOCTOR:<name>:<verdict>:<detail> lines; read-only;
+# resolves nothing from cwd (gh state is global). May hit the network
+# (gh auth status) — one of the two checks allowed to (N2).
+
+set -u
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "DOCTOR:gh-auth:FAIL:gh CLI not installed — the bot/CI loop cannot run (install: https://cli.github.com)"
+    exit 0
+fi
+
+if gh auth status >/dev/null 2>&1; then
+    echo "DOCTOR:gh-auth:PASS:gh installed and authenticated"
+else
+    echo "DOCTOR:gh-auth:FAIL:gh installed but not authenticated — run: gh auth login"
+fi

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/15-git-version.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/15-git-version.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: git meets the kit's supported version floor (KIT-0080 F4).
+#
+# Incident (KIT-0080): the kit's path resolvers used
+# `git rev-parse --path-format=absolute`, a flag added in git 2.31
+# (March 2021). Stock macOS ships Apple Git 2.30.1 — one minor version
+# below — which does NOT consume the flag: it echoes it back as the
+# first output line and still exits 0. Failures ranged from silent (the
+# setup door resolved an operator path to relative garbage, so a
+# correctly-authored preset was ignored on every run and planning repos
+# came out misprovisioned) to hard (new-worktree.sh died, making the
+# kit's DEFAULT session topology unusable). CI could not catch any of
+# it: Ubuntu runners ship modern git, so the whole class was green in
+# CI and broken on stock Macs.
+#
+# KIT-0080 made every resolver portable, which is why the floor below is
+# 2.30 and not 2.31 — this check documents the floor the scripts
+# actually hold to, and turns the next such incident loud instead of
+# silent. Raise FLOOR_* here (and the README Requirements row, which
+# must agree) if the kit ever adopts a newer git feature.
+#
+# Verdicts:
+#   PASS  git present and at/above the floor
+#   WARN  git present but below the floor (named, with the remedy)
+#   WARN  git present but the version string is unparseable
+#   FAIL  git not installed at all
+#
+# Read-only, no network. Portable by construction: `git --version` plus
+# bash string ops — no Homebrew-only tools (README portability rule; the
+# `timeout` lesson), and deliberately no sort -V, whose BSD/GNU
+# availability differs across the platforms the kit supports.
+
+set -u
+
+FLOOR_MAJOR=2
+FLOOR_MINOR=30
+FLOOR="$FLOOR_MAJOR.$FLOOR_MINOR"
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "DOCTOR:git-version:FAIL:git not installed — the kit's task, worktree and CI flows all run through it (install: https://git-scm.com/downloads)"
+    exit 0
+fi
+
+RAW="$(git --version 2>/dev/null)" || RAW=""
+
+# `git version 2.30.1 (Apple Git-130)` -> `2.30.1 (Apple Git-130)` -> `2.30.1`
+VERSION="${RAW#git version }"
+VERSION="${VERSION%% *}"
+
+# Split on dots without a subshell or external tool. A non-numeric or
+# absent field must not be silently treated as 0 — that would let an
+# unparseable string masquerade as an ancient (or modern) git, so bail
+# to WARN instead and name what we saw.
+MAJOR="${VERSION%%.*}"
+# A version with no dot at all ("git version 2") leaves REST identical
+# to VERSION, which would silently reuse the major as the minor and read
+# "2" as 2.2. Require the dot explicitly.
+if [ "$VERSION" = "${VERSION#*.}" ]; then
+    MINOR=""
+else
+    REST="${VERSION#*.}"
+    MINOR="${REST%%.*}"
+fi
+
+case "$MAJOR" in
+    '' | *[!0-9]*) MAJOR="" ;;
+esac
+case "$MINOR" in
+    '' | *[!0-9]*) MINOR="" ;;
+esac
+
+if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || [ "$VERSION" = "$RAW" ]; then
+    echo "DOCTOR:git-version:WARN:cannot parse the git version from '$RAW' — the kit needs git >= $FLOOR; verify manually with: git --version"
+    exit 0
+fi
+
+if [ "$MAJOR" -gt "$FLOOR_MAJOR" ] \
+    || { [ "$MAJOR" -eq "$FLOOR_MAJOR" ] && [ "$MINOR" -ge "$FLOOR_MINOR" ]; }; then
+    echo "DOCTOR:git-version:PASS:git $VERSION meets the supported floor (>= $FLOOR)"
+    exit 0
+fi
+
+# Below the floor. `xcode-select --install` is the intuitive first thing
+# to try and does NOT help — Apple's Command Line Tools ship 2.30.x by
+# design (a constrained system binary, not a stale download), so the
+# remedy names the two things that do work.
+echo "DOCTOR:git-version:WARN:git $VERSION is below the supported floor ($FLOOR) — path resolution and worktree flows may misbehave; upgrade with 'brew install git' then 'hash -r' (note: xcode-select --install does NOT help — Apple's CLT ship 2.30.x by design)"
+exit 0

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/20-env-keys.py
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/20-env-keys.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# shapes: single planning
+"""doctor check: .env exists; required keys present AND uncommented.
+
+Incident (KIT-0032): the evaluator trio ran 2-of-3 because
+ANTHROPIC_API_KEY sat commented out in .env — nothing surfaced it
+until a mid-review "missing key" failure.
+
+Not-checkable note (per the incident-closure lifecycle rule; not
+worktree-specific despite riding KIT-0071's doctor work): a VALID key
+is not necessarily a USABLE key. KIT-0069's claude-code evaluator
+failed at runtime with a valid ANTHROPIC_API_KEY because the account's
+credit balance was zero — and balance has no cheap API, so this check
+stops at presence by design. The symptom to recognize: valid key,
+evaluator writes no log file → check the Anthropic console credit
+balance (same shape as the CodeRabbit quota note in
+80-bot-presence.sh).
+
+Never prints key values — presence and comment-state only (read-only,
+N3). Root comes from DOCTOR_ROOT (set by the driver; tests point it at
+tmp fixtures), falling back to the repo root relative to this file.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# FAIL-level: the trio cannot run at all without it.
+REQUIRED_KEYS = ["ANTHROPIC_API_KEY"]
+# WARN-level: o3 / Gemini evaluators silently drop out without these.
+RECOMMENDED_KEYS = ["OPENAI_API_KEY", "GEMINI_API_KEY"]
+# WARN-level (KIT-0084): TASK_PREFIX left unset or at the old template
+# placeholder is silently-wrong project identity — the door writes it
+# empty on planning-shape --new precisely so this check surfaces it.
+PREFIX_PLACEHOLDER = "TASK"
+
+
+def _effective_value(raw):
+    """Normalize an assignment's right-hand side: a QUOTED value keeps
+    everything inside the quotes (a '#' inside quotes is data — the
+    old split-then-unquote order corrupted such values, fast-v2
+    evaluator KIT-0084); an unquoted trailing `# comment` is not a
+    value, and quoted-empty ("" / '') is empty — KEY="" or
+    KEY= # placeholder must not PASS an unusable env.
+    """
+    value = raw.strip()
+    if value and value[0] in "\"'":
+        closing = value.find(value[0], 1)
+        if closing != -1:
+            return value[1:closing].strip()
+    return value.split("#", 1)[0].strip()
+
+
+def key_state(lines, key):
+    """Return 'present', 'commented', or 'missing' for key. Values unread.
+
+    Scans the WHOLE file: an uncommented assignment anywhere wins over a
+    commented one (the copy-template-then-append layout keeps the
+    commented template line — o3 review caught the first-match-wins
+    false FAIL). Accepts an optional `export ` prefix. Strict `KEY=value`
+    format otherwise — spaces around `=` are deliberately not recognized
+    (standard .env parsers do not accept them either).
+    """
+    state = "missing"
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("export "):
+            stripped = stripped[len("export ") :].lstrip()
+        if stripped.startswith(f"{key}="):
+            _, _, value = stripped.partition("=")
+            if _effective_value(value):
+                return "present"
+            state = "commented"
+            continue
+        if stripped.startswith("#") and stripped.lstrip("# ").startswith(f"{key}="):
+            state = "commented"
+    return state
+
+
+def key_value(lines, key):
+    """Effective value of key for identity checks: the LAST uncommented
+    assignment wins, matching dotenv semantics (CodeRabbit, KIT-0084 —
+    key_state's first-non-empty scan serves key PRESENCE, where the
+    copy-template-then-append layout matters; a VALUE check must report
+    what a parser would actually load). Comments and quotes stripped,
+    `export ` accepted. Returns None when no uncommented assignment
+    exists at all. Only ever called for non-secret identity keys —
+    key_state stays the reader for key material.
+    """
+    for line in reversed(lines):
+        stripped = line.strip()
+        if stripped.startswith("export "):
+            stripped = stripped[len("export ") :].lstrip()
+        if stripped.startswith(f"{key}="):
+            _, _, value = stripped.partition("=")
+            return _effective_value(value)
+    return None
+
+
+def main():
+    root = Path(os.environ.get("DOCTOR_ROOT") or Path(__file__).resolve().parents[3])
+    env_file = root / ".env"
+
+    if not env_file.exists():
+        print(
+            "DOCTOR:env-keys:FAIL:.env not found — copy .env.template and fill in keys"
+        )
+        return 0
+
+    try:
+        lines = env_file.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"DOCTOR:env-keys:FAIL:.env unreadable ({exc.__class__.__name__})")
+        return 0
+
+    problems = []
+    for key in REQUIRED_KEYS:
+        state = key_state(lines, key)
+        if state == "commented":
+            problems.append(f"{key} commented out or empty")
+        elif state == "missing":
+            problems.append(f"{key} missing")
+    if problems:
+        print(f"DOCTOR:env-keys:FAIL:{'; '.join(problems)} in .env")
+        return 0
+
+    warn_parts = []
+    warnings = []
+    for key in RECOMMENDED_KEYS:
+        if key_state(lines, key) != "present":
+            warnings.append(key)
+    if warnings:
+        warn_parts.append(
+            "evaluator keys not set: "
+            + ", ".join(warnings)
+            + " — those evaluators will drop out of the trio"
+        )
+    prefix = key_value(lines, "TASK_PREFIX")
+    if prefix is None or prefix == "" or prefix == PREFIX_PLACEHOLDER:
+        warn_parts.append(
+            "TASK_PREFIX not set (empty, missing, or the 'TASK' placeholder)"
+            " — set your project's task prefix in .env (decided at intake"
+            " Step 4a / project onboarding)"
+        )
+    if warn_parts:
+        print("DOCTOR:env-keys:WARN:" + "; ".join(warn_parts))
+        return 0
+
+    print(
+        "DOCTOR:env-keys:PASS:required and evaluator keys present and "
+        "uncommented (presence only — credit balance is not checkable: "
+        "a valid key whose evaluator writes no log usually means zero "
+        "balance, KIT-0069)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/30-evaluators.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/30-evaluators.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: evaluator library installed (.adversarial/evaluators/ non-empty).
+#
+# Incident (KIT-0043 worktree pilot): a fresh worktree had no
+# .adversarial/evaluators/, so the `adversarial` CLI listed no evaluator
+# commands and failed with a confusing "invalid choice" error mid-review.
+#
+# Read-only. Root from DOCTOR_ROOT (driver-set; tests use tmp fixtures),
+# else derived from this file's location.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+if [ ! -d "$ROOT/.adversarial" ]; then
+    echo "DOCTOR:evaluators:SKIP:adversarial workflow not initialized (.adversarial/ absent)"
+    exit 0
+fi
+
+EVAL_DIR="$ROOT/.adversarial/evaluators"
+if [ ! -d "$EVAL_DIR" ] || [ -z "$(ls -A "$EVAL_DIR" 2>/dev/null)" ]; then
+    echo "DOCTOR:evaluators:FAIL:.adversarial/evaluators/ missing or empty — run: ./scripts/core/project install-evaluators"
+    exit 0
+fi
+
+COUNT=$(ls -A "$EVAL_DIR" | wc -l | tr -d ' ')
+echo "DOCTOR:evaluators:PASS:evaluator library installed ($COUNT entries)"

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/31-evaluator-cli.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/31-evaluator-cli.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: the `adversarial` CLI binary is on PATH and runnable.
+#
+# Incident (KIT-0083, issue #103): a fresh consumer project shipped
+# .adversarial/config.yml AND the evaluator library, so 30-evaluators.sh
+# reported PASS — but nothing had ever installed the CLI itself. The
+# failure surfaced at the planner's Phase 3 evaluation GATE as
+# `adversarial: command not found`, long after the project looked fully
+# provisioned. This check exists so the library's PASS can never mask a
+# missing binary again.
+#
+# Deliberately separate from 30-evaluators.sh: that one answers "is the
+# evaluator library installed" (a tree fact), this one answers "can we
+# actually run an evaluation" (a PATH fact). One verdict cannot carry
+# both. (KIT-0055 will add a third question — *which* binary is it,
+# editable vs tool install — which is meaningless before this one.)
+#
+# Read-only. Root from DOCTOR_ROOT (driver-set; tests use tmp fixtures),
+# else derived from this file's location.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+if [ ! -d "$ROOT/.adversarial" ]; then
+    echo "DOCTOR:evaluator-cli:SKIP:adversarial workflow not initialized (.adversarial/ absent)"
+    exit 0
+fi
+
+FIX="run: ./scripts/core/project install-evaluators (or: uv tool install adversarial-workflow)"
+PATH_HINT="if you just installed it, uv puts binaries in ~/.local/bin — add it to PATH"
+
+if ! command -v adversarial >/dev/null 2>&1; then
+    echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI not on PATH — $FIX; $PATH_HINT"
+    exit 0
+fi
+
+# Probe the EXIT CODE, never the output: `adversarial --version` prints
+# "Unknown fields in evaluator.yml" warnings to stderr on a healthy
+# install (verified 2026-08-05), so an output-parsing check would report
+# a false FAIL.
+#
+# Bounded so a corrupt install that blocks on stdin/network cannot hang
+# the whole doctor run (o3 review). Deliberately NOT GNU `timeout`:
+# it is a homebrew add-on on macOS (absent from a stock system), so
+# depending on it would work on a brew-equipped machine and hang on a
+# plain one — the same "passes locally, proves nothing" trap that let
+# issue #103 ship. </dev/null closes the stdin path; the
+# background-and-poll below bounds everything else.
+#
+# `sleep` is resolved to an ABSOLUTE path (same idea as BASH in
+# tests/test_doctor.py): doctor checks must survive a restricted PATH,
+# and a bare `sleep` there fails, spins the loop instantly and reports a
+# false FAIL on a perfectly healthy CLI — caught by
+# test_stub_binary_on_path_passes. If no sleep exists at all, skip the
+# bound rather than invent one: an unbounded probe is still better than
+# a wrong verdict.
+SLEEP_BIN=""
+for candidate in /bin/sleep /usr/bin/sleep; do
+    if [ -x "$candidate" ]; then
+        SLEEP_BIN="$candidate"
+        break
+    fi
+done
+
+# MUST match CLI_PROBE_TIMEOUT in scripts/core/project: the installer and
+# this check probe the same binary for the same purpose, and a CLI that
+# answers in between the two bounds would be "working" to one surface and
+# FAIL to the other — the two-surfaces-disagree state this check exists
+# to close (CodeRabbit round 1).
+PROBE_TIMEOUT=20
+
+REINSTALL="reinstall: uv tool install --force adversarial-workflow"
+
+adversarial --version >/dev/null 2>&1 </dev/null &
+probe_pid=$!
+
+if [ -n "$SLEEP_BIN" ]; then
+    probe_waited=0
+    while kill -0 "$probe_pid" 2>/dev/null && [ "$probe_waited" -lt "$PROBE_TIMEOUT" ]; do
+        "$SLEEP_BIN" 1
+        probe_waited=$((probe_waited + 1))
+    done
+    if kill -0 "$probe_pid" 2>/dev/null; then
+        kill "$probe_pid" 2>/dev/null
+        wait "$probe_pid" 2>/dev/null
+        echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' did not finish within ${PROBE_TIMEOUT}s — likely a corrupt install; $REINSTALL"
+        exit 0
+    fi
+fi
+# Reaped either way: the polling loop above exits only once the probe is
+# done. With NO sleep binary this `wait` blocks unbounded — a deliberate
+# tradeoff, not an oversight (CodeRabbit round 1 proposed a `read -t`
+# timer instead). Rejected because every bash-builtin timer needs a
+# non-EOF descriptor, which needs a long-lived helper process holding a
+# pipe open — reintroducing the very external-binary dependency this
+# branch exists to survive, in exchange for a rarer, harder-to-audit
+# construct. The branch requires neither /bin/sleep nor /usr/bin/sleep
+# to exist, i.e. effectively no POSIX system; there, answering slowly
+# beats answering wrongly.
+if ! wait "$probe_pid"; then
+    echo "DOCTOR:evaluator-cli:FAIL:adversarial CLI found but '--version' failed — $REINSTALL"
+    exit 0
+fi
+
+echo "DOCTOR:evaluator-cli:PASS:adversarial CLI available ($(command -v adversarial))"

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/35-handoffs-paths.py
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/35-handoffs-paths.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# shapes: single planning
+"""doctor check: agent-handoffs.json task paths point at real files.
+
+KIT-0086 F2: feature-branch lifecycle moves no longer rewrite the
+shared coordination JSON (single-writer guard — the planner owns it on
+main), so its ``.kit/tasks/<folder>/<file>`` path strings can go stale
+between a branch-side move and the planner's next edit. Drift must be
+LOUD without reintroducing a second writer: this check WARNs when a
+recorded path does not exist while the same file name exists in a
+different status folder (a stale pointer), and stays quiet on paths
+that are simply gone (archived/deleted tasks are the planner's
+bookkeeping, not drift).
+
+Read-only (N3). Root comes from DOCTOR_ROOT (set by the driver).
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+NAME = "35-handoffs-paths.py"
+
+root = Path(os.environ.get("DOCTOR_ROOT") or Path(__file__).resolve().parents[3])
+handoffs = root / ".kit" / "context" / "agent-handoffs.json"
+tasks_dir = root / ".kit" / "tasks"
+
+if not handoffs.is_file() or not tasks_dir.is_dir():
+    print(f"DOCTOR:{NAME}:SKIP:no agent-handoffs.json or .kit/tasks in this repo")
+    sys.exit(0)
+
+try:
+    text = handoffs.read_text(encoding="utf-8")
+    json.loads(text)  # structural sanity only; paths are scanned as strings
+except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    print(
+        f"DOCTOR:{NAME}:WARN:agent-handoffs.json unreadable or not JSON "
+        f"({exc.__class__.__name__}) — fix it on main (planner owns this file)"
+    )
+    sys.exit(0)
+
+# Scan raw path strings — the same shape lifecycle rewrites; scanning
+# text (not the JSON tree) also catches paths in nested/unknown keys.
+recorded = set(re.findall(r"\.kit/tasks/[0-9]+-[a-z-]+/[A-Za-z0-9._-]+\.md", text))
+
+stale = []
+for rel in sorted(recorded):
+    if (root / rel).is_file():
+        continue
+    file_name = rel.rsplit("/", 1)[1]
+    actual = [
+        f".kit/tasks/{p.parent.name}/{p.name}"
+        for p in tasks_dir.glob(f"*/{file_name}")
+        if p.is_file()
+    ]
+    if actual:
+        stale.append(f"{rel} -> {actual[0]}")
+
+if stale:
+    detail = "; ".join(stale)
+    print(
+        f"DOCTOR:{NAME}:WARN:stale task path(s) in agent-handoffs.json "
+        f"({detail}) — planner repairs on main; branch sessions must not "
+        "edit this file (KIT-0086)"
+    )
+else:
+    print(
+        f"DOCTOR:{NAME}:PASS:all {len(recorded)} recorded task path(s) "
+        "resolve to their folders"
+    )

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/40-version-skew.py
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/40-version-skew.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# profiles: python
+"""doctor check: venv-vs-system version skew for packages that bit us.
+
+Profile-scoped, not shape-scoped (KIT-0050 F5): these are Python
+toolchain checks, so they run wherever the effective profile is python
+and SKIP by declaration everywhere else (planning repos force profile
+none; a docs-only single repo can opt out with --profile none).
+
+Incidents:
+- adversarial-workflow (KIT-0044): the venv carried the 0.9.7 build,
+  which MUTATED the working tree during reviews, while the system had
+  moved on — the skew went undetected until a review run applied its
+  own edit.
+- black vs the pyproject.toml pin (KIT-0032): a stale venv Black
+  produced a phantom CI formatting failure. Generalizes the KIT-0035 F1
+  ci-check warning into a standing check.
+
+isort is deliberately NOT checked: its pin is a floor (>=), not exact,
+so "active vs pinned" comparison is meaningless (REVIEW-INSIGHTS,
+KIT-0035).
+
+Read-only. Root from DOCTOR_ROOT (driver-set; tests point it at tmp
+fixtures with stub executables), else derived from this file's
+location. The system-side pip probe uses `pip3` from PATH so tests can
+stub it (stub-gh harness pattern).
+
+Emits two lines: venv-skew-adversarial and black-pin.
+"""
+
+import os
+import re
+import shutil
+import subprocess  # nosec - fixed argv, no shell
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:  # Python 3.10
+    try:
+        import tomli as tomllib
+    except ImportError:
+        tomllib = None  # black_pin falls back to a regex scan
+
+SKEW_PACKAGE = "adversarial-workflow"
+
+
+def venv_bin(root):
+    """The project venv's bin dir — .venv/ preferred, venv/ accepted
+    (both layouts are supported by ci-check.sh and the project CLI)."""
+    for name in (".venv", "venv"):
+        candidate = root / name / "bin"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def system_pip(root):
+    """First pip3 on PATH that is NOT inside the project venv.
+
+    With an activated venv, a bare `shutil.which("pip3")` resolves to
+    the venv itself and both probe sides compare equal — masking the
+    exact skew this check exists for (BugBot round 4).
+    """
+    venv_bins = {str((root / name / "bin").resolve()) for name in (".venv", "venv")}
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        if str(Path(entry).resolve()) in venv_bins:
+            continue
+        candidate = Path(entry) / "pip3"
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def pip_version(pip_cmd, package):
+    """Return the version `pip show` reports, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            [pip_cmd, "show", package],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        if line.startswith("Version:"):
+            return line.partition(":")[2].strip()
+    return None
+
+
+def black_pin(root):
+    """Return the exact black pin from pyproject.toml, or None."""
+    pyproject = root / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    if tomllib is None:
+        # No TOML parser on this interpreter (bare 3.10): regex scan so
+        # drift detection still works instead of silently SKIPping
+        # (o3 review finding). Comment lines are skipped and both TOML
+        # quote styles accepted (CodeRabbit round 2).
+        try:
+            text = pyproject.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+        for line in text.splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            match = re.search(r"['\"]black\s*==\s*([0-9][0-9a-zA-Z.]*)['\"]", line)
+            if match:
+                return match.group(1)
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return None
+    project = data.get("project", {})
+    dep_lists = [project.get("dependencies", [])]
+    dep_lists.extend(project.get("optional-dependencies", {}).values())
+    for deps in dep_lists:
+        for dep in deps:
+            match = re.match(r"black\s*==\s*([0-9][0-9a-zA-Z.]*)$", dep.strip())
+            if match:
+                return match.group(1)
+    return None
+
+
+def active_black_version(root):
+    """Version of the black the project actually runs (venv first)."""
+    candidates = []
+    bin_dir = venv_bin(root)
+    if bin_dir:
+        candidates.append(str(bin_dir / "black"))
+    path_black = shutil.which("black")
+    if path_black:
+        candidates.append(path_black)
+    for black_cmd in candidates:
+        if not Path(black_cmd).exists():
+            continue
+        try:
+            result = subprocess.run(
+                [black_cmd, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        # anchor to the tool name so a version-like string earlier in the
+        # output (e.g. inside a path) cannot be captured (claude-code
+        # review finding)
+        match = re.search(r"black[,\s]+(\d+\.\d+(?:\.\d+)?[a-z0-9]*)", result.stdout)
+        if match:
+            return match.group(1)
+    return None
+
+
+def main():
+    root = Path(os.environ.get("DOCTOR_ROOT") or Path(__file__).resolve().parents[3])
+
+    # --- adversarial-workflow: venv vs system ---
+    bin_dir = venv_bin(root)
+    venv_pip = bin_dir / "pip" if bin_dir else None
+    venv_ver = (
+        pip_version(str(venv_pip), SKEW_PACKAGE)
+        if venv_pip and venv_pip.exists()
+        else None
+    )
+    sys_pip = system_pip(root)
+    system_ver = pip_version(sys_pip, SKEW_PACKAGE) if sys_pip else None
+
+    if venv_ver is None and system_ver is None:
+        print(
+            f"DOCTOR:venv-skew-adversarial:SKIP:{SKEW_PACKAGE} not installed "
+            "in venv or system"
+        )
+    elif venv_ver is None or system_ver is None:
+        where = "venv" if venv_ver is None else "system"
+        print(
+            f"DOCTOR:venv-skew-adversarial:SKIP:{SKEW_PACKAGE} only installed "
+            f"on one side ({where} has none) — no comparison possible"
+        )
+    elif venv_ver == system_ver:
+        print(
+            f"DOCTOR:venv-skew-adversarial:PASS:{SKEW_PACKAGE} {venv_ver} "
+            "matches in venv and system"
+        )
+    else:
+        print(
+            f"DOCTOR:venv-skew-adversarial:FAIL:{SKEW_PACKAGE} skew — venv "
+            f"{venv_ver} vs system {system_ver} (the KIT-0044 mutation class)"
+        )
+
+    # --- black vs pyproject pin ---
+    pin = black_pin(root)
+    if pin is None:
+        print("DOCTOR:black-pin:SKIP:no exact black pin found in pyproject.toml")
+        return 0
+    active = active_black_version(root)
+    if active is None:
+        print(f"DOCTOR:black-pin:FAIL:black not runnable but pyproject pins {pin}")
+    elif active == pin:
+        print(f"DOCTOR:black-pin:PASS:active black {active} matches pyproject pin")
+    else:
+        print(
+            f"DOCTOR:black-pin:FAIL:active black {active} != pyproject pin {pin} "
+            "(phantom-CI-failure class, KIT-0032)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/50-plugin-source.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/50-plugin-source.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: plugin marketplace source is GitHub, not a directory.
+#
+# Incident (KIT-0030 gotcha): a `Directory (...)` marketplace source
+# serves whatever is on disk and silently defeats version pins — the
+# plugin "upgrade" path then does nothing.
+#
+# Grep is the hardened pattern from docs/PLUGIN-UPGRADE-GUIDE.md
+# (anchored to the Source field so "Directory (/Users/alice/github/
+# movito/agentive-skills)" cannot slip past; end-anchored so
+# movito/agentive-skills-beta cannot either). Do not re-derive it.
+#
+# Read-only; no network (reads the local plugin registry).
+
+set -u
+
+if ! command -v claude >/dev/null 2>&1; then
+    echo "DOCTOR:plugin-source:SKIP:claude CLI not on PATH — cannot inspect marketplace"
+    exit 0
+fi
+
+OUT="$(claude plugin marketplace list 2>/dev/null)" || {
+    echo "DOCTOR:plugin-source:SKIP:claude plugin marketplace list failed — cannot inspect"
+    exit 0
+}
+
+if printf '%s\n' "$OUT" | grep -qiE '^[[:space:]]*source: *(github \(|https://github\.com/)movito/agentive-skills([[:space:]]*\)|$)'; then
+    echo "DOCTOR:plugin-source:PASS:agentive-skills marketplace is GitHub-sourced"
+elif printf '%s\n' "$OUT" | grep -qi 'agentive-skills'; then
+    echo "DOCTOR:plugin-source:FAIL:agentive-skills marketplace is not GitHub-sourced (directory source defeats version pins) — re-point: claude plugin marketplace remove agentive-skills && claude plugin marketplace add movito/agentive-skills"
+else
+    echo "DOCTOR:plugin-source:SKIP:agentive-skills marketplace not installed"
+fi

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/55-worktree-provisioning.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/55-worktree-provisioning.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: worktree provisioning correctness (KIT-0071).
+#
+# Incidents:
+#   - KIT-0065: worktrees were provisioned with .venv SYMLINKED to the
+#     primary clone; an in-worktree `python3 -m venv --clear` followed
+#     the link and EMPTIED THE PRIMARY'S VENV (repaired in-session).
+#     The same link is the KIT-0044 stale-venv split-brain in
+#     permanent form.
+#   - KIT-0069: Serena resolves a project NAME to its REGISTERED path —
+#     activate_project("<primary-name>") inside a worktree targets the
+#     primary clone, so bulk edits would hit main's checkout (caught
+#     pre-use). Worktree sessions activate by ABSOLUTE PATH.
+#
+# Verdicts (one line per concern; the driver aggregates):
+#   worktree-venv    WARN  .venv is a symlink (the destruction vector);
+#                          also fires for the alternate venv/ layout
+#                    PASS  real venv, or no venv yet
+#   worktree-audit   SKIP  outside a linked worktree — the remaining
+#                          concerns only exist inside one
+#   worktree-serena  WARN  no worktree-local .serena/project.yml, an
+#                          unnamed one, or a name colliding with the
+#                          primary's
+#                    SKIP  the project does not use Serena
+#                    PASS  worktree-local config with its own name
+#   worktree-shared  PASS  enumerates what a worktree SHARES by design
+#
+# Read-only (N3), no network. Scratch-dir hygiene (mktemp -d + sweep
+# lists) is settled policy recorded in WORKTREE-WORKFLOW.md — this
+# check deliberately audits provisioning only and never asks for
+# permission-list changes.
+
+set -u
+
+# Leaked GIT_* env would redirect every git call below at the wrong
+# repository (the KIT-0043 leak class) — scrub all of it; the driver
+# also scrubs, but this check must survive standalone runs.
+for _git_var in $(compgen -A variable | grep '^GIT_' || true); do
+    unset "$_git_var"
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+# Worktree-ness first: the venv remedy differs inside one — hooks are
+# SHARED with the primary, so an in-worktree setup must say --no-hooks
+# or the reinstall re-points them at a venv that dies with the
+# worktree (BugBot, this PR).
+# KIT-0080: --path-format=absolute needs git >= 2.31; Apple's system git
+# (2.30.1) echoes the flag back as an output line and exits 0, so both
+# vars became two-line garbage — they compared unequal, the check claimed
+# "in a worktree", and PRIMARY_ROOT resolved through a dirname that
+# errored to stderr. Every Serena verdict below was then computed against
+# a nonexistent primary (it reported SKIP "project does not use Serena").
+# Plain flags are portable; output is relative to the -C directory, so
+# absolutize there.
+#
+# Emptiness-checked BEFORE joining: on failure the substitution is
+# empty, which would otherwise resolve to $ROOT — turning "not a repo"
+# into a confident wrong answer and defeating the not-a-checkout SKIP
+# below. A relative answer is joined by STRING rather than `cd`+`pwd`,
+# so a symlinked checkout keeps its logical path (/var -> /private/var
+# on macOS); the two vars are only ever compared with each other, so
+# both must normalize the same way.
+git_path() {  # $1 = rev-parse path flag; prints an absolute path or nothing
+    local raw
+    raw="$(git -C "$ROOT" rev-parse "$1" 2>/dev/null)" || return 0
+    case "$raw" in
+        '') return 0 ;;
+        /*) printf '%s\n' "$raw" ;;
+        *)  printf '%s\n' "$ROOT/$raw" ;;
+    esac
+}
+GIT_DIR_PATH="$(git_path --git-dir)"
+GIT_COMMON="$(git_path --git-common-dir)"
+IN_WORKTREE=""
+if [ -n "$GIT_DIR_PATH" ] && [ -n "$GIT_COMMON" ] \
+    && [ "$GIT_DIR_PATH" != "$GIT_COMMON" ]; then
+    IN_WORKTREE=1
+fi
+# SETUP_CMD stays a pure, copy-able command — root-scoped via cd so a
+# paste from ANY cwd provisions the diagnosed checkout, never the
+# caller's (CodeRabbit round 2). Paths are %q-escaped so quotes,
+# spaces, or substitution characters in the path cannot break or
+# execute inside the pasted snippet (CodeRabbit round 4). The
+# rationale rides in SETUP_NOTE as a SHELL COMMENT, so pasting the
+# remedy tail whole stays executable (rounds 2-3).
+ROOT_Q="$(printf '%q' "$ROOT")"
+VENV_Q="$(printf '%q' "$ROOT/.venv")"
+SETUP_CMD="(cd $ROOT_Q && ./scripts/core/project setup)"
+SETUP_NOTE=""
+if [ -n "$IN_WORKTREE" ]; then
+    SETUP_CMD="(cd $ROOT_Q && ./scripts/core/project setup --no-hooks)"
+    SETUP_NOTE="  # hooks stay shared with the primary, hence --no-hooks"
+fi
+
+# ── .venv: must never be a symlink, worktree or not ──
+if [ -L "$ROOT/.venv" ]; then
+    TARGET="$(readlink "$ROOT/.venv")"
+    echo "DOCTOR:worktree-venv:WARN:.venv is a symlink -> $TARGET — split-brain (KIT-0044) and a destruction vector: a venv --clear or rebuild through the link empties the TARGET venv (KIT-0065 emptied the primary clone's); replace it: rm $VENV_Q && $SETUP_CMD$SETUP_NOTE"
+elif [ -d "$ROOT/.venv" ]; then
+    echo "DOCTOR:worktree-venv:PASS:.venv is a real directory (not a symlink)"
+else
+    echo "DOCTOR:worktree-venv:PASS:no .venv — provision one with $SETUP_CMD when needed$SETUP_NOTE"
+fi
+# The alternate venv/ layout (40-version-skew probes it too) carries
+# the same hazard class; silent when absent or a real directory.
+if [ -L "$ROOT/venv" ]; then
+    echo "DOCTOR:worktree-venv:WARN:venv is a symlink -> $(readlink "$ROOT/venv") — same destruction vector as a symlinked .venv (KIT-0065); replace it with a real venv"
+fi
+
+# ── the rest of the audit only applies inside a linked worktree ──
+if [ -z "$GIT_DIR_PATH" ] || [ -z "$GIT_COMMON" ]; then
+    echo "DOCTOR:worktree-audit:SKIP:not a git checkout — no worktree provisioning to audit"
+    exit 0
+fi
+if [ -z "$IN_WORKTREE" ]; then
+    echo "DOCTOR:worktree-audit:SKIP:primary clone (not a linked worktree) — worktree audit not applicable"
+    exit 0
+fi
+PRIMARY_ROOT="$(dirname "$GIT_COMMON")"
+
+# ── Serena: name-based activation resolves to the PRIMARY ──
+serena_name() {  # $1 = project.yml path; prints the project name
+    # Mirrors the reader in scripts/core/project (reconfigure): accepts
+    # top-level `name:` OR `project_name:`, first non-empty value wins,
+    # and strips SURROUNDING quotes only — an internal apostrophe is
+    # part of the name, not quoting (code-reviewer, this PR).
+    local line value
+    while IFS= read -r line; do
+        case "$line" in
+            name:* | project_name:*)
+                value="${line#*:}"
+                value="$(printf '%s' "$value" \
+                    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+                case "$value" in
+                    \"*\") value="${value#\"}"; value="${value%\"}" ;;
+                    \'*\') value="${value#\'}"; value="${value%\'}" ;;
+                esac
+                if [ -n "$value" ]; then
+                    printf '%s\n' "$value"
+                    return 0
+                fi
+                ;;
+        esac
+    done < "$1"
+    return 0
+}
+if [ ! -f "$PRIMARY_ROOT/.serena/project.yml" ]; then
+    echo "DOCTOR:worktree-serena:SKIP:project does not use Serena (no .serena/project.yml in the primary clone)"
+elif [ ! -f "$ROOT/.serena/project.yml" ]; then
+    echo "DOCTOR:worktree-serena:WARN:no worktree-local .serena/project.yml — activate_project by NAME resolves to the PRIMARY clone and bulk edits would hit main's checkout (KIT-0069); activate by ABSOLUTE PATH instead: $ROOT"
+else
+    WT_NAME="$(serena_name "$ROOT/.serena/project.yml")"
+    PRIMARY_NAME="$(serena_name "$PRIMARY_ROOT/.serena/project.yml")"
+    if [ -z "$WT_NAME" ]; then
+        # An unnamed config is not a collision, but it defeats the
+        # per-worktree identity the contract promises (fast-v2, this PR)
+        echo "DOCTOR:worktree-serena:WARN:worktree .serena/project.yml has no name/project_name — regenerate it (scripts/local/new-worktree.sh does this) or activate by ABSOLUTE PATH: $ROOT"
+    elif [ "$WT_NAME" = "$PRIMARY_NAME" ]; then
+        echo "DOCTOR:worktree-serena:WARN:worktree Serena project name '$WT_NAME' collides with the primary's — name-based activation is ambiguous and may resolve to the primary (KIT-0069); regenerate with a per-worktree name (scripts/local/new-worktree.sh does this) or activate by ABSOLUTE PATH: $ROOT"
+    else
+        echo "DOCTOR:worktree-serena:PASS:worktree-local Serena config (project name '$WT_NAME') — activate by absolute path: $ROOT"
+    fi
+fi
+
+# ── what a worktree DOES share, so nobody re-diagnoses it ──
+echo "DOCTOR:worktree-shared:PASS:shared with the primary by design (read-only use): .env, .adversarial/evaluators, git hooks via the common git dir; worktree-local by design: .venv, .serena"
+exit 0

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/60-push-sync-token.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/60-push-sync-token.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: push-sync secrets exist — only while the push trigger
+# is active in sync-core-scripts.yml.
+#
+# Incident: CROSS_REPO_TOKEN was never provisioned, so the push-triggered
+# sync workflow failed 22/22 times over four months before anyone
+# noticed (the trigger is parked, dispatch-only, since 2026-07-14 —
+# re-enablement tracked as KIT-0045).
+#
+# Read-only. Root from DOCTOR_ROOT (driver-set), else file-relative.
+# May hit the network (gh secret list) only when the trigger is active.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+WORKFLOW="$ROOT/.github/workflows/sync-core-scripts.yml"
+
+if [ ! -f "$WORKFLOW" ]; then
+    echo "DOCTOR:push-sync-token:SKIP:sync-core-scripts.yml not present"
+    exit 0
+fi
+
+# An active push trigger can be block style at any indent (`push:`
+# inside the top-level `on:` block), flow style (`on: [push, ...]`), or
+# scalar (`on: push`). Block-style detection is scoped to the `on:`
+# block so a nested `push:` key elsewhere (e.g. under jobs:) cannot
+# false-positive (CodeRabbit round 2); comments never match (o3 round 1:
+# any-indent tolerance — erring toward "checking" beats erring toward
+# SKIP for this incident class).
+# Trailing same-line comments after the trigger are allowed
+# (`push:  # deploy` is active — BugBot round 3).
+BLOCK_PUSH="$(awk '
+    /^on:[[:space:]]*(#.*)?$/ { in_on = 1; next }
+    in_on && /^[^ \t#]/ { in_on = 0 }
+    in_on && /^[[:space:]]+push:[[:space:]]*(#.*)?$/ { found = 1 }
+    END { print found + 0 }
+' "$WORKFLOW")"
+
+if [ "$BLOCK_PUSH" != "1" ] && ! grep -qE '^on:[[:space:]]*(\[[^]]*push|push[[:space:]]*(#.*)?$)' "$WORKFLOW"; then
+    echo "DOCTOR:push-sync-token:SKIP:push channel parked — see KIT-0045"
+    exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "DOCTOR:push-sync-token:WARN:push trigger active but gh unavailable — cannot verify CROSS_REPO_TOKEN"
+    exit 0
+fi
+
+SECRETS="$(gh secret list 2>/dev/null)" || {
+    echo "DOCTOR:push-sync-token:WARN:push trigger active but secret list unreadable (needs repo admin) — verify CROSS_REPO_TOKEN manually"
+    exit 0
+}
+
+if printf '%s\n' "$SECRETS" | grep -q 'CROSS_REPO_TOKEN'; then
+    echo "DOCTOR:push-sync-token:PASS:push trigger active and CROSS_REPO_TOKEN present"
+else
+    echo "DOCTOR:push-sync-token:FAIL:push trigger active but CROSS_REPO_TOKEN missing — the 22/22-failure incident repeats on next push"
+fi

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/70-core-bare.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/70-core-bare.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: core.bare is false in the primary clone.
+#
+# Incident (KIT-0043): a pre-commit GIT_DIR leak from inside a worktree
+# flipped core.bare=true on the PRIMARY clone — repository state
+# corruption, not just a failing test. The suite-wide GIT_* isolation
+# in tests/conftest.py kills the known vector; this check is the
+# standing canary (WORKTREE-WORKFLOW.md documents the manual form).
+#
+# Read-only. Resolves the primary clone via git-common-dir from
+# DOCTOR_ROOT (never cwd assumptions — N4), so it works from any
+# worktree and always inspects the shared config.
+
+set -u
+
+# Leaked GIT_* env would make git ignore -C or override config values
+# (GIT_CONFIG_COUNT/KEY_0/VALUE_0 can literally rewrite core.bare) — the
+# exact leak class this check diagnoses must not be able to blind the
+# check itself. Scrub EVERY GIT_* variable, not an allowlist (fast-v2
+# round 1 + CodeRabbit round 2; the driver also scrubs, but this check
+# must survive standalone runs).
+for _git_var in $(compgen -A variable | grep '^GIT_' || true); do
+    unset "$_git_var"
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+# KIT-0080: plain --git-common-dir, absolutized in shell. The
+# --path-format=absolute form needs git >= 2.31; Apple's system git
+# (2.30.1) echoes the flag back as an output line and still exits 0, so
+# the SKIP branch below never fired and COMMON_DIR became garbage — the
+# check then read core.bare from a nonexistent git dir and always said
+# PASS, blinding the KIT-0043 canary. Plain output may be relative to
+# the -C directory, hence the join below.
+#
+# The result is emptiness-checked BEFORE joining: on failure the
+# substitution is empty, which would otherwise resolve to $ROOT —
+# turning "not a repo" into a confident wrong answer, the very class
+# this task removes. A relative answer is joined by STRING rather than
+# `cd`+`pwd`, so a symlinked checkout keeps its logical path in the
+# verdict line (/var -> /private/var on macOS).
+COMMON_DIR=""
+COMMON_RAW="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null)" || COMMON_RAW=""
+case "$COMMON_RAW" in
+    '') COMMON_DIR="" ;;
+    /*) COMMON_DIR="$COMMON_RAW" ;;
+    *)  COMMON_DIR="$ROOT/$COMMON_RAW" ;;
+esac
+if [ -z "$COMMON_DIR" ]; then
+    echo "DOCTOR:core-bare:SKIP:not a git repository ($ROOT)"
+    exit 0
+fi
+
+BARE="$(git --git-dir "$COMMON_DIR" config --get core.bare 2>/dev/null)"
+
+if [ "$BARE" = "true" ]; then
+    echo "DOCTOR:core-bare:FAIL:primary clone is bare ($COMMON_DIR) — GIT_DIR leak damage; restore: git --git-dir $COMMON_DIR config core.bare false, then verify the working tree"
+else
+    echo "DOCTOR:core-bare:PASS:primary clone is a normal checkout (core.bare=${BARE:-unset})"
+fi

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/80-bot-presence.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/80-bot-presence.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: review bots present on the repo — WARN-max by design.
+#
+# Incidents: CodeRabbit "internal error" ×3 rounds (prepaid credits
+# exhausted, KIT-0042) and bot no-shows that stall the Phase 6 loop.
+# Detection is inherently unreliable pre-PR, so this check NEVER emits
+# FAIL — WARN is its ceiling.
+#
+# Not-checkable note (per the incident-closure lifecycle rule): the
+# CodeRabbit *quota/credit* state has no cheap API — exhaustion still
+# surfaces only as an "internal error" review comment at review time.
+# Signals used instead: CodeRabbit reports via commit STATUSES,
+# BugBot via CHECK-RUNS (verified in KIT-0034) — both visible in the
+# statusCheckRollup of any recent PR.
+#
+# Read-only; network via gh (the optional bot probe allowed by N2).
+
+set -u
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "DOCTOR:bot-presence:SKIP:gh unavailable — cannot probe bot activity"
+    exit 0
+fi
+
+# gh's built-in --jq extracts robustly — no regex-over-JSON (convergent
+# finding from all three evaluators)
+PR_NUM="$(gh pr list --state all --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null)" || {
+    echo "DOCTOR:bot-presence:SKIP:cannot list PRs (unauthenticated or no remote)"
+    exit 0
+}
+if [ -z "$PR_NUM" ]; then
+    echo "DOCTOR:bot-presence:SKIP:no PRs yet — bot presence unknowable pre-PR"
+    exit 0
+fi
+
+ROLLUP="$(gh pr view "$PR_NUM" --json statusCheckRollup 2>/dev/null)" || {
+    echo "DOCTOR:bot-presence:SKIP:cannot read PR #$PR_NUM status rollup"
+    exit 0
+}
+
+MISSING=""
+printf '%s' "$ROLLUP" | grep -qi 'coderabbit' || MISSING="CodeRabbit"
+if ! printf '%s' "$ROLLUP" | grep -qiE 'bugbot|cursor'; then
+    MISSING="${MISSING:+$MISSING, }BugBot"
+fi
+
+if [ -z "$MISSING" ]; then
+    echo "DOCTOR:bot-presence:PASS:CodeRabbit and BugBot both active on PR #$PR_NUM"
+else
+    echo "DOCTOR:bot-presence:WARN:no recent activity from: $MISSING (checked PR #$PR_NUM) — quota/credit state is not cheaply checkable"
+fi

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/90-config-home.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/90-config-home.sh
@@ -118,8 +118,11 @@ if [ -z "$REMOTE_URL" ]; then
     exit 0
 fi
 
+# Never print the raw URL: embedded credentials/tokens must not reach
+# doctor output or CI logs (CodeRabbit, PR #109) — redact userinfo.
+REMOTE_URL_DISPLAY="$(printf '%s' "$REMOTE_URL" | sed -E 's#(://)[^/@]*@#\1<redacted>@#')"
 if ! command -v gh >/dev/null 2>&1; then
-    echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL (gh not installed) — if that repo is public, your operator config is exposed"
+    echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL_DISPLAY (gh not installed) — if that repo is public, your operator config is exposed"
     exit 0
 fi
 
@@ -129,13 +132,13 @@ VISIBILITY="$(gh repo view --json visibility --jq .visibility -- "$REMOTE_URL" 2
 VISIBILITY="$(printf '%s' "$VISIBILITY" | tr '[:upper:]' '[:lower:]')"
 case "$VISIBILITY" in
     private)
-        echo "DOCTOR:config-home:PASS:config home remote is private ($REMOTE_URL)"
+        echo "DOCTOR:config-home:PASS:config home remote is private ($REMOTE_URL_DISPLAY)"
         ;;
     "")
-        echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL (gh query failed) — if that repo is public, your operator config is exposed"
+        echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL_DISPLAY (gh query failed) — if that repo is public, your operator config is exposed"
         ;;
     *)
-        echo "DOCTOR:config-home:WARN:config home remote is $VISIBILITY ($REMOTE_URL) — your operator config is exposed; make the repo private"
+        echo "DOCTOR:config-home:WARN:config home remote is $VISIBILITY ($REMOTE_URL_DISPLAY) — your operator config is exposed; make the repo private"
         ;;
 esac
 exit 0

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/90-config-home.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/90-config-home.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# shapes: single planning
+# doctor check: operator config-home guardrails (KIT-0058, ADR-0027 P7).
+#
+# Incident (operator review, 2026-07-21 — the P7 amendment): the
+# invisible ~/.config dotfolder was a discoverability threshold, so
+# the operator config moved to a VISIBLE sibling of the kit checkout
+# (<kit-parent>/agentive-config/). Visibility + guardrails beat
+# obscurity — but only if the guardrails are checked: a config home
+# pushed to a PUBLIC remote exposes the operator's setup, and a
+# TRACKED env.source is a secret in git.
+#
+# Verdicts:
+#   SKIP  no config home yet (path named), or nothing to resolve from
+#   PASS  home exists with no git repo, or a repo with no remote
+#   WARN  remote visibility is not private, or gh cannot verify it
+#         (the risk is named either way)
+#   FAIL  env.source is TRACKED in the config home's git repo
+#
+# Resolution mirrors the door's config_home():
+# AGENTIVE_KIT_CONFIG_DIR override, else the primary clone's parent
+# via --git-common-dir (worktree-safe) + /agentive-config. Read-only;
+# network only via gh repo view (the visibility probe).
+#
+# Anchoring note (BugBot, PR #91): this check anchors to the checkout
+# it diagnoses (DOCTOR_ROOT), the door to the kit clone — identical
+# exactly when kit and project share a parent (the documented sibling
+# layout). A consumer checkout cannot compute the kit clone's local
+# path, so when layouts diverge the override is the pin, and every
+# verdict line names the resolved path to keep the anchor visible.
+
+set -u
+
+# Leaked GIT_* env would redirect every git call below at the wrong
+# repository (the KIT-0043 leak class) — scrub all of it; the driver
+# also scrubs, but this check must survive standalone runs.
+for _git_var in $(compgen -A variable | grep '^GIT_' || true); do
+    unset "$_git_var"
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${DOCTOR_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+resolve_home() {
+    if [ -n "${AGENTIVE_KIT_CONFIG_DIR:-}" ]; then
+        # leading-~ expansion, mirroring the door's config_home
+        printf '%s\n' "${AGENTIVE_KIT_CONFIG_DIR/#\~/$HOME}"
+        return 0
+    fi
+    local common
+    # KIT-0080: --path-format=absolute needs git >= 2.31; Apple's system
+    # git (2.30.1) does not consume the flag, echoes it back as the first
+    # output line and exits 0 — the nested dirname then sees an arg
+    # starting with `--` (the stray `dirname: illegal option`) and the
+    # home resolved to the relative garbage ./agentive-config, silently
+    # hiding the operator preset. Plain --git-common-dir is portable; its
+    # output is relative to the -C directory, so absolutize there.
+    #
+    # Emptiness-checked BEFORE joining: on failure the substitution is
+    # empty, which would otherwise resolve to $ROOT — a confident wrong
+    # home instead of the rc 1 that drives the SKIP branch.
+    #
+    # A RELATIVE answer (both gits print a bare ".git" from a primary
+    # clone) is joined by string, not by `cd`+`pwd`: cd-ing resolves
+    # symlinked ancestors and would return the PHYSICAL path, changing
+    # the reported home on any symlinked checkout (/var -> /private/var
+    # on macOS). String-joining preserves the caller's logical path,
+    # matching what this check reported before KIT-0080.
+    local raw
+    raw="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null)" || return 1
+    [ -n "$raw" ] || return 1
+    case "$raw" in
+        /*) common="$raw" ;;
+        *)  common="$ROOT/$raw" ;;
+    esac
+    # Two levels: $common is <primary-clone>/.git, so one dirname gives
+    # the clone root and the second its PARENT, which is where the
+    # visible agentive-config sibling lives.
+    printf '%s\n' "$(dirname "$(dirname "$common")")/agentive-config"
+}
+
+if ! HOME_DIR="$(resolve_home)"; then
+    echo "DOCTOR:config-home:SKIP:cannot resolve the config home ($ROOT is not a git clone)"
+    exit 0
+fi
+
+if [ ! -d "$HOME_DIR" ]; then
+    echo "DOCTOR:config-home:SKIP:no config home at $HOME_DIR — author one with /setup-preset (path anchors to the primary clone's parent; AGENTIVE_KIT_CONFIG_DIR overrides)"
+    exit 0
+fi
+
+# -e, not -d: a gitfile (worktree/submodule layout) also marks a repo.
+# The home must be its OWN repo — being inside some parent repo's tree
+# does not make the guardrails apply to it.
+if [ ! -e "$HOME_DIR/.git" ]; then
+    echo "DOCTOR:config-home:PASS:config home at $HOME_DIR (no git repo — the private-repo pattern is optional)"
+    exit 0
+fi
+
+# The one hard line: a tracked env.source is a secret in git (FAIL).
+# No exit — the visibility verdict below still runs; the driver
+# aggregates multi-line checks and FAIL wins.
+if git -C "$HOME_DIR" ls-files --error-unmatch env.source >/dev/null 2>&1; then
+    echo "DOCTOR:config-home:FAIL:env.source is TRACKED in $HOME_DIR — a secret in git; untrack it: git -C $HOME_DIR rm --cached env.source (the seeded .gitignore ignores it)"
+fi
+
+REMOTE_URL="$(git -C "$HOME_DIR" remote get-url origin 2>/dev/null)" || REMOTE_URL=""
+if [ -z "$REMOTE_URL" ]; then
+    # no origin — fall back to the first remote of any name
+    FIRST_REMOTE="$(git -C "$HOME_DIR" remote 2>/dev/null | head -1)"
+    if [ -n "$FIRST_REMOTE" ]; then
+        REMOTE_URL="$(git -C "$HOME_DIR" remote get-url "$FIRST_REMOTE" 2>/dev/null)" || REMOTE_URL=""
+    fi
+fi
+
+if [ -z "$REMOTE_URL" ]; then
+    echo "DOCTOR:config-home:PASS:config home at $HOME_DIR is a git repo with no remote — local-only is fine"
+    exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL (gh not installed) — if that repo is public, your operator config is exposed"
+    exit 0
+fi
+
+# flags first, then `--`: a hostile remote URL beginning with `-` can
+# never be parsed as a gh flag (claude-code review, this PR)
+VISIBILITY="$(gh repo view --json visibility --jq .visibility -- "$REMOTE_URL" 2>/dev/null)" || VISIBILITY=""
+VISIBILITY="$(printf '%s' "$VISIBILITY" | tr '[:upper:]' '[:lower:]')"
+case "$VISIBILITY" in
+    private)
+        echo "DOCTOR:config-home:PASS:config home remote is private ($REMOTE_URL)"
+        ;;
+    "")
+        echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL (gh query failed) — if that repo is public, your operator config is exposed"
+        ;;
+    *)
+        echo "DOCTOR:config-home:WARN:config home remote is $VISIBILITY ($REMOTE_URL) — your operator config is exposed; make the repo private"
+        ;;
+esac
+exit 0

--- a/scripts/.core-manifest.json
+++ b/scripts/.core-manifest.json
@@ -13,6 +13,7 @@
       "core/doctor.d/20-env-keys.py",
       "core/doctor.d/30-evaluators.sh",
       "core/doctor.d/31-evaluator-cli.sh",
+      "core/doctor.d/35-handoffs-paths.py",
       "core/doctor.d/40-version-skew.py",
       "core/doctor.d/50-plugin-source.sh",
       "core/doctor.d/55-worktree-provisioning.sh",

--- a/scripts/core/doctor.d/35-handoffs-paths.py
+++ b/scripts/core/doctor.d/35-handoffs-paths.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# shapes: single planning
+"""doctor check: agent-handoffs.json task paths point at real files.
+
+KIT-0086 F2: feature-branch lifecycle moves no longer rewrite the
+shared coordination JSON (single-writer guard — the planner owns it on
+main), so its ``.kit/tasks/<folder>/<file>`` path strings can go stale
+between a branch-side move and the planner's next edit. Drift must be
+LOUD without reintroducing a second writer: this check WARNs when a
+recorded path does not exist while the same file name exists in a
+different status folder (a stale pointer), and stays quiet on paths
+that are simply gone (archived/deleted tasks are the planner's
+bookkeeping, not drift).
+
+Read-only (N3). Root comes from DOCTOR_ROOT (set by the driver).
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+NAME = "35-handoffs-paths.py"
+
+root = Path(os.environ.get("DOCTOR_ROOT") or Path(__file__).resolve().parents[3])
+handoffs = root / ".kit" / "context" / "agent-handoffs.json"
+tasks_dir = root / ".kit" / "tasks"
+
+if not handoffs.is_file() or not tasks_dir.is_dir():
+    print(f"DOCTOR:{NAME}:SKIP:no agent-handoffs.json or .kit/tasks in this repo")
+    sys.exit(0)
+
+try:
+    text = handoffs.read_text(encoding="utf-8")
+    json.loads(text)  # structural sanity only; paths are scanned as strings
+except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    print(
+        f"DOCTOR:{NAME}:WARN:agent-handoffs.json unreadable or not JSON "
+        f"({exc.__class__.__name__}) — fix it on main (planner owns this file)"
+    )
+    sys.exit(0)
+
+# Scan raw path strings — the same shape lifecycle rewrites; scanning
+# text (not the JSON tree) also catches paths in nested/unknown keys.
+recorded = set(re.findall(r"\.kit/tasks/[0-9]+-[a-z-]+/[A-Za-z0-9._-]+\.md", text))
+
+stale = []
+for rel in sorted(recorded):
+    if (root / rel).is_file():
+        continue
+    file_name = rel.rsplit("/", 1)[1]
+    actual = [
+        f".kit/tasks/{p.parent.name}/{p.name}"
+        for p in tasks_dir.glob(f"*/{file_name}")
+        if p.is_file()
+    ]
+    if actual:
+        stale.append(f"{rel} -> {actual[0]}")
+
+if stale:
+    detail = "; ".join(stale)
+    print(
+        f"DOCTOR:{NAME}:WARN:stale task path(s) in agent-handoffs.json "
+        f"({detail}) — planner repairs on main; branch sessions must not "
+        "edit this file (KIT-0086)"
+    )
+else:
+    print(
+        f"DOCTOR:{NAME}:PASS:all {len(recorded)} recorded task path(s) "
+        "resolve to their folders"
+    )

--- a/scripts/core/doctor.d/90-config-home.sh
+++ b/scripts/core/doctor.d/90-config-home.sh
@@ -118,8 +118,11 @@ if [ -z "$REMOTE_URL" ]; then
     exit 0
 fi
 
+# Never print the raw URL: embedded credentials/tokens must not reach
+# doctor output or CI logs (CodeRabbit, PR #109) — redact userinfo.
+REMOTE_URL_DISPLAY="$(printf '%s' "$REMOTE_URL" | sed -E 's#(://)[^/@]*@#\1<redacted>@#')"
 if ! command -v gh >/dev/null 2>&1; then
-    echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL (gh not installed) — if that repo is public, your operator config is exposed"
+    echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL_DISPLAY (gh not installed) — if that repo is public, your operator config is exposed"
     exit 0
 fi
 
@@ -129,13 +132,13 @@ VISIBILITY="$(gh repo view --json visibility --jq .visibility -- "$REMOTE_URL" 2
 VISIBILITY="$(printf '%s' "$VISIBILITY" | tr '[:upper:]' '[:lower:]')"
 case "$VISIBILITY" in
     private)
-        echo "DOCTOR:config-home:PASS:config home remote is private ($REMOTE_URL)"
+        echo "DOCTOR:config-home:PASS:config home remote is private ($REMOTE_URL_DISPLAY)"
         ;;
     "")
-        echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL (gh query failed) — if that repo is public, your operator config is exposed"
+        echo "DOCTOR:config-home:WARN:cannot verify visibility of $REMOTE_URL_DISPLAY (gh query failed) — if that repo is public, your operator config is exposed"
         ;;
     *)
-        echo "DOCTOR:config-home:WARN:config home remote is $VISIBILITY ($REMOTE_URL) — your operator config is exposed; make the repo private"
+        echo "DOCTOR:config-home:WARN:config home remote is $VISIBILITY ($REMOTE_URL_DISPLAY) — your operator config is exposed; make the repo private"
         ;;
 esac
 exit 0

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1993,9 +1993,10 @@ def cmd_doctor(args, project_dir):
 
 
 def _kit_doctor():
-    """Import agentive_kit.doctor with the same fallback chain as
-    _kit_lifecycle (installed copy → in-repo source → loud install
-    instruction)."""
+    """Import agentive_kit.doctor (installed copy → in-repo source);
+    returns None when neither exists — the caller falls back to the
+    inline driver below (package-less consumers keep a working
+    doctor)."""
     try:
         from agentive_kit import doctor
 

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1540,440 +1540,43 @@ def _doctor_install(project_dir):
     return shape, profile, bots, errors
 
 
-def _check_declared(check_path, keyword):
-    """Tokens a doctor.d check declares via its `# <keyword>:` header
-    line — keyword is "shapes" (KIT-0048) or "profiles" (KIT-0050 F5);
-    the two declarations share one mechanism by design.
+# ── Doctor: extracted to the agentive-kit package (KIT-0090 PR 2) ──────────
+# The driver, per-shape/profile check inclusion, config-home resolution
+# and preset comparison live in agentive_kit.doctor. _doctor_install and
+# _normalize_bots above are KEPT here — cmd_sync's shape gate must work
+# package-free for consumers until phase 3 (recorded duplication; this
+# script retires in phase 4).
 
-    Returns a set of tokens, or None when the check declares nothing —
-    an undeclared OR empty declaration runs everywhere (never silently
-    skipped; o3 review: an empty set would skip the check in every
-    shape forever). Case-insensitive; scanned over the first 30 lines,
-    which covers long banners without picking up documentation strings
-    deep in a check body (convention: the header sits right under the
-    shebang).
-    """
+
+def _kit_doctor():
+    """Import agentive_kit.doctor with the same fallback chain as
+    _kit_lifecycle (installed copy → in-repo source → loud install
+    instruction)."""
     try:
-        text = check_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return None
-    head = "\n".join(text.splitlines()[:30])
-    # [^\S\n] = horizontal whitespace only — \s would slurp the newline
-    # of an empty declaration and capture the NEXT line as tokens
-    match = re.search(
-        r"^#[^\S\n]*" + keyword + r":[^\S\n]*(.*)$",
-        head,
-        re.MULTILINE | re.IGNORECASE,
+        from agentive_kit import doctor
+
+        return doctor
+    except ModuleNotFoundError:
+        pass
+    pkg_src = (
+        Path(__file__).resolve().parent.parent.parent
+        / "packages"
+        / "agentive-kit"
+        / "src"
     )
-    if match:
-        # lowercase the tokens too — IGNORECASE only covers the keyword,
-        # and '# Shapes: Single' must match shape 'single' (CodeRabbit)
-        declared = {token.lower() for token in match.group(1).split()}
-        return declared or None
-    return None
-
-
-def _config_home(project_dir):
-    """Locate the operator config home (KIT-0058, ADR-0027 P7
-    amendment): the visible sibling
-    ``<primary-clone-parent>/agentive-config`` of this checkout,
-    resolved worktree-safely via ``--git-common-dir``.
-    ``AGENTIVE_KIT_CONFIG_DIR`` is the ONLY override — an override,
-    never a search chain. Mirrors the door's ``config_home()``; the
-    equivalence test in tests/test_setup_door.py pins the two so the
-    door and doctor can never disagree on the path. Returns None when
-    the checkout is not a git repository (no sibling to name).
-
-    Anchoring note (BugBot, PR #91): each resolver anchors to ITS OWN
-    checkout — the door to the kit clone, doctor to the project it
-    diagnoses. The two name the same folder exactly when kit and
-    project share a parent (the documented sibling layout); a consumer
-    checkout has no pointer to the kit clone's local path, so the
-    kit's parent is not computable from here. When the layouts
-    diverge, the override pins the real location, and every output
-    line below names the resolved path so the anchor is visible.
-    """
-    override = os.environ.get("AGENTIVE_KIT_CONFIG_DIR")
-    if override:
-        # leading-~ expansion mirrors the bash resolvers (env files can
-        # carry a literal tilde the shell never expanded)
-        return Path(override).expanduser()
-    # scrub GIT_* — a leaked GIT_DIR would resolve the WRONG primary
-    # clone (the KIT-0043 incident class; this runs in-process, so the
-    # driver's per-check scrub does not cover it)
-    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
-    try:
-        result = subprocess.run(
-            [
-                "git",
-                "-C",
-                str(project_dir),
-                "rev-parse",
-                "--git-common-dir",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            env=env,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    common = result.stdout.strip()
-    if result.returncode != 0 or not common:
-        return None
-    # KIT-0080: plain --git-common-dir, absolutized here. The
-    # --path-format=absolute form needs git >= 2.31; Apple's system git
-    # (2.30.1) echoes the flag back as an output line and exits 0, so
-    # `common` became "--path-format=absolute\n<path>" and the home
-    # resolved to garbage. Plain output is RELATIVE to the -C directory
-    # (both gits return a bare ".git" from a primary clone), so anchor
-    # it on project_dir — never on the process cwd. `/` already discards
-    # the left operand when `common` is absolute.
-    #
-    # No .resolve(): that would follow symlinked ancestors and report a
-    # PHYSICAL path, diverging from the bash resolvers this function is
-    # pinned equivalent to (tests/test_setup_door.py). os.path.normpath
-    # collapses the "<root>/.git" join without touching symlinks.
-    # Two levels: `joined` is <primary-clone>/.git, so .parent is the
-    # clone root and .parent.parent its PARENT, where the visible
-    # agentive-config sibling lives.
-    joined = Path(os.path.normpath(Path(project_dir) / common))
-    return joined.parent.parent / "agentive-config"
-
-
-def _print_preset_comparison(shape, profile, bots, record_errors, project_dir):
-    """`doctor --against-preset` (KIT-0056 F8, ADR-0027 P7): compare
-    the project's kit-install record against the operator preset at
-    ``<kit-parent>/agentive-config/preset`` (KIT-0058;
-    ``AGENTIVE_KIT_CONFIG_DIR`` overrides the location).
-
-    INFO-only by design: divergence is reported as
-    ``PRESET:<field>:INFO:<detail>`` lines and NEVER as WARN/FAIL, and
-    the doctor exit code is never affected — a deliberately-lean
-    project is not wrong. Doctor validates the RECORD (the DOCTOR:
-    lines above); the preset is only a comparison baseline. The
-    PRESET: prefix keeps these lines out of DOCTOR: parsers entirely.
-
-    Keys other than shape/profile/bots are ignored here by design:
-    the door owns the preset-key vocabulary (unknown keys WARN there);
-    duplicating its key list in this comparator would be a second
-    source of truth that drifts. Structural faults shared with the
-    door's parser (malformed lines, duplicate keys) do get reported —
-    as INFO, with the comparison skipped whole.
-    """
-    home = _config_home(project_dir)
-    print()
-    if home is None:
-        print(
-            f"PRESET:comparison:INFO:cannot locate the config home "
-            f"({project_dir} is not a git clone) — nothing to compare"
-        )
-        return
-    preset_path = home / "preset"
-    if not preset_path.is_file():
-        print(
-            f"PRESET:comparison:INFO:no preset found at {preset_path} — "
-            "nothing to compare (the path anchors to this project's "
-            "primary-clone parent; set AGENTIVE_KIT_CONFIG_DIR if your "
-            "config home lives beside the kit clone elsewhere)"
-        )
-        return
-    try:
-        preset_lines = preset_path.read_text(encoding="utf-8").splitlines()
-    except OSError as exc:
-        print(
-            f"PRESET:comparison:INFO:preset unreadable "
-            f"({exc.__class__.__name__}) — comparison skipped"
-        )
-        return
-    preset_values = {}
-    for lineno, line in enumerate(preset_lines, 1):
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if ":" not in stripped:
-            # loud, names the line, and skips the WHOLE comparison — a
-            # partial read could report agreement on fields it never
-            # parsed (the masking class, record-reader face)
-            print(
-                f"PRESET:comparison:INFO:preset malformed at line {lineno} "
-                f"('{stripped}') — fix {preset_path}; comparison skipped"
-            )
-            return
-        key, _, value = stripped.partition(":")
-        key = key.strip()
-        if key in preset_values:
-            # same duplicate rule as the door's load_preset — silently
-            # letting the last value win could compare against a value
-            # the door would refuse to load
-            print(
-                f"PRESET:comparison:INFO:duplicate preset key '{key}' at "
-                f"line {lineno} — fix {preset_path}; comparison skipped"
-            )
-            return
-        preset_values[key] = value.strip()
-
-    if shape is None or profile is None:
-        print(
-            "PRESET:comparison:INFO:kit-install record unreadable "
-            "(see the DOCTOR record FAIL lines) — comparison skipped"
-        )
-        return
-
-    bots_errored = any(record == "bots-record" for record, _ in record_errors)
-    record_values = {
-        "shape": shape,
-        "profile": profile,
-        # absent bots line = both expected (the pre-KIT-0056 default)
-        "bots": bots if bots is not None else "coderabbit bugbot",
-    }
-    defaulted = {"bots": bots is None}
-    # Vocabulary checks mirror the door's validate_values: a preset
-    # value the door would refuse to install must read as malformed
-    # preset data here, never as legitimate divergence (CodeRabbit).
-    valid_vocab = {
-        "shape": ("single", "planning"),
-        "profile": ("python", "none"),
-    }
-    if (
-        preset_values.get("shape") == "planning"
-        and preset_values.get("profile") == "python"
-    ):
-        print(
-            "PRESET:comparison:INFO:preset declares an illegal pair "
-            "(planning forces profile none) — fix the preset; "
-            "shape/profile comparison skipped"
-        )
-        preset_values.pop("shape", None)
-        preset_values.pop("profile", None)
-    compared = 0
-    divergences = 0
-    for key in ("shape", "profile", "bots"):
-        preset_val = preset_values.get(key, "")
-        if not preset_val:
-            continue
-        if key in valid_vocab and preset_val not in valid_vocab[key]:
-            print(
-                f"PRESET:{key}:INFO:preset {key} value invalid "
-                f"('{preset_val}') — {key} comparison skipped"
-            )
-            continue
-        if key == "bots":
-            if bots_errored:
-                print(
-                    "PRESET:bots:INFO:recorded bots declaration is invalid "
-                    "(see DOCTOR:bots-record above) — bots comparison skipped"
-                )
-                continue
-            normalized = _normalize_bots(preset_val)
-            if normalized is None:
-                print(
-                    f"PRESET:bots:INFO:preset bots value invalid "
-                    f"('{preset_val}') — bots comparison skipped"
-                )
-                continue
-            preset_val = normalized
-        compared += 1
-        if preset_val != record_values[key]:
-            suffix = (
-                " (defaulted — no line in the record)" if defaulted.get(key) else ""
-            )
-            print(
-                f"PRESET:{key}:INFO:record has '{record_values[key]}'{suffix}, "
-                f"preset says '{preset_val}' — informational only, a "
-                "deliberately-lean project is not wrong"
-            )
-            divergences += 1
-    if compared == 0:
-        print(
-            "PRESET:comparison:INFO:preset answers none of the comparable "
-            "fields (shape/profile/bots) — nothing to compare"
-        )
-    elif divergences == 0:
-        print(
-            f"PRESET:comparison:INFO:record matches the preset on all "
-            f"{compared} compared field(s)"
-        )
-
-
-def cmd_doctor(args, project_dir):
-    """`project doctor`: run all doctor.d environment checks (ADR-0027 P4).
-
-    Composable driver: every executable in scripts/core/doctor.d/ runs;
-    a failing check never short-circuits its siblings (the fail-fast-
-    masking lesson from the sync workflow). Checks emit
-    ``DOCTOR:<name>:<verdict>:<detail>`` lines — <name> and <verdict>
-    are colon-free tokens, <detail> is everything after the third colon
-    (parsers split on the first three colons only, exactly like the
-    preflight GATE: format). Verdicts: PASS, WARN, FAIL, SKIP.
-
-    Exit-code contract (F3 — driver errors never overload 0/1):
-      0  every check PASS or SKIP
-      1  at least one FAIL
-      2  warnings only (no FAIL)
-      3  driver/usage error (unknown flag, doctor.d missing or empty)
-
-    Read-only (N3): the driver and every check diagnose the environment;
-    they never mutate config, env, or the working tree.
-    """
-    doctor_dir = project_dir / "scripts" / "core" / "doctor.d"
-    against_preset = False
-    for arg in args:
-        # An empty value would resolve Path("") to the cwd and silently
-        # diagnose the wrong tree — usage error instead (BugBot round 6).
-        if arg == "--against-preset":
-            # KIT-0056 F8: compare the record against the operator
-            # preset, INFO-only (see _print_preset_comparison).
-            against_preset = True
-        elif arg.startswith("--dir="):
-            # test/advanced seam: run a different check set (resolve now —
-            # checks run with a different cwd, so relative would break)
-            value = arg.partition("=")[2]
-            if not value:
-                print("❌ --dir= requires a path")
-                return 3
-            doctor_dir = Path(value).resolve()
-        elif arg.startswith("--root="):
-            # diagnose another checkout (e.g. the primary clone from a
-            # worktree); checks receive it as DOCTOR_ROOT
-            value = arg.partition("=")[2]
-            if not value:
-                print("❌ --root= requires a path")
-                return 3
-            project_dir = Path(value).resolve()
-            if not project_dir.is_dir():
-                print(f"❌ --root is not a directory: {project_dir}")
-                return 3
-        else:
-            print(f"Unknown option: {arg}")
-            print(
-                "Usage: ./scripts/core/project doctor "
-                "[--dir=<checks-dir>] [--root=<checkout>] [--against-preset]"
-            )
-            return 3
-
-    if not doctor_dir.is_dir():
-        print(f"❌ doctor checks directory not found: {doctor_dir}")
-        return 3
-    # dotfiles (.DS_Store & friends) are never checks — everything else
-    # in doctor.d/ is held to the check contract
-    checks = sorted(
-        p for p in doctor_dir.iterdir() if p.is_file() and not p.name.startswith(".")
-    )
-    if not checks:
-        print(f"❌ no checks found in {doctor_dir}")
-        return 3
-
-    # Per-shape inclusion (KIT-0048, fills the P2 seam) and per-profile
-    # inclusion (KIT-0050 F5): checks declare their shapes/profiles in
-    # `# shapes:` / `# profiles:` headers; the driver reads the install
-    # record once and stays otherwise declaration-driven. A malformed
-    # record runs everything AND fails loud via the record lines below.
-    shape, profile, bots, record_errors = _doctor_install(project_dir)
-
-    # Scrub ambient GIT_* so a leaked GIT_DIR (the KIT-0043 incident
-    # class — e.g. doctor invoked from a pre-commit hook in a worktree)
-    # cannot redirect git-facing checks at the wrong repository.
-    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
-    env["DOCTOR_ROOT"] = str(project_dir)
-    verdicts = []
-    for record, detail in record_errors:
-        print(f"DOCTOR:{record}:FAIL:{detail}")
-        verdicts.append("FAIL")
-    for check in checks:
-        name = check.name
-        declared = _check_declared(check, "shapes")
-        if shape is not None and declared is not None and shape not in declared:
-            print(
-                f"DOCTOR:{name}:SKIP:not applicable to shape '{shape}' "
-                f"(check declares: {' '.join(sorted(declared))})"
-            )
-            verdicts.append("SKIP")
-            continue
-        declared_profiles = _check_declared(check, "profiles")
-        if (
-            profile is not None
-            and declared_profiles is not None
-            and profile not in declared_profiles
-        ):
-            print(
-                f"DOCTOR:{name}:SKIP:not applicable to profile '{profile}' "
-                f"(check declares: {' '.join(sorted(declared_profiles))})"
-            )
-            verdicts.append("SKIP")
-            continue
-        if not os.access(check, os.X_OK):
-            print(f"DOCTOR:{name}:FAIL:check file is not executable")
-            verdicts.append("FAIL")
-            continue
+    if pkg_src.is_dir() and str(pkg_src) not in sys.path:
+        sys.path.insert(0, str(pkg_src))
         try:
-            result = subprocess.run(
-                [str(check)],
-                cwd=project_dir,
-                env=env,
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-        except subprocess.TimeoutExpired:
-            print(f"DOCTOR:{name}:FAIL:check timed out after 30s")
-            verdicts.append("FAIL")
-            continue
-        except OSError as exc:
-            print(f"DOCTOR:{name}:FAIL:check failed to run ({exc.__class__.__name__})")
-            verdicts.append("FAIL")
-            continue
+            from agentive_kit import doctor
 
-        emitted = False
-        for line in result.stdout.splitlines():
-            if not line.startswith("DOCTOR:"):
-                continue
-            parts = line.split(":", 3)
-            # F1 field contract: exactly DOCTOR:<name>:<verdict>:<detail>
-            # with non-empty name and detail — an incomplete record must
-            # not be able to count as a pass (CodeRabbit round 2)
-            malformed = len(parts) < 4 or not parts[1] or not parts[3].strip()
-            verdict = parts[2] if len(parts) >= 3 else ""
-            # membership: verdict vocabulary check, not identifier equality
-            if malformed or verdict not in ("PASS", "WARN", "FAIL", "SKIP"):
-                # malformed line: surface it, count it as a failure
-                print(line)
-                verdicts.append("FAIL")
-                emitted = True
-                continue
-            print(line)
-            verdicts.append(verdict)
-            emitted = True
-        if result.stderr:
-            sys.stderr.write(result.stderr)
-        if not emitted:
-            print(
-                f"DOCTOR:{name}:FAIL:check produced no DOCTOR line "
-                f"(exit {result.returncode})"
-            )
-            verdicts.append("FAIL")
-        elif result.returncode != 0:
-            # a check that emitted lines but then crashed may have lost
-            # its remaining concerns — surface the crash, don't let an
-            # early PASS line mask it (fast-v2 review finding)
-            print(
-                f"DOCTOR:{name}:FAIL:check exited {result.returncode} "
-                "after emitting output — remaining concerns may be lost"
-            )
-            verdicts.append("FAIL")
-
-    fails = verdicts.count("FAIL")
-    warns = verdicts.count("WARN")
-    passes = verdicts.count("PASS")
-    skips = verdicts.count("SKIP")
-    print(f"\nDoctor: {passes} pass, {warns} warn, {fails} fail, {skips} skip")
-    if against_preset:
-        _print_preset_comparison(shape, profile, bots, record_errors, project_dir)
-    if fails:
-        return 1
-    if warns:
-        return 2
-    return 0
+            return doctor
+        except ModuleNotFoundError:
+            pass
+    print("❌ agentive-kit is not installed")
+    print("   The doctor now lives in the agentive-kit package")
+    print("   (KIT-ADR-0028 phase 1). Install it:")
+    print("     uv tool install agentive-kit")
+    sys.exit(1)
 
 
 def cmd_sync(args, project_dir):
@@ -2398,7 +2001,7 @@ except Exception as e:
 
     elif command == "doctor":
         # Incident-mapped environment verifier (KIT-0046, ADR-0027 P4)
-        sys.exit(cmd_doctor(sys.argv[2:], project_dir))
+        sys.exit(_kit_doctor().cmd_doctor(sys.argv[2:], project_dir))
 
     elif command == "sync-status":
         # Check Linear sync status

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1548,6 +1548,450 @@ def _doctor_install(project_dir):
 # script retires in phase 4).
 
 
+# ── Inline doctor FALLBACK (KIT-0090 PR 2) ─────────────────────────────────
+# agentive_kit.doctor is canonical; this inline copy exists so a repo
+# WITHOUT the package (door-made consumers before the phase-2
+# package-install door, consumers syncing main pre-publish) still has a
+# working doctor. Recorded duplication — retires with this script in
+# phase 4. Keep in sync only via the package (fixes land there first).
+
+
+def _check_declared(check_path, keyword):
+    """Tokens a doctor.d check declares via its `# <keyword>:` header
+    line — keyword is "shapes" (KIT-0048) or "profiles" (KIT-0050 F5);
+    the two declarations share one mechanism by design.
+
+    Returns a set of tokens, or None when the check declares nothing —
+    an undeclared OR empty declaration runs everywhere (never silently
+    skipped; o3 review: an empty set would skip the check in every
+    shape forever). Case-insensitive; scanned over the first 30 lines,
+    which covers long banners without picking up documentation strings
+    deep in a check body (convention: the header sits right under the
+    shebang).
+    """
+    try:
+        text = check_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    head = "\n".join(text.splitlines()[:30])
+    # [^\S\n] = horizontal whitespace only — \s would slurp the newline
+    # of an empty declaration and capture the NEXT line as tokens
+    match = re.search(
+        r"^#[^\S\n]*" + keyword + r":[^\S\n]*(.*)$",
+        head,
+        re.MULTILINE | re.IGNORECASE,
+    )
+    if match:
+        # lowercase the tokens too — IGNORECASE only covers the keyword,
+        # and '# Shapes: Single' must match shape 'single' (CodeRabbit)
+        declared = {token.lower() for token in match.group(1).split()}
+        return declared or None
+    return None
+
+
+def _config_home(project_dir):
+    """Locate the operator config home (KIT-0058, ADR-0027 P7
+    amendment): the visible sibling
+    ``<primary-clone-parent>/agentive-config`` of this checkout,
+    resolved worktree-safely via ``--git-common-dir``.
+    ``AGENTIVE_KIT_CONFIG_DIR`` is the ONLY override — an override,
+    never a search chain. Mirrors the door's ``config_home()``; the
+    equivalence test in tests/test_setup_door.py pins the two so the
+    door and doctor can never disagree on the path. Returns None when
+    the checkout is not a git repository (no sibling to name).
+
+    Anchoring note (BugBot, PR #91): each resolver anchors to ITS OWN
+    checkout — the door to the kit clone, doctor to the project it
+    diagnoses. The two name the same folder exactly when kit and
+    project share a parent (the documented sibling layout); a consumer
+    checkout has no pointer to the kit clone's local path, so the
+    kit's parent is not computable from here. When the layouts
+    diverge, the override pins the real location, and every output
+    line below names the resolved path so the anchor is visible.
+    """
+    override = os.environ.get("AGENTIVE_KIT_CONFIG_DIR")
+    if override:
+        # leading-~ expansion mirrors the bash resolvers (env files can
+        # carry a literal tilde the shell never expanded)
+        return Path(override).expanduser()
+    # scrub GIT_* — a leaked GIT_DIR would resolve the WRONG primary
+    # clone (the KIT-0043 incident class; this runs in-process, so the
+    # driver's per-check scrub does not cover it)
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(project_dir),
+                "rev-parse",
+                "--git-common-dir",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    common = result.stdout.strip()
+    if result.returncode != 0 or not common:
+        return None
+    # KIT-0080: plain --git-common-dir, absolutized here. The
+    # --path-format=absolute form needs git >= 2.31; Apple's system git
+    # (2.30.1) echoes the flag back as an output line and exits 0, so
+    # `common` became "--path-format=absolute\n<path>" and the home
+    # resolved to garbage. Plain output is RELATIVE to the -C directory
+    # (both gits return a bare ".git" from a primary clone), so anchor
+    # it on project_dir — never on the process cwd. `/` already discards
+    # the left operand when `common` is absolute.
+    #
+    # No .resolve(): that would follow symlinked ancestors and report a
+    # PHYSICAL path, diverging from the bash resolvers this function is
+    # pinned equivalent to (tests/test_setup_door.py). os.path.normpath
+    # collapses the "<root>/.git" join without touching symlinks.
+    # Two levels: `joined` is <primary-clone>/.git, so .parent is the
+    # clone root and .parent.parent its PARENT, where the visible
+    # agentive-config sibling lives.
+    joined = Path(os.path.normpath(Path(project_dir) / common))
+    return joined.parent.parent / "agentive-config"
+
+
+def _print_preset_comparison(shape, profile, bots, record_errors, project_dir):
+    """`doctor --against-preset` (KIT-0056 F8, ADR-0027 P7): compare
+    the project's kit-install record against the operator preset at
+    ``<kit-parent>/agentive-config/preset`` (KIT-0058;
+    ``AGENTIVE_KIT_CONFIG_DIR`` overrides the location).
+
+    INFO-only by design: divergence is reported as
+    ``PRESET:<field>:INFO:<detail>`` lines and NEVER as WARN/FAIL, and
+    the doctor exit code is never affected — a deliberately-lean
+    project is not wrong. Doctor validates the RECORD (the DOCTOR:
+    lines above); the preset is only a comparison baseline. The
+    PRESET: prefix keeps these lines out of DOCTOR: parsers entirely.
+
+    Keys other than shape/profile/bots are ignored here by design:
+    the door owns the preset-key vocabulary (unknown keys WARN there);
+    duplicating its key list in this comparator would be a second
+    source of truth that drifts. Structural faults shared with the
+    door's parser (malformed lines, duplicate keys) do get reported —
+    as INFO, with the comparison skipped whole.
+    """
+    home = _config_home(project_dir)
+    print()
+    if home is None:
+        print(
+            f"PRESET:comparison:INFO:cannot locate the config home "
+            f"({project_dir} is not a git clone) — nothing to compare"
+        )
+        return
+    preset_path = home / "preset"
+    if not preset_path.is_file():
+        print(
+            f"PRESET:comparison:INFO:no preset found at {preset_path} — "
+            "nothing to compare (the path anchors to this project's "
+            "primary-clone parent; set AGENTIVE_KIT_CONFIG_DIR if your "
+            "config home lives beside the kit clone elsewhere)"
+        )
+        return
+    try:
+        preset_lines = preset_path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        print(
+            f"PRESET:comparison:INFO:preset unreadable "
+            f"({exc.__class__.__name__}) — comparison skipped"
+        )
+        return
+    preset_values = {}
+    for lineno, line in enumerate(preset_lines, 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            # loud, names the line, and skips the WHOLE comparison — a
+            # partial read could report agreement on fields it never
+            # parsed (the masking class, record-reader face)
+            print(
+                f"PRESET:comparison:INFO:preset malformed at line {lineno} "
+                f"('{stripped}') — fix {preset_path}; comparison skipped"
+            )
+            return
+        key, _, value = stripped.partition(":")
+        key = key.strip()
+        if key in preset_values:
+            # same duplicate rule as the door's load_preset — silently
+            # letting the last value win could compare against a value
+            # the door would refuse to load
+            print(
+                f"PRESET:comparison:INFO:duplicate preset key '{key}' at "
+                f"line {lineno} — fix {preset_path}; comparison skipped"
+            )
+            return
+        preset_values[key] = value.strip()
+
+    if shape is None or profile is None:
+        print(
+            "PRESET:comparison:INFO:kit-install record unreadable "
+            "(see the DOCTOR record FAIL lines) — comparison skipped"
+        )
+        return
+
+    bots_errored = any(record == "bots-record" for record, _ in record_errors)
+    record_values = {
+        "shape": shape,
+        "profile": profile,
+        # absent bots line = both expected (the pre-KIT-0056 default)
+        "bots": bots if bots is not None else "coderabbit bugbot",
+    }
+    defaulted = {"bots": bots is None}
+    # Vocabulary checks mirror the door's validate_values: a preset
+    # value the door would refuse to install must read as malformed
+    # preset data here, never as legitimate divergence (CodeRabbit).
+    valid_vocab = {
+        "shape": ("single", "planning"),
+        "profile": ("python", "none"),
+    }
+    if (
+        preset_values.get("shape") == "planning"
+        and preset_values.get("profile") == "python"
+    ):
+        print(
+            "PRESET:comparison:INFO:preset declares an illegal pair "
+            "(planning forces profile none) — fix the preset; "
+            "shape/profile comparison skipped"
+        )
+        preset_values.pop("shape", None)
+        preset_values.pop("profile", None)
+    compared = 0
+    divergences = 0
+    for key in ("shape", "profile", "bots"):
+        preset_val = preset_values.get(key, "")
+        if not preset_val:
+            continue
+        if key in valid_vocab and preset_val not in valid_vocab[key]:
+            print(
+                f"PRESET:{key}:INFO:preset {key} value invalid "
+                f"('{preset_val}') — {key} comparison skipped"
+            )
+            continue
+        if key == "bots":
+            if bots_errored:
+                print(
+                    "PRESET:bots:INFO:recorded bots declaration is invalid "
+                    "(see DOCTOR:bots-record above) — bots comparison skipped"
+                )
+                continue
+            normalized = _normalize_bots(preset_val)
+            if normalized is None:
+                print(
+                    f"PRESET:bots:INFO:preset bots value invalid "
+                    f"('{preset_val}') — bots comparison skipped"
+                )
+                continue
+            preset_val = normalized
+        compared += 1
+        if preset_val != record_values[key]:
+            suffix = (
+                " (defaulted — no line in the record)" if defaulted.get(key) else ""
+            )
+            print(
+                f"PRESET:{key}:INFO:record has '{record_values[key]}'{suffix}, "
+                f"preset says '{preset_val}' — informational only, a "
+                "deliberately-lean project is not wrong"
+            )
+            divergences += 1
+    if compared == 0:
+        print(
+            "PRESET:comparison:INFO:preset answers none of the comparable "
+            "fields (shape/profile/bots) — nothing to compare"
+        )
+    elif divergences == 0:
+        print(
+            f"PRESET:comparison:INFO:record matches the preset on all "
+            f"{compared} compared field(s)"
+        )
+
+
+def cmd_doctor(args, project_dir):
+    """`project doctor`: run all doctor.d environment checks (ADR-0027 P4).
+
+    Composable driver: every executable in scripts/core/doctor.d/ runs;
+    a failing check never short-circuits its siblings (the fail-fast-
+    masking lesson from the sync workflow). Checks emit
+    ``DOCTOR:<name>:<verdict>:<detail>`` lines — <name> and <verdict>
+    are colon-free tokens, <detail> is everything after the third colon
+    (parsers split on the first three colons only, exactly like the
+    preflight GATE: format). Verdicts: PASS, WARN, FAIL, SKIP.
+
+    Exit-code contract (F3 — driver errors never overload 0/1):
+      0  every check PASS or SKIP
+      1  at least one FAIL
+      2  warnings only (no FAIL)
+      3  driver/usage error (unknown flag, doctor.d missing or empty)
+
+    Read-only (N3): the driver and every check diagnose the environment;
+    they never mutate config, env, or the working tree.
+    """
+    doctor_dir = project_dir / "scripts" / "core" / "doctor.d"
+    against_preset = False
+    for arg in args:
+        # An empty value would resolve Path("") to the cwd and silently
+        # diagnose the wrong tree — usage error instead (BugBot round 6).
+        if arg == "--against-preset":
+            # KIT-0056 F8: compare the record against the operator
+            # preset, INFO-only (see _print_preset_comparison).
+            against_preset = True
+        elif arg.startswith("--dir="):
+            # test/advanced seam: run a different check set (resolve now —
+            # checks run with a different cwd, so relative would break)
+            value = arg.partition("=")[2]
+            if not value:
+                print("❌ --dir= requires a path")
+                return 3
+            doctor_dir = Path(value).resolve()
+        elif arg.startswith("--root="):
+            # diagnose another checkout (e.g. the primary clone from a
+            # worktree); checks receive it as DOCTOR_ROOT
+            value = arg.partition("=")[2]
+            if not value:
+                print("❌ --root= requires a path")
+                return 3
+            project_dir = Path(value).resolve()
+            if not project_dir.is_dir():
+                print(f"❌ --root is not a directory: {project_dir}")
+                return 3
+        else:
+            print(f"Unknown option: {arg}")
+            print(
+                "Usage: ./scripts/core/project doctor "
+                "[--dir=<checks-dir>] [--root=<checkout>] [--against-preset]"
+            )
+            return 3
+
+    if not doctor_dir.is_dir():
+        print(f"❌ doctor checks directory not found: {doctor_dir}")
+        return 3
+    # dotfiles (.DS_Store & friends) are never checks — everything else
+    # in doctor.d/ is held to the check contract
+    checks = sorted(
+        p for p in doctor_dir.iterdir() if p.is_file() and not p.name.startswith(".")
+    )
+    if not checks:
+        print(f"❌ no checks found in {doctor_dir}")
+        return 3
+
+    # Per-shape inclusion (KIT-0048, fills the P2 seam) and per-profile
+    # inclusion (KIT-0050 F5): checks declare their shapes/profiles in
+    # `# shapes:` / `# profiles:` headers; the driver reads the install
+    # record once and stays otherwise declaration-driven. A malformed
+    # record runs everything AND fails loud via the record lines below.
+    shape, profile, bots, record_errors = _doctor_install(project_dir)
+
+    # Scrub ambient GIT_* so a leaked GIT_DIR (the KIT-0043 incident
+    # class — e.g. doctor invoked from a pre-commit hook in a worktree)
+    # cannot redirect git-facing checks at the wrong repository.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["DOCTOR_ROOT"] = str(project_dir)
+    verdicts = []
+    for record, detail in record_errors:
+        print(f"DOCTOR:{record}:FAIL:{detail}")
+        verdicts.append("FAIL")
+    for check in checks:
+        name = check.name
+        declared = _check_declared(check, "shapes")
+        if shape is not None and declared is not None and shape not in declared:
+            print(
+                f"DOCTOR:{name}:SKIP:not applicable to shape '{shape}' "
+                f"(check declares: {' '.join(sorted(declared))})"
+            )
+            verdicts.append("SKIP")
+            continue
+        declared_profiles = _check_declared(check, "profiles")
+        if (
+            profile is not None
+            and declared_profiles is not None
+            and profile not in declared_profiles
+        ):
+            print(
+                f"DOCTOR:{name}:SKIP:not applicable to profile '{profile}' "
+                f"(check declares: {' '.join(sorted(declared_profiles))})"
+            )
+            verdicts.append("SKIP")
+            continue
+        if not os.access(check, os.X_OK):
+            print(f"DOCTOR:{name}:FAIL:check file is not executable")
+            verdicts.append("FAIL")
+            continue
+        try:
+            result = subprocess.run(
+                [str(check)],
+                cwd=project_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"DOCTOR:{name}:FAIL:check timed out after 30s")
+            verdicts.append("FAIL")
+            continue
+        except OSError as exc:
+            print(f"DOCTOR:{name}:FAIL:check failed to run ({exc.__class__.__name__})")
+            verdicts.append("FAIL")
+            continue
+
+        emitted = False
+        for line in result.stdout.splitlines():
+            if not line.startswith("DOCTOR:"):
+                continue
+            parts = line.split(":", 3)
+            # F1 field contract: exactly DOCTOR:<name>:<verdict>:<detail>
+            # with non-empty name and detail — an incomplete record must
+            # not be able to count as a pass (CodeRabbit round 2)
+            malformed = len(parts) < 4 or not parts[1] or not parts[3].strip()
+            verdict = parts[2] if len(parts) >= 3 else ""
+            # membership: verdict vocabulary check, not identifier equality
+            if malformed or verdict not in ("PASS", "WARN", "FAIL", "SKIP"):
+                # malformed line: surface it, count it as a failure
+                print(line)
+                verdicts.append("FAIL")
+                emitted = True
+                continue
+            print(line)
+            verdicts.append(verdict)
+            emitted = True
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+        if not emitted:
+            print(
+                f"DOCTOR:{name}:FAIL:check produced no DOCTOR line "
+                f"(exit {result.returncode})"
+            )
+            verdicts.append("FAIL")
+        elif result.returncode != 0:
+            # a check that emitted lines but then crashed may have lost
+            # its remaining concerns — surface the crash, don't let an
+            # early PASS line mask it (fast-v2 review finding)
+            print(
+                f"DOCTOR:{name}:FAIL:check exited {result.returncode} "
+                "after emitting output — remaining concerns may be lost"
+            )
+            verdicts.append("FAIL")
+
+    fails = verdicts.count("FAIL")
+    warns = verdicts.count("WARN")
+    passes = verdicts.count("PASS")
+    skips = verdicts.count("SKIP")
+    print(f"\nDoctor: {passes} pass, {warns} warn, {fails} fail, {skips} skip")
+    if against_preset:
+        _print_preset_comparison(shape, profile, bots, record_errors, project_dir)
+    if fails:
+        return 1
+    if warns:
+        return 2
+    return 0
+
+
 def _kit_doctor():
     """Import agentive_kit.doctor with the same fallback chain as
     _kit_lifecycle (installed copy → in-repo source → loud install
@@ -1572,11 +2016,10 @@ def _kit_doctor():
             return doctor
         except ModuleNotFoundError:
             pass
-    print("❌ agentive-kit is not installed")
-    print("   The doctor now lives in the agentive-kit package")
-    print("   (KIT-ADR-0028 phase 1). Install it:")
-    print("     uv tool install agentive-kit")
-    sys.exit(1)
+    # No package anywhere: fall back to the inline driver above so
+    # package-less repos (door-made consumers pre-phase-2) keep a
+    # working doctor.
+    return None
 
 
 def cmd_sync(args, project_dir):
@@ -2001,7 +2444,9 @@ except Exception as e:
 
     elif command == "doctor":
         # Incident-mapped environment verifier (KIT-0046, ADR-0027 P4)
-        sys.exit(_kit_doctor().cmd_doctor(sys.argv[2:], project_dir))
+        _doc = _kit_doctor()
+        _run_doctor = _doc.cmd_doctor if _doc else cmd_doctor
+        sys.exit(_run_doctor(sys.argv[2:], project_dir))
 
     elif command == "sync-status":
         # Check Linear sync status

--- a/tests/agentive_kit/test_doctor_pkg.py
+++ b/tests/agentive_kit/test_doctor_pkg.py
@@ -54,3 +54,36 @@ class TestDefaultChecksDir:
             if check.name.startswith("."):
                 continue
             assert (pkg_dir / check.name).read_bytes() == check.read_bytes(), check.name
+
+
+class TestPackagedChecksExecBitFallback:
+    def test_non_executable_packaged_check_runs_via_interpreter(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # pip/sdist installs may drop the exec bit (deep evaluator,
+        # PR 2): a packaged check must run via its interpreter, not
+        # FAIL for a packaging artifact.
+        checks = tmp_path / "checks"
+        checks.mkdir()
+        stub = checks / "10-stub.py"
+        stub.write_text(
+            "print('DOCTOR:10-stub.py:PASS:ran without exec bit')\n",
+            encoding="utf-8",
+        )  # deliberately NOT chmod +x
+        monkeypatch.setattr(doctor, "PACKAGED_CHECKS_DIR", checks)
+        (tmp_path / "root").mkdir()
+        code = doctor.cmd_doctor([], tmp_path / "root")
+        out = capsys.readouterr().out
+        assert "DOCTOR:10-stub.py:PASS:ran without exec bit" in out
+        assert code == 0
+
+    def test_repo_local_checks_keep_strict_exec_contract(self, tmp_path, capsys):
+        # The strict FAIL for non-executable files is unchanged outside
+        # the packaged dir (behavior pinned by tests/test_doctor.py).
+        local = tmp_path / "root" / "scripts" / "core" / "doctor.d"
+        local.mkdir(parents=True)
+        (local / "10-inert.py").write_text("print('nope')\n", encoding="utf-8")
+        code = doctor.cmd_doctor([], tmp_path / "root")
+        out = capsys.readouterr().out
+        assert "DOCTOR:10-inert.py:FAIL:check file is not executable" in out
+        assert code == 1

--- a/tests/agentive_kit/test_doctor_pkg.py
+++ b/tests/agentive_kit/test_doctor_pkg.py
@@ -1,0 +1,56 @@
+"""Tests for agentive_kit.doctor packaging seams (KIT-0090 PR 2).
+
+The driver's behavior itself is covered by tests/test_doctor.py, which
+drives the real script (now delegating here) through the --dir= seam —
+those tests are the extraction spec. This module covers only what is
+NEW in the package: check-set resolution.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "agentive_kit", reason="agentive-kit package source present only in the kit repo"
+)
+
+from agentive_kit import doctor  # noqa: E402
+
+
+class TestDefaultChecksDir:
+    def test_repo_local_doctor_d_wins(self, tmp_path):
+        local = tmp_path / "scripts" / "core" / "doctor.d"
+        local.mkdir(parents=True)
+        assert doctor.default_checks_dir(tmp_path) == local
+
+    def test_packaged_checks_are_the_fallback(self, tmp_path):
+        resolved = doctor.default_checks_dir(tmp_path)
+        assert resolved == Path(doctor.__file__).resolve().parent / "checks"
+        assert resolved.is_dir()
+
+    def test_packaged_set_matches_repo_set(self):
+        # The packaged copy must not drift from the synced canonical
+        # set in scripts/core/doctor.d (both ship this phase).
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        repo_set = {
+            p.name
+            for p in (repo_root / "scripts/core/doctor.d").iterdir()
+            if not p.name.startswith(".")
+        }
+        pkg_dir = Path(doctor.__file__).resolve().parent / "checks"
+        pkg_set = {
+            p.name
+            for p in pkg_dir.iterdir()
+            if not p.name.startswith(".") and p.name != "__init__.py"
+        }
+        assert pkg_set == repo_set
+
+    def test_packaged_checks_keep_content_identical(self):
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        pkg_dir = Path(doctor.__file__).resolve().parent / "checks"
+        for check in (repo_root / "scripts/core/doctor.d").iterdir():
+            if check.name.startswith("."):
+                continue
+            assert (pkg_dir / check.name).read_bytes() == check.read_bytes(), check.name

--- a/tests/agentive_kit/test_doctor_pkg.py
+++ b/tests/agentive_kit/test_doctor_pkg.py
@@ -87,3 +87,28 @@ class TestPackagedChecksExecBitFallback:
         out = capsys.readouterr().out
         assert "DOCTOR:10-inert.py:FAIL:check file is not executable" in out
         assert code == 1
+
+    def test_sh_check_runs_via_bash_fallback(self, tmp_path, monkeypatch, capsys):
+        checks = tmp_path / "checks"
+        checks.mkdir()
+        stub = checks / "10-stub.sh"
+        stub.write_text(
+            "echo 'DOCTOR:10-stub.sh:PASS:bash fallback ran'\n", encoding="utf-8"
+        )  # no exec bit
+        monkeypatch.setattr(doctor, "PACKAGED_CHECKS_DIR", checks)
+        (tmp_path / "root").mkdir()
+        code = doctor.cmd_doctor([], tmp_path / "root")
+        assert "DOCTOR:10-stub.sh:PASS:bash fallback ran" in capsys.readouterr().out
+        assert code == 0
+
+    def test_unmapped_suffix_still_fails(self, tmp_path, monkeypatch, capsys):
+        checks = tmp_path / "checks"
+        checks.mkdir()
+        (checks / "10-stub.rb").write_text("puts 'nope'\n", encoding="utf-8")
+        monkeypatch.setattr(doctor, "PACKAGED_CHECKS_DIR", checks)
+        (tmp_path / "root").mkdir()
+        code = doctor.cmd_doctor([], tmp_path / "root")
+        assert "DOCTOR:10-stub.rb:FAIL:check file is not executable" in (
+            capsys.readouterr().out
+        )
+        assert code == 1

--- a/tests/test_core_manifest.py
+++ b/tests/test_core_manifest.py
@@ -140,7 +140,8 @@ class TestManifestConsistency:
 
     def test_scripts_core_count(self, manifest):
         count = len(manifest["files"]["scripts_core"])
-        assert count == 28, f"Expected 28 scripts_core entries, got {count}"
+        # 29 = 28 + doctor.d/35-handoffs-paths.py (KIT-0086 F2, PR KIT-0090/2)
+        assert count == 29, f"Expected 29 scripts_core entries, got {count}"
 
     def test_commands_core_count(self, manifest):
         count = len(manifest["files"]["commands_core"])
@@ -156,7 +157,8 @@ class TestManifestConsistency:
 
     def test_total_entry_count(self, manifest):
         total = sum(len(entries) for entries in manifest["files"].values())
-        assert total == 49, f"Expected 49 total entries, got {total}"
+        # 50 = 49 + doctor.d/35-handoffs-paths.py (KIT-0086 F2, PR KIT-0090/2)
+        assert total == 50, f"Expected 50 total entries, got {total}"
 
 
 def _planning_heredoc_core_version(engine_text: str) -> str | None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -12,6 +12,7 @@ covers the git-facing tests — no per-module env handling here.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shlex
@@ -2446,3 +2447,99 @@ class TestGitVersionFloorCheck:
         assert (
             floor in row[0]
         ), f"README git row does not state the doctor floor {floor}: {row[0]}"
+
+
+# ── 35-handoffs-paths.py: agent-handoffs.json stale-path drift (KIT-0086 F2,
+# landed via KIT-0090 PR 2) ─────────────────────────────────────────────────
+
+
+def run_handoffs_check(root: Path) -> subprocess.CompletedProcess:
+    check = DOCTOR_D / "35-handoffs-paths.py"
+    return subprocess.run(
+        [sys.executable, str(check)],
+        env={**os.environ, "DOCTOR_ROOT": str(root)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _handoffs_fixture(tmp_path: Path, details_link: str, actual_folder: str) -> Path:
+    root = tmp_path / "root"
+    context = root / ".kit" / "context"
+    context.mkdir(parents=True)
+    tasks = root / ".kit" / "tasks"
+    (tasks / actual_folder).mkdir(parents=True)
+    (tasks / actual_folder / "KIT-1234-sample.md").write_text(
+        "**Status**: In Progress\n", encoding="utf-8"
+    )
+    (context / "agent-handoffs.json").write_text(
+        json.dumps({"planner": {"details_link": details_link}}) + "\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+class TestHandoffsPathsCheck:
+    def test_fresh_path_passes(self, tmp_path):
+        root = _handoffs_fixture(
+            tmp_path, ".kit/tasks/3-in-progress/KIT-1234-sample.md", "3-in-progress"
+        )
+        result = run_handoffs_check(root)
+        assert "DOCTOR:35-handoffs-paths.py:PASS:" in result.stdout
+
+    def test_stale_path_warns_and_names_both_folders(self, tmp_path):
+        # The KIT-0086 drift shape: a branch-side move left the JSON
+        # pointing at 2-todo while the file lives in 3-in-progress.
+        root = _handoffs_fixture(
+            tmp_path, ".kit/tasks/2-todo/KIT-1234-sample.md", "3-in-progress"
+        )
+        result = run_handoffs_check(root)
+        line = [
+            ln
+            for ln in result.stdout.splitlines()
+            if ln.startswith("DOCTOR:35-handoffs-paths.py:WARN:")
+        ]
+        assert line, result.stdout
+        assert "2-todo/KIT-1234-sample.md" in line[0]
+        assert "3-in-progress/KIT-1234-sample.md" in line[0]
+        assert "KIT-0086" in line[0]
+
+    def test_gone_task_is_not_drift(self, tmp_path):
+        # A recorded path whose file exists in NO folder (archived or
+        # deleted task) is the planner's bookkeeping, not stale drift.
+        root = _handoffs_fixture(
+            tmp_path, ".kit/tasks/2-todo/KIT-9999-gone.md", "3-in-progress"
+        )
+        result = run_handoffs_check(root)
+        assert "DOCTOR:35-handoffs-paths.py:PASS:" in result.stdout
+
+    def test_missing_json_skips(self, tmp_path):
+        root = tmp_path / "root"
+        (root / ".kit" / "tasks" / "2-todo").mkdir(parents=True)
+        result = run_handoffs_check(root)
+        assert "DOCTOR:35-handoffs-paths.py:SKIP:" in result.stdout
+
+    def test_corrupt_json_warns_not_crashes(self, tmp_path):
+        root = _handoffs_fixture(
+            tmp_path, ".kit/tasks/3-in-progress/KIT-1234-sample.md", "3-in-progress"
+        )
+        (root / ".kit" / "context" / "agent-handoffs.json").write_bytes(b"\xff{broken")
+        result = run_handoffs_check(root)
+        assert "DOCTOR:35-handoffs-paths.py:WARN:" in result.stdout
+        assert "Traceback" not in result.stderr
+
+    def test_driver_runs_the_check(self, tmp_path):
+        # The check rides the standard driver contract — one real-driver
+        # pass over the real doctor.d proves registration (uses --root
+        # to keep the diagnosis off the developer's checkout).
+        root = _handoffs_fixture(
+            tmp_path, ".kit/tasks/3-in-progress/KIT-1234-sample.md", "3-in-progress"
+        )
+        result = subprocess.run(
+            [sys.executable, str(PROJECT_SCRIPT), "doctor", f"--root={root}"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert "DOCTOR:35-handoffs-paths.py:" in result.stdout

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2542,4 +2542,6 @@ class TestHandoffsPathsCheck:
             text=True,
             timeout=120,
         )
-        assert "DOCTOR:35-handoffs-paths.py:" in result.stdout
+        # PASS specifically — a bare prefix match would also accept the
+        # not-executable FAIL shape (CodeRabbit, PR #109).
+        assert "DOCTOR:35-handoffs-paths.py:PASS:" in result.stdout


### PR DESCRIPTION
## Summary

KIT-0090 PR 2, **stacked on #108** (retarget to main after #108 merges; CodeRabbit skips non-main bases until then — a fresh `@coderabbitai review` is needed post-retarget).

- `agentive_kit.doctor`: driver, kit-install record reader, config-home resolution (via `gitio.git_common_dir` — one portable resolver), preset comparison; script's `doctor` delegates with the PR-1 fallback chain
- **Per-check decision (F1, recorded)**: all 13 checks remain executable files run by the driver (the executable contract is the tested public seam); the set also ships as package data with a byte-parity test, repo-local `doctor.d` winning whenever present. Packaged checks run via suffix interpreter when pip drops exec bits (deep-evaluator finding) — repo-local strictness unchanged
- **KIT-0086 F2**: new `35-handoffs-paths.py` check WARNs on stale task paths in `agent-handoffs.json` (drift loud, no second writer); manifest + count pins updated same-commit. **F3**: workflow docs updated to the single-writer rule. With F1 (PR 1), KIT-0086 closes by reference
- `_doctor_install`/`_normalize_bots` stay in the script for `cmd_sync` (package-free for consumers until phase 3 — recorded duplication)

## Gates
- Full suite green (980 fast in hooks; doctor suites 191)
- Evaluator: fast CONCERNS (dispositions recorded), deep FAIL → exec-bit finding fixed with tests
- ⚠️ CI proof = manually dispatched run on the branch (pull_request-event anomaly, see #108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral extraction with a duplicated inline fallback path until phase 4; regressions would affect provisioning/diagnostics across consumers, though existing doctor tests are treated as the spec.
> 
> **Overview**
> **Moves the environment doctor into `agentive_kit.doctor`** (driver, kit-install reader, config-home resolution, preset comparison) and wires `./scripts/core/project doctor` to the package using the same installed-then-in-repo import pattern as lifecycle, with an **inline driver fallback** when the package is missing so door-bootstrapped consumers still work.
> 
> Checks stay **executable files** under `doctor/checks/` shipped as **package data**; `scripts/core/doctor.d` still wins when present. Packaged checks get a **`.py`/`.sh` interpreter fallback** when pip drops execute bits; repo-local checks keep the strict executable contract. Adds **`35-handoffs-paths.py`** (WARN on stale `agent-handoffs.json` task paths, KIT-0086 F2), sync manifest/count bumps, and **redacts credentials** in `90-config-home.sh` doctor output. Workflow docs restate the **single-writer** rule for `agent-handoffs.json` on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee063d39f5321a1042e382e31735d4a589d13ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->