### PR TITLE
feat(KIT-0090): publish workflow + dogfood switch — PR 4 of 4 (stacked on #110)

### DIFF
--- a/.github/workflows/publish-agentive-kit.yml
+++ b/.github/workflows/publish-agentive-kit.yml
@@ -11,11 +11,26 @@ on:
     tags:
       - "agentive-kit-v*"
 
+# One run per tag: a retried/moved tag must never race a publish for
+# the same version (PyPI accepts each version exactly once). No
+# cancellation of an in-flight publish — let it finish.
+concurrency:
+  group: publish-agentive-kit-${{ github.ref_name }}
+  cancel-in-progress: false
+
+# Least privilege: build needs repo read only; the publish job adds
+# id-token for trusted publishing.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # No later git operation in this job needs credentials.
+          persist-credentials: false
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"

--- a/.github/workflows/publish-agentive-kit.yml
+++ b/.github/workflows/publish-agentive-kit.yml
@@ -1,0 +1,56 @@
+# Publish agentive-kit to PyPI (KIT-0090 F4, KIT-ADR-0028 phase 1).
+# Shape follows the adversarial-workflow precedent: tag-triggered,
+# build + publish, nothing else. Trusted publishing (OIDC) — configure
+# the PyPI trusted publisher for this repo/workflow before the first
+# tag: project "agentive-kit", owner movito, repo agentive-starter-kit,
+# workflow publish-agentive-kit.yml, environment pypi.
+name: Publish agentive-kit
+
+on:
+  push:
+    tags:
+      - "agentive-kit-v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Verify tag matches the package version
+        run: |
+          PKG_VERSION=$(python -c "import sys; sys.path.insert(0, 'packages/agentive-kit/src'); import agentive_kit; print(agentive_kit.__version__)")
+          TAG_VERSION="${GITHUB_REF_NAME#agentive-kit-v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match agentive_kit.__version__ ($PKG_VERSION)" >&2
+            exit 1
+          fi
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build packages/agentive-kit --outdir dist/
+      - name: Smoke-test the wheel
+        run: |
+          python -m pip install dist/*.whl
+          agentive version
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.kit/context/reviews/KIT-0090-pr3-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0090-pr3-evaluator-review.md
@@ -1,0 +1,33 @@
+# KIT-0090 PR 3 — Evaluator Review Record
+
+**PR**: #110 (stacked on #109 → #108) — evaluator provisioning + KIT-0079
+**Date**: 2026-08-06
+**Ordering**: trio run BEFORE PR open
+
+## Rounds
+
+- **code-reviewer-fast**: CONCERNS — malformed-quote .env robustness
+  and `_check_declared` strictness repeats (declined, PR-2
+  dispositions); package-absent path (covered by the inline-fallback
+  design).
+- **code-reviewer (o3)**: CONCERNS — (1) option-shaped config.yml
+  library pin could reach `git clone --branch` as a git option:
+  **taken** (4bbed8a — tag-shaped validation, letters allowed, with a
+  negative test); (2) package-less planning repos fall back to the
+  frozen pyproject-only reader: **recorded as the accepted phase-1
+  state** — identical to pre-KIT-0079 behavior, `--ref` still works,
+  fully resolved once the package publishes (PR 4) and installs
+  (phase 2/3).
+
+## Scope decision raised
+
+The spec's PR 3 also listed preflight/review-input/worktree-lib —
+three bash surfaces (~1,370 lines). Ported code is a rewrite, not an
+extraction; deferred to a follow-on PR and flagged in PR #110's body
+for the planner/operator (handoff rule: raise sequencing pressure,
+never silently merge phases).
+
+## Verification
+
+Full suite 1033 passed / 12 skipped; CI green on head 4bbed8a via
+dispatched run 31142745417; BugBot clean, zero threads.

--- a/.kit/context/reviews/KIT-0090-pr4-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0090-pr4-evaluator-review.md
@@ -1,0 +1,27 @@
+# KIT-0090 PR 4 — Evaluator Review Record
+
+**PR**: stacked on #110 — publish workflow + dogfood
+**Date**: 2026-08-06. Trio run BEFORE PR open; deep verdict FAIL,
+all four findings dispositioned without code change:
+
+1. "Catch generic ImportError in _kit_lifecycle" — REFUTED by its own
+   earlier round: ModuleNotFoundError-only was o3's PR-1 round-5
+   instruction (a broken INSTALLED package must surface its real
+   error, not a false install hint). Recorded oscillation #2.
+2. "Failed editable install must be fatal / cleaned" — DECLINED: the
+   dogfood install is best-effort by design; a failed `pip install -e`
+   leaves nothing importable and every caller has the source-tree
+   fallback chain. Same non-critical pattern as the pre-commit hook
+   install in the same function.
+3. "Publish workflow imports runtime code for the version" — DECLINED:
+   agentive_kit/__init__.py is a docstring plus __version__ (stdlib-
+   only, no side effects), and setuptools' own dynamic-attr mechanism
+   performs the equivalent read at every build.
+4. "Tests for the dogfood block" — DECLINED with honesty: the block is
+   non-critical glue; the live proof is this venv running
+   installed-first with the full suite green (1033 passed, and
+   test_missing_package_fails_loud auto-skipping via its guard exactly
+   as designed in PR 1).
+
+fast: CONCERNS, repeats of prior dispositions. Full suite green before
+and after the dogfood install flip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   review-input, worktree lib) are deliberately deferred to their own
   PR — raised as a sequencing decision, not silently merged.
 
+- **agentive-kit publish + dogfood** (KIT-0090 PR 4):
+  tag-triggered PyPI publish workflow (`agentive-kit-v*` → build from
+  `packages/agentive-kit/`, wheel smoke test, trusted publishing —
+  configure the PyPI trusted publisher before the first tag). README
+  Requirements gains the install/upgrade row. `project setup` now
+  dev-installs the in-repo package (kit checkout only; CI deliberately
+  keeps testing the package-less fallback path — recorded decision),
+  and the script's help carries the one-release-cycle shim deprecation
+  note (F5).
+
 ### Changed
 
 - **`agent-handoffs.json` becomes single-writer** (KIT-0086 F1, landed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Using agents to build software works better if you add a bit of structure — An
 | **Python** | ≥ 3.10 | For code-project shapes (CI tests 3.10/3.12/3.14); planning-shape repos need only system `python3` |
 | **Claude Code** | current | The kit is built around it |
 | **uv** | optional | Easiest install path for the `adversarial` evaluation CLI (`uv tool install adversarial-workflow`) |
-| **agentive-kit** | 0.1.x | The kit's lifecycle CLI as a PyPI package (KIT-ADR-0028 phase 1, pre-consumer-migration): `uv tool install agentive-kit`, upgrade with `uv tool upgrade agentive-kit`. Inside this repo the scripts use the in-tree `packages/agentive-kit/` source automatically; `./scripts/core/project` remains as a delegating shim for one release cycle |
+| **agentive-kit** | 0.1.x | The kit's lifecycle CLI as a PyPI package (KIT-ADR-0028 phase 1, pre-consumer-migration): `uv tool install agentive-kit` (or `pipx install agentive-kit` — any isolated-CLI installer works), upgrade with `uv tool upgrade agentive-kit`. Inside this repo the scripts use the in-tree `packages/agentive-kit/` source automatically; `./scripts/core/project` remains as a delegating shim for one release cycle |
 
 `./scripts/core/project doctor` inside any created project tells you what's missing.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Using agents to build software works better if you add a bit of structure — An
 | **Python** | ≥ 3.10 | For code-project shapes (CI tests 3.10/3.12/3.14); planning-shape repos need only system `python3` |
 | **Claude Code** | current | The kit is built around it |
 | **uv** | optional | Easiest install path for the `adversarial` evaluation CLI (`uv tool install adversarial-workflow`) |
+| **agentive-kit** | 0.1.x | The kit's lifecycle CLI as a PyPI package (KIT-ADR-0028 phase 1, pre-consumer-migration): `uv tool install agentive-kit`, upgrade with `uv tool upgrade agentive-kit`. Inside this repo the scripts use the in-tree `packages/agentive-kit/` source automatically; `./scripts/core/project` remains as a delegating shim for one release cycle |
 
 `./scripts/core/project doctor` inside any created project tells you what's missing.
 

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -813,6 +813,31 @@ def cmd_setup(args):
         print(f"❌ Failed to install dependencies: {e}")
         sys.exit(1)
 
+    # Dogfood (KIT-0090 F5): dev-install the in-repo agentive-kit
+    # package when present (kit checkout only — consumer copies of
+    # this script have no packages/ tree and skip silently). CI
+    # deliberately does NOT install it, so the source-tree fallback
+    # path stays exercised there (recorded decision).
+    pkg_dir = project_dir / "packages" / "agentive-kit"
+    if (pkg_dir / "pyproject.toml").is_file():
+        print("\n📦 Dev-installing agentive-kit (dogfood)...")
+        try:
+            result = subprocess.run(
+                [str(pip), "install", "-e", str(pkg_dir)],
+                capture_output=True,
+                text=True,
+                cwd=project_dir,
+            )
+            if result.returncode == 0:
+                print("✅ agentive-kit dev-installed (CLI: agentive)")
+            else:
+                tail = (result.stderr or "").strip().splitlines()
+                print("⚠️  agentive-kit dev-install failed (non-critical)")
+                if tail:
+                    print(f"   {tail[-1]}")
+        except Exception as e:
+            print(f"⚠️  agentive-kit dev-install failed (non-critical): {e}")
+
     # 5. Install pre-commit hooks (optional - skip if pre-commit not installed)
     pre_commit = venv_dir / "bin" / "pre-commit"
     if not install_hooks:
@@ -2712,6 +2737,11 @@ Project CLI - Agentive Starter Kit
 ==================================
 
 Usage: ./scripts/core/project <command> [options]
+
+NOTE: this script is becoming a shim over the agentive-kit package
+(KIT-ADR-0028). Extracted commands already delegate; install the CLI
+with `uv tool install agentive-kit` and prefer `agentive <command>`.
+The script remains for one release cycle after the package ships.
 
 Setup:
   setup [--force] [--no-hooks]  Create venv and install dependencies


### PR DESCRIPTION
## Summary

Final PR of the KIT-0090 phase-1 series (stack: #108 → #109 → #110 → this).

- **Publish workflow** (`publish-agentive-kit.yml`): tag `agentive-kit-v*` → tag/version parity gate → build sdist+wheel from `packages/agentive-kit/` → wheel smoke test (`agentive version`) → PyPI via trusted publishing. ⚠️ Operator: configure the PyPI trusted publisher (project `agentive-kit`, this repo, workflow `publish-agentive-kit.yml`, environment `pypi`) BEFORE pushing the first tag `agentive-kit-v0.1.0`.
- **README Requirements** row: `uv tool install agentive-kit` / `uv tool upgrade`.
- **Dogfood (F5)**: `project setup` dev-installs the in-repo package (kit checkout only). Recorded decision: CI does NOT install it, keeping the package-less fallback path exercised; installed-first coverage comes from dev venvs (this worktree's suite ran 1033 green installed-first, with `test_missing_package_fails_loud` auto-skipping via its PR-1 guard).
- **Shim deprecation note** in `project help` (one release cycle, F5).

## Gates
- Full suite 1033 green (installed-first); trio run pre-open — deep FAIL fully dispositioned in `.kit/context/reviews/KIT-0090-pr4-evaluator-review.md` (includes o3 reversing its own PR-1 ModuleNotFoundError instruction — recorded oscillation)
- ⚠️ CI proof = dispatched run on the branch (pull_request anomaly, see #108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PyPI trusted publishing and version/tag gating affect release integrity; setup’s non-fatal editable install is low blast radius but changes local dev behavior for kit checkouts.
> 
> **Overview**
> Adds **tag-triggered PyPI publishing** for `agentive-kit` via `.github/workflows/publish-agentive-kit.yml`: pushes matching `agentive-kit-v*` run a build job that checks the tag against `agentive_kit.__version__`, builds from `packages/agentive-kit/`, smoke-tests the wheel (`agentive version`), then publishes through **trusted publishing** (OIDC, `pypi` environment) with concurrency pinned so in-flight publishes are not cancelled.
> 
> Documents the **PyPI install path** in the README Requirements table (`uv tool install` / upgrade) and records **KIT-0090 PR 4** in the changelog.
> 
> **Dogfood (F5):** `project setup` now best-effort `pip install -e` on the in-repo package when `packages/agentive-kit/pyproject.toml` exists; failures are non-fatal. **`project help`** notes that `./scripts/core/project` is a one-release-cycle shim toward the `agentive` CLI. Review notes for PR 3/4 are added under `.kit/context/reviews/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5fc15e0294fae4d0e3ba503c8087df388cbdc73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->