### PR TITLE
test(KIT-0093): scaffold acceptance test RED against the copying door + F4 quick fixes (PR 1 of 3)

### DIFF
--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -201,7 +201,10 @@ All commands target the code folder explicitly (`git -C <code-path>`).
      locally neither renames `origin/master` nor changes the remote
      default — first check `git -C <code-path> ls-remote --heads
      origin main`; if `origin/main` ALREADY exists, stop and ask how
-     to reconcile before any push. Otherwise, after the rename,
+     to reconcile before any push. The probe itself must SUCCEED — a
+     failing `ls-remote` (auth, network) means unknown, not absent:
+     stop and ask the user to resolve remote access. Otherwise (probe
+     succeeded, no `origin/main`), after the rename,
      `git -C <code-path> push -u origin main`, then
      `gh repo edit <owner>/<name> --default-branch main`, and only
      delete `origin/master` with the user's consent

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -206,7 +206,12 @@ All commands target the code folder explicitly (`git -C <code-path>`).
      stop and ask the user to resolve remote access. Otherwise (probe
      succeeded, no `origin/main`), after the rename,
      `git -C <code-path> push -u origin main`, then
-     `gh repo edit <owner>/<name> --default-branch main`. Delete
+     `gh repo edit <owner>/<repo> --default-branch main` — where
+     `<owner>/<repo>` is DERIVED from the existing `origin` URL (the
+     "already has a remote" rules in Edge cases), never assumed from
+     the project name: a repo whose GitHub name differs from the
+     folder must not have some OTHER repository's default flipped.
+     Delete
      `origin/master` only after BOTH of those commands succeeded AND
      with the user's consent — if either fails, stop and preserve
      `origin/master` (GitHub refuses to delete the current default

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -193,9 +193,19 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    prints `master` (a pre-existing repo, or an init that predates
    step 1's `-b main`), rename first: `git -C <code-path> branch -m
    main` (KIT-0081 F3 — a `master` first push needed a remote
-   default-branch PATCH and branch deletion to undo). Any OTHER name
-   (`dev`, a feature branch): ask the user — an existing repo's branch
-   layout is theirs; never silently rename a non-default branch.
+   default-branch PATCH and branch deletion to undo). Three guards on
+   that rename:
+   - a `main` branch ALREADY existing alongside `master` makes the
+     rename fail — stop and ask which branch to keep
+   - a remote-backed `master` (an `origin` already exists): renaming
+     locally neither renames `origin/master` nor changes the remote
+     default — after the rename, `git -C <code-path> push -u origin
+     main`, then `gh repo edit <owner>/<name> --default-branch main`,
+     and only delete `origin/master` with the user's consent
+   - EMPTY output means detached HEAD — stop and ask, never rename
+   Any OTHER name (`dev`, a feature branch): ask the user — an
+   existing repo's branch layout is theirs; never silently rename a
+   non-default branch.
    Then check for an existing remote: if the repo already has an
    `origin`, do NOT run `gh repo create` — derive `owner/repo` from
    it per the "already has a remote" rules in Edge cases (github.com

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -199,9 +199,12 @@ All commands target the code folder explicitly (`git -C <code-path>`).
      rename fail — stop and ask which branch to keep
    - a remote-backed `master` (an `origin` already exists): renaming
      locally neither renames `origin/master` nor changes the remote
-     default — after the rename, `git -C <code-path> push -u origin
-     main`, then `gh repo edit <owner>/<name> --default-branch main`,
-     and only delete `origin/master` with the user's consent
+     default — first check `git -C <code-path> ls-remote --heads
+     origin main`; if `origin/main` ALREADY exists, stop and ask how
+     to reconcile before any push. Otherwise, after the rename,
+     `git -C <code-path> push -u origin main`, then
+     `gh repo edit <owner>/<name> --default-branch main`, and only
+     delete `origin/master` with the user's consent
    - EMPTY output means detached HEAD — stop and ask, never rename
    Any OTHER name (`dev`, a feature branch): ask the user — an
    existing repo's branch layout is theirs; never silently rename a

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -189,11 +189,13 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    so it CAN be published later (`docs/CROSS-REPO-PATTERN.md`) —
    starting private costs nothing and flipping later is one setting.
 5. Before any push, verify the branch:
-   `git -C <code-path> branch --show-current` must print `main` — if
-   it prints `master` (a pre-existing repo, or an init that predates
+   `git -C <code-path> branch --show-current` must print `main`. If it
+   prints `master` (a pre-existing repo, or an init that predates
    step 1's `-b main`), rename first: `git -C <code-path> branch -m
    main` (KIT-0081 F3 — a `master` first push needed a remote
-   default-branch PATCH and branch deletion to undo).
+   default-branch PATCH and branch deletion to undo). Any OTHER name
+   (`dev`, a feature branch): ask the user — an existing repo's branch
+   layout is theirs; never silently rename a non-default branch.
    Then check for an existing remote: if the repo already has an
    `origin`, do NOT run `gh repo create` — derive `owner/repo` from
    it per the "already has a remote" rules in Edge cases (github.com

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -206,8 +206,12 @@ All commands target the code folder explicitly (`git -C <code-path>`).
      stop and ask the user to resolve remote access. Otherwise (probe
      succeeded, no `origin/main`), after the rename,
      `git -C <code-path> push -u origin main`, then
-     `gh repo edit <owner>/<name> --default-branch main`, and only
-     delete `origin/master` with the user's consent
+     `gh repo edit <owner>/<name> --default-branch main`. Delete
+     `origin/master` only after BOTH of those commands succeeded AND
+     with the user's consent — if either fails, stop and preserve
+     `origin/master` (GitHub refuses to delete the current default
+     branch, so a failed `gh repo edit` must end the cleanup, not
+     precede a deletion attempt)
    - EMPTY output means detached HEAD — stop and ask, never rename
    Any OTHER name (`dev`, a feature branch): ask the user — an
    existing repo's branch layout is theirs; never silently rename a

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -151,8 +151,12 @@ and report — do not continue against the old path.
 
 All commands target the code folder explicitly (`git -C <code-path>`).
 
-1. If the folder is not already a git repo, `git -C <code-path> init`.
-   If it is one, keep its history — do not re-init. If the existing
+1. If the folder is not already a git repo, `git -C <code-path> init
+   -b main` (`-b` needs git ≥ 2.28 — on older git, init then
+   `git -C <code-path> branch -m main`). A machine without
+   `init.defaultBranch=main` would otherwise land the first push on
+   `master` (KIT-0081 F3, happened live). If it is one, keep its
+   history — do not re-init. If the existing
    repo's working tree is dirty, show `git -C <code-path> status
    --short` and ask: commit everything as the import, or stop for the
    user to review first. If it is clean and already committed, skip
@@ -184,7 +188,13 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    the split pair keeps planning artifacts out of this repo precisely
    so it CAN be published later (`docs/CROSS-REPO-PATTERN.md`) —
    starting private costs nothing and flipping later is one setting.
-5. First check for an existing remote: if the repo already has an
+5. Before any push, verify the branch:
+   `git -C <code-path> branch --show-current` must print `main` — if
+   it prints `master` (a pre-existing repo, or an init that predates
+   step 1's `-b main`), rename first: `git -C <code-path> branch -m
+   main` (KIT-0081 F3 — a `master` first push needed a remote
+   default-branch PATCH and branch deletion to undo).
+   Then check for an existing remote: if the repo already has an
    `origin`, do NOT run `gh repo create` — derive `owner/repo` from
    it per the "already has a remote" rules in Edge cases (github.com
    origins only). Otherwise:

--- a/.kit/context/reviews/KIT-0093-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0093-evaluator-review.md
@@ -1,0 +1,28 @@
+# KIT-0093 — Evaluator review record
+
+## PR 1: scaffold acceptance test RED + F4 quick fixes
+
+**Date**: 2026-08-08
+**Input**: `.adversarial/inputs/KIT-0093-code-review-input.md` (full format, 5,782 lines — diff + full contents of changed files, so the evaluators also saw ~2,800 pre-existing lines of `scripts/core/project`)
+**Trio**: code-reviewer-fast (FAIL) · code-reviewer (FAIL) · claude-code (APPROVED)
+**Logs**: `.adversarial/logs/KIT-0093-code-review-input--{code-reviewer-fast,code-reviewer,claude-code}.md`
+
+### Disposition table
+
+| # | Evaluator | Finding | Disposition |
+|---|-----------|---------|-------------|
+| 1 | fast | `--ref` value not validated in `scripts/core/project` install-evaluators fallback (no `_is_tag_like`) | CONFIRMED, pre-existing, out of diff (this PR changed one print line in that file). The canonical package implementation HAS the validation (`evaluators.py:_is_tag_like`); the legacy inline copy is recorded duplication that retires with the script (ADR-0028 phase 3). Not fixed here. |
+| 2 | fast | `git rev-parse` not wrapped in try/except in the same fallback | Same as #1 — pre-existing legacy divergence, canonical copy handles it, dies with the shim. |
+| 3 | fast | Intake branch check only handles `master`, silent on `dev` etc. | ACCEPTED — fixed: any non-main/non-master branch now routes to "ask the user; never silently rename". |
+| 4 | fast | `gh repo create` generic failures read as deferral | Pre-existing instruction text, untouched by this diff. Declined here; candidate for a later intake polish. |
+| 5 | fast | `_referenced_paths` extension filter too narrow | ACCEPTED — broadened to `md/json/yaml/yml/sh/py`. Extensionless refs (e.g. `.kit/launchers/launch`) stay out: that file's fate is PR 2's decision table. |
+| 6 | fast | `_is_placeholder` could mask a real file named `*-XXXX-*` | Declined — no such file exists or is plausible in the kit's naming scheme; documented heuristic. |
+| 7 | fast | Contract-string assertions brittle to rewording | Declined by design — the door's printed lines ARE a contract (`displayed_commands_are_contracts`); the test is the contract's origin and PR 2 implements to it. |
+| 8 | fast | `test_no_copied_agent_bodies` only checks `*.md` | Declined — agent/skill/command bodies are `.md` by definition; non-md `.claude/` content (settings.json) is a PR 2 decision-table row, not a copy-of-agent-bodies question. |
+| 9 | deep | **Headline FAIL**: runtime allegedly reads `GOOGLE_API_KEY`, so the rename breaks Gemini | **REFUTED against the tree**: every installed evaluator declares `api_key_env: GEMINI_API_KEY` (`.adversarial/evaluators/google/*/evaluator.yml`) and the adversarial CLI resolver maps `gemini → GEMINI_API_KEY` (`resolver.py:118`). `GOOGLE_API_KEY` in the installer tail was the misnomer (KIT-0081 F4); the fix direction is correct. Classic verify-before-believing catch. |
+| 10 | deep | Package/legacy text duplication risks re-divergence | Known, recorded duplication (`scripts/core/project` header notes it); retires with the script in phase 3. Declined. |
+| 11 | deep | No test asserts the key-name happy path | Declined — key-name membership is pinned by `doctor.d/20-env-keys.py` (`RECOMMENDED_KEYS`) and its tests; an install-then-evaluate integration test would spend real API keys in CI. |
+
+### Verdict handling
+
+claude-code APPROVED. Both FAIL verdicts rest on findings triaged above: the deep FAIL's sole correctness claim is refuted with tree evidence (#9); the fast FAIL's correctness claims are pre-existing out-of-diff legacy code (#1/#2) plus the intake wording gap, which is fixed (#3). Deep rounds capped at 1 — no re-run needed: the two accepted fixes are test-scope and agent-doc wording, both re-verified locally (module green, 14 passed / 12 strict-xfail unchanged).

--- a/.kit/context/workflows/COMMIT-PROTOCOL.md
+++ b/.kit/context/workflows/COMMIT-PROTOCOL.md
@@ -236,6 +236,7 @@ If CI is still running after timeout:
 - Don't make massive commits mixing unrelated changes
 - Don't mix planner artifacts (task specs, handoffs) with implementation code in the same PR (see `PR-SIZE-WORKFLOW.md`)
 - Don't push planner artifacts to feature branches — every push restarts bot reviews. Planner commits go to main only (see planner agent Branch Isolation Policy)
+- Don't delete or de-ship a file on a directory-shaped rationale: a PR that removes a file from the repo or from any scaffold/export path must enumerate the file's FUNCTIONS (who calls it, what breaks without it) and show the scaffold acceptance test (`tests/test_scaffold_acceptance.py`) still passes (KIT-0082 F3 — the KIT-0067 launcher deletion is the incident this rule exists to prevent)
 
 ---
 

--- a/packages/agentive-kit/src/agentive_kit/evaluators.py
+++ b/packages/agentive-kit/src/agentive_kit/evaluators.py
@@ -517,5 +517,5 @@ def cmd_install_evaluators(args, project_dir):
     print()
     print("API keys needed (add to .env):")
     print("  OPENAI_API_KEY   - OpenAI evaluators")
-    print("  GOOGLE_API_KEY   - Gemini evaluators")
+    print("  GEMINI_API_KEY   - Gemini evaluators")
     print("  MISTRAL_API_KEY  - Mistral evaluators")

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1048,7 +1048,7 @@ def cmd_install_evaluators(args, project_dir):
     print()
     print("API keys needed (add to .env):")
     print("  OPENAI_API_KEY   - OpenAI evaluators")
-    print("  GOOGLE_API_KEY   - Gemini evaluators")
+    print("  GEMINI_API_KEY   - Gemini evaluators")
     print("  MISTRAL_API_KEY  - Mistral evaluators")
 
 

--- a/scripts/local/engine-consumer.sh
+++ b/scripts/local/engine-consumer.sh
@@ -477,6 +477,7 @@ rm -f "$TARGET/tests/test_kit_markers.py" \
       "$TARGET/tests/test_entrance_shims.py" \
       "$TARGET/tests/test_engine_materials.py" \
       "$TARGET/tests/test_new_worktree.py" \
+      "$TARGET/tests/test_scaffold_acceptance.py" \
       "$TARGET/tests/test_setup_door.py"
 "${RSYNC_BASE[@]}" --exclude='test_kit_markers.py' \
     --exclude='test_bootstrap_consumer.py' \
@@ -486,6 +487,7 @@ rm -f "$TARGET/tests/test_kit_markers.py" \
     --exclude='test_entrance_shims.py' \
     --exclude='test_engine_materials.py' \
     --exclude='test_new_worktree.py' \
+    --exclude='test_scaffold_acceptance.py' \
     --exclude='test_setup_door.py' \
     "$PROJECT_ROOT/tests/" "$TARGET/tests/"
 

--- a/scripts/local/engine-materials.sh
+++ b/scripts/local/engine-materials.sh
@@ -125,6 +125,8 @@ RSYNC_BASE=(rsync -a --ignore-existing --exclude='.git/' --exclude='.venv/' --ex
     --exclude='test_bots_conformance.py' \
     --exclude='test_check_hook_seeds.py' \
     --exclude='test_entrance_shims.py' \
+    --exclude='test_new_worktree.py' \
+    --exclude='test_scaffold_acceptance.py' \
     --exclude='test_setup_door.py' \
     --exclude='test_engine_materials.py' \
     "$PROJECT_ROOT/tests/" "$TARGET/tests/"

--- a/tests/test_scaffold_acceptance.py
+++ b/tests/test_scaffold_acceptance.py
@@ -41,7 +41,18 @@ import re
 from pathlib import Path
 
 import pytest
-from test_setup_door import (  # noqa: E402  (module-skips when door absent)
+
+# Explicit door check BEFORE the test_setup_door import (BugBot, this
+# PR): the docstring's module-skip promise must not depend on the
+# imported module's own guard surviving a partial scaffold.
+_DOOR = Path(__file__).resolve().parent.parent / "scripts" / "local" / "bootstrap"
+if not _DOOR.exists():
+    pytest.skip(
+        "setup door present only in the kit repo",
+        allow_module_level=True,
+    )
+
+from test_setup_door import (  # noqa: E402
     _assert_env_invariants,
     _env_lines,
     _git_identity,

--- a/tests/test_scaffold_acceptance.py
+++ b/tests/test_scaffold_acceptance.py
@@ -1,0 +1,290 @@
+"""Scaffold acceptance test — the door's output must demonstrably work.
+
+KIT-0093 F5 (absorbing KIT-0082): a fresh ``bootstrap --new`` run per
+shape is exercised end-to-end and its output asserted USABLE — not
+merely that the install steps ran. Two assertion tiers:
+
+- ``TestScaffoldInvariants``: must hold in BOTH the copying world
+  (today) and the packaged world (after the KIT-0093 PR 2 door
+  switch). These run plain.
+- ``TestPackagedWorld``: the ADR-0028 phase 2 contract — no copied
+  scripts/agents, verify-or-instruct lines for the two package
+  installs. RED against today's door by design (the red-first
+  falsifiability rule: a test born green against the old world proves
+  nothing). Marked ``xfail(strict=True)`` so CI stays green while the
+  door still copies, and the suite FAILS the moment the door changes
+  without these markers being consciously removed — PR 2 removes them.
+
+Shape-divergent findings (KIT-0081 F2/F8: the planning scaffold ships
+no agent-handoffs.json and no README) carry the xfail marker only on
+the shape where they are red today; the dangling-reference check is
+red on both shapes (the single export's agent copies reference kit
+ADRs the export deletes).
+
+Contract strings the PR 2 door must print (defined HERE first, the
+test being the contract's origin):
+- lifecycle CLI verified:    a line starting ``agentive CLI:``
+- lifecycle CLI absent:      ``Install the lifecycle CLI: uv tool install agentive-kit``
+- agent plugin verified:     ``agent plugin: verified``
+- agent plugin absent:       a line starting ``Install the agent plugin:``
+Absence of a package is always an instruction, never a hard failure
+(the KIT-0083 degradation pattern).
+
+Consumer-rsync boundary: this module reads scripts/local/ content, so
+it is excluded from the consumer tests/ rsync in engine-consumer.sh
+(exclude + rm -f sweep) and module-skips when the door is absent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from test_setup_door import (  # noqa: E402  (module-skips when door absent)
+    _assert_env_invariants,
+    _env_lines,
+    _git_identity,
+    _scrubbed_env,
+    run_door,
+)
+
+# The one marker PR 2 removes: strict, so an accidentally-flipped door
+# (or a green-by-construction assertion) fails the suite instead of
+# silently draining the test of meaning.
+RED_UNTIL_DOOR_SWITCH = pytest.mark.xfail(
+    reason="RED until KIT-0093 PR 2 switches the door to package-install mode",
+    strict=True,
+)
+
+BOTH_SHAPES_RED = pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param("single", marks=RED_UNTIL_DOOR_SWITCH),
+        pytest.param("planning", marks=RED_UNTIL_DOOR_SWITCH),
+    ],
+)
+
+BOTH_SHAPES = pytest.mark.parametrize("shape", ["single", "planning"])
+
+# KIT-0081 findings red on the planning shape only (single's git-archive
+# export happens to ship the referenced files / README today).
+PLANNING_RED = pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param("single"),
+        pytest.param("planning", marks=RED_UNTIL_DOOR_SWITCH),
+    ],
+)
+
+
+@pytest.fixture(scope="module")
+def single_scaffold(tmp_path_factory):
+    base = tmp_path_factory.mktemp("accept-single")
+    env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(base)))
+    target = base / "fresh-single"
+    result = run_door("--new", str(target), env=env)
+    return target, result, env
+
+
+@pytest.fixture(scope="module")
+def planning_scaffold(tmp_path_factory):
+    base = tmp_path_factory.mktemp("accept-planning")
+    env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(base)))
+    target = base / "fresh-planning"
+    result = run_door(
+        "--new",
+        str(target),
+        "--shape",
+        "planning",
+        "--target-path",
+        "../product",
+        env=env,
+    )
+    return target, result, env
+
+
+def _scaffold(request, shape):
+    return request.getfixturevalue(f"{shape}_scaffold")
+
+
+_REF_PATTERN = re.compile(r"`((?:docs|\.kit)/[A-Za-z0-9_./-]+\.(?:md|json|yml))`")
+
+
+def _is_placeholder(ref: str) -> bool:
+    """Example paths (`ASK-XXXX-review.md`) are illustrations, not
+    references — a dangling one is not a defect."""
+    return "XXXX" in ref or "NNNN" in ref
+
+
+def _referenced_paths(target: Path) -> dict[str, list[str]]:
+    """Backtick-quoted docs/… and .kit/… file references per seeded
+    guidance surface (CLAUDE.md + any agent copies) — the grep-and-test
+    loop from the 2026-08-04 audit (KIT-0081 F2), automated."""
+    surfaces = [target / "CLAUDE.md"]
+    agents_dir = target / ".claude" / "agents"
+    if agents_dir.is_dir():
+        surfaces.extend(sorted(agents_dir.glob("*.md")))
+    missing: dict[str, list[str]] = {}
+    for surface in surfaces:
+        text = surface.read_text(encoding="utf-8")
+        dangling = [
+            ref
+            for ref in _REF_PATTERN.findall(text)
+            if not _is_placeholder(ref) and not (target / ref).exists()
+        ]
+        if dangling:
+            missing[str(surface.relative_to(target))] = sorted(set(dangling))
+    return missing
+
+
+@pytest.mark.slow
+class TestScaffoldInvariants:
+    """Hold in both worlds: the scaffold is usable on day one."""
+
+    @BOTH_SHAPES
+    def test_install_succeeds_and_reports(self, request, shape):
+        target, result, env = _scaffold(request, shape)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "Install complete:" in result.stdout
+
+    @BOTH_SHAPES
+    def test_env_invariants(self, request, shape):
+        """KIT-0084: present, 0600, gitignored, identity filled —
+        the TestEnvSeedingE2E assertions, applied to the acceptance
+        scaffold."""
+        target, result, env = _scaffold(request, shape)
+        _assert_env_invariants(target, env)
+        lines = _env_lines(target)
+        assert f"PROJECT_NAME={target.name}" in lines
+        prefix_lines = [ln for ln in lines if ln.startswith("TASK_PREFIX=")]
+        assert prefix_lines, "TASK_PREFIX line must exist"
+        assert prefix_lines[0] != "TASK_PREFIX=TASK", "never the old placeholder"
+        if shape == "single":
+            assert prefix_lines[0] != "TASK_PREFIX=", "single shape derives a prefix"
+
+    @BOTH_SHAPES
+    def test_kit_skeleton_present(self, request, shape):
+        """The planner's Phase 1 triage paths exist."""
+        target, result, env = _scaffold(request, shape)
+        for d in (
+            "1-backlog",
+            "2-todo",
+            "3-in-progress",
+            "4-in-review",
+            "5-done",
+        ):
+            assert (target / ".kit" / "tasks" / d).is_dir(), f"missing tasks/{d}"
+        assert (target / ".kit" / "context").is_dir()
+
+    @BOTH_SHAPES
+    def test_entry_flow_reachable(self, request, shape):
+        """A cold-open session is told what to do first (KIT-0067 F3),
+        and the install record exists for every downstream reader."""
+        target, result, env = _scaffold(request, shape)
+        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "BEGIN KIT-LOCAL: kit-install" in text
+        assert "BEGIN KIT-LOCAL: first-session" in text
+
+    @BOTH_SHAPES
+    def test_doctor_ran_or_cli_instructed(self, request, shape):
+        """Green-or-actionably-instructive, never silent: either doctor
+        ran in the target, or the door printed the CLI install line."""
+        target, result, env = _scaffold(request, shape)
+        out = result.stdout
+        assert (
+            "Doctor verdict:" in out
+            or "Install the lifecycle CLI: uv tool install agentive-kit" in out
+        ), "door must run doctor or instruct installing the CLI"
+
+    @BOTH_SHAPES
+    def test_evaluator_path_pass_or_instructive(self, request, shape):
+        """The evaluator provisioning line: PASS, or an instruction the
+        operator can follow — never an unexplained failure (#103 trap)."""
+        target, result, env = _scaffold(request, shape)
+        lines = [ln for ln in result.stdout.splitlines() if "evaluator" in ln.lower()]
+        assert lines, "door output must mention the evaluator path"
+        # line-scoped, never whole-output: "Install complete:" would
+        # otherwise satisfy the instruction arm vacuously
+        assert any(
+            "pass" in ln.lower() or "install" in ln.lower() for ln in lines
+        ), f"no evaluator line passes or instructs: {lines}"
+
+    @PLANNING_RED
+    def test_readme_names_the_repo_purpose(self, request, shape):
+        """KIT-0081 F8: a scaffold whose only Finder-visible contents
+        are dot-folders reads as empty — a README must say what the
+        repo is."""
+        target, result, env = _scaffold(request, shape)
+        readme = target / "README.md"
+        assert readme.is_file(), "scaffold must ship a README.md"
+        assert readme.read_text(encoding="utf-8").strip(), "README must not be empty"
+
+    @PLANNING_RED
+    def test_agent_handoffs_exists_for_planner_triage(self, request, shape):
+        """KIT-0081 F2: the planner reads agent-handoffs.json from
+        Phase 1 on; a scaffold without it dead-ends the first session."""
+        target, result, env = _scaffold(request, shape)
+        assert (target / ".kit" / "context" / "agent-handoffs.json").is_file()
+
+    @BOTH_SHAPES_RED
+    def test_zero_dangling_references(self, request, shape):
+        """KIT-0081 F2: every docs/… and .kit/… file a seeded guidance
+        surface references must exist in the scaffold. Red on BOTH
+        shapes today (the single export's agent copies reference kit
+        ADRs the export deletes — KIT-ADR-0014/0019). Trivial by
+        construction once nothing is copied — asserted anyway."""
+        target, result, env = _scaffold(request, shape)
+        missing = _referenced_paths(target)
+        assert not missing, f"dangling references in scaffold: {missing}"
+
+
+@pytest.mark.slow
+class TestPackagedWorld:
+    """The ADR-0028 phase 2 contract — RED until the door switch."""
+
+    @BOTH_SHAPES_RED
+    def test_no_copied_core_scripts(self, request, shape):
+        """agentive-kit provides the lifecycle scripts; the scaffold
+        carries none."""
+        target, result, env = _scaffold(request, shape)
+        assert not (target / "scripts" / "core").exists(), (
+            "scripts/core must not be copied — the agentive-kit package "
+            "provides the lifecycle surface"
+        )
+
+    @BOTH_SHAPES_RED
+    def test_no_copied_agent_bodies(self, request, shape):
+        """The plugin provides agents/skills/commands; the scaffold
+        carries no copies (project specifics live in repo-owned files
+        per KIT-ADR-0025)."""
+        target, result, env = _scaffold(request, shape)
+        copied = [
+            str(p.relative_to(target))
+            for sub in ("agents", "skills", "commands")
+            for p in (target / ".claude" / sub).rglob("*.md")
+            if (target / ".claude" / sub).is_dir()
+        ]
+        assert not copied, f"agent/skill/command copies shipped: {copied}"
+
+    @BOTH_SHAPES_RED
+    def test_lifecycle_cli_verified_or_instructed(self, request, shape):
+        """The door verifies `agentive` on PATH or prints the install
+        line — the degradation pattern, never a hard fail."""
+        target, result, env = _scaffold(request, shape)
+        out = result.stdout
+        assert (
+            "agentive CLI:" in out
+            or "Install the lifecycle CLI: uv tool install agentive-kit" in out
+        ), "door must verify the agentive CLI or instruct installing it"
+
+    @BOTH_SHAPES_RED
+    def test_agent_plugin_verified_or_instructed(self, request, shape):
+        """The door verifies the agentive-workflow plugin (the
+        50-plugin-source.sh detection approach) or prints the install
+        instruction."""
+        target, result, env = _scaffold(request, shape)
+        out = result.stdout
+        assert (
+            "agent plugin: verified" in out or "Install the agent plugin:" in out
+        ), "door must verify the plugin or instruct installing it"

--- a/tests/test_scaffold_acceptance.py
+++ b/tests/test_scaffold_acceptance.py
@@ -108,7 +108,9 @@ def _scaffold(request, shape):
     return request.getfixturevalue(f"{shape}_scaffold")
 
 
-_REF_PATTERN = re.compile(r"`((?:docs|\.kit)/[A-Za-z0-9_./-]+\.(?:md|json|yml))`")
+_REF_PATTERN = re.compile(
+    r"`((?:docs|\.kit)/[A-Za-z0-9_./-]+\.(?:md|json|ya?ml|sh|py))`"
+)
 
 
 def _is_placeholder(ref: str) -> bool:


### PR DESCRIPTION
## Summary

ADR-0028 phase 2, PR 1 of 3 (task: `.kit/tasks/3-in-progress/KIT-0093-door-package-install-mode.md`).

- **F5 scaffold acceptance test** (`tests/test_scaffold_acceptance.py`, absorbing KIT-0082): runs `bootstrap --new` end-to-end per shape (single+python, planning+none) and asserts the output is USABLE, in two tiers:
  - **Invariants** (pass today AND after the switch): .env seeding invariants (reusing the `TestEnvSeedingE2E` assertions), .kit skeleton / planner triage paths, entry flow reachable (kit-install + first-session regions), doctor-ran-or-CLI-instructed, evaluator line pass-or-instructive.
  - **Packaged-world contract** (`xfail(strict=True)` — **proven RED against today's door**): zero copied `scripts/core`, zero copied agent/skill/command bodies, verify-or-instruct lines for the `agentive` CLI and the agent plugin. Strict xfail means CI is green while the door still copies, and the suite FAILS the moment the door flips without PR 2 consciously removing the markers — red-first falsifiability with no CI cost.
  - Also red today, encoding KIT-0081 findings: dangling references on BOTH shapes (the single export's agent copies cite `KIT-ADR-0014/0019`, which the export deletes), planning README (F8), planning `agent-handoffs.json` (F2).
- **Contract strings** the PR 2 door must print are defined in the test module docstring (CLI verified/instructed, plugin verified/instructed) — the test is the contract's origin.
- **F4 quick fixes**: `GEMINI_API_KEY` naming in the evaluator installer tail (package + legacy script — kit standard per `.env.template` and `doctor.d/20-env-keys.py`; runtime confirmed reading `GEMINI_API_KEY` in every `evaluator.yml` + the CLI resolver); project-intake `git init -b main` + pre-push branch check with ask-the-user on non-default branches (F3).
- **Removal rule** (KIT-0082 F3) recorded in `COMMIT-PROTOCOL.md`: de-shipping a file requires enumerating its FUNCTIONS + a green acceptance run.
- New test module added to the consumer-rsync exclusions (both the `--exclude` list and the `rm -f` sweep).

## Red-proof evidence

```
tests/test_scaffold_acceptance.py: 14 passed, 12 xfailed
```
All 12 xfails are strict — an xpass fails the suite.

## Deferred to PR 2 (decision table)

`.kit/launchers/launch` assertion (open decision, KIT-0075 F4 cross-ref), `.claude/settings.json` fate, F4 items likely moot by construction (F1 stale tail, F2 dangling refs, F7 topology placeholder, F9 dirty-tree notice).

## Evaluator trio (before PR, KIT-0035 ordering)

fast FAIL / deep FAIL / claude-code APPROVED — deep's headline (runtime reads `GOOGLE_API_KEY`) **refuted against the tree**; full dispositions in `.kit/context/reviews/KIT-0093-evaluator-review.md`.

## Test plan

- [x] Full suite green locally: 1260 passed, 13 skipped, 12 xfailed
- [x] Acceptance module: 14 passed, 12 strict-xfailed (red-first proven)
- [x] CI-equivalent lint (black/isort/flake8/ruff/pattern-lint) green
- [x] Evaluator trio run + dispositions persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new tests and agent/docs/protocol text; installer output rename aligns with existing `GEMINI_API_KEY` usage and does not change runtime key resolution.
> 
> **Overview**
> **KIT-0093 PR 1** introduces `tests/test_scaffold_acceptance.py`, which runs `bootstrap --new` for **single** and **planning** shapes and asserts the scaffold is usable today (env seeding, `.kit` skeleton, entry flow, doctor/evaluator pass-or-instruct). **Packaged-world** expectations—no copied `scripts/core` or agent bodies, CLI/plugin verify-or-instruct lines, dangling doc refs, planning README/`agent-handoffs.json`—are **`xfail(strict=True)`** so CI stays green while the door still copies and PR 2 must flip behavior and drop the markers.
> 
> **F4 fixes:** evaluator install tails now say **`GEMINI_API_KEY`** (package + legacy `scripts/core/project`). **Project-intake** uses `git init -b main` and a **pre-push branch gate** (`main` vs `master` rename with remote/default-branch guards; other branch names prompt the user). **COMMIT-PROTOCOL** adds a rule against de-shipping scaffold files without function analysis and a green acceptance run. Consumer rsync excludes the new test module; **KIT-0093 evaluator dispositions** are persisted under `.kit/context/reviews/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8789a08db6e140a6496ade4bbc836ab43beb06d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->