### PR TITLE
KIT-0101: cold-start UX contract — transparency headers, hop reasons, completion checklist (R1–R4)

### DIFF
--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -2,9 +2,9 @@
 name: project-intake
 description: Graduates a prototype into the split pair — plain code repo plus preset-configured planning repo — from a handoff brief and a code folder
 model: claude-sonnet-5
-version: 1.0.0
+version: 1.1.0
 origin: agentive-starter-kit
-last-updated: 2026-07-24
+last-updated: 2026-08-11
 created-by: "@movito (KIT-0066)"
 tools:
   - Read
@@ -36,8 +36,9 @@ tools:
 
 You are the **project-intake** agent. Run this flow yourself, directly —
 never delegate via the Task tool or spawn another agent instance. You
-are user-invoked in a new tab (operator rule: agents never run in the
-main thread).
+are user-invoked in a new tab — agent identity is fixed at session
+launch, so this role gets its own session with its own clean context
+(the operator's coordination thread stays theirs).
 
 You turn a prototype — a handoff brief plus a code folder — into the
 operator's split pair, planner-ready in one invocation:
@@ -360,32 +361,66 @@ The scan between add and commit is the same staged-content credential
 scan as Step 2.3 — the seeded content is brief-derived, and a brief
 that leaked a value must not land in the planning repo either.
 
-### Step 5: Finish loudly
+### Step 5: Finish loudly — ONE verified checklist, ONE command
 
-Print a completion summary containing, at minimum:
+The completion summary is a single checklist ending in a single
+command (format operator-specified, KIT-0101/KIT-0100 F10). Its
+binding rules:
+
+- **Every ✓ line is a claim verified at print time** — check the fact
+  (the repo exists, the push landed, the value is set) immediately
+  before printing it, never assume it from "that step ran earlier".
+- **Anything outstanding appears IN the same list as ✗** with the
+  exact remedy command — including everything the door's tail left
+  open (a missing `agentive` CLI, an uninstalled plugin, doctor
+  FAILs). "Done" and "still needed" must never contradict each other
+  across two messages: this list is the only completion statement.
+- **Relay the door's doctor tail verbatim** below the checklist —
+  never summarize it away.
+- **The closing launch command prints ONLY when the doctor reported
+  no FAILs** (and the `agentive` CLI exists — without it the doctor
+  could not run at all). It carries its opening prompt: a session
+  cannot speak first, so a bare `claude --agent planner` opens an
+  idle prompt that looks broken (KIT-0075; reproduced live under
+  native `--agent`, 2026-08-11). When there ARE failures, the last
+  line is the re-run instruction instead — never a ready-to-plan
+  next action.
+
+Format (✓/✗ per what actually happened; every line verified):
 
 ```
-📦 **PROJECT-INTAKE** | Step: Complete ✅
+📦 **PROJECT-INTAKE** | Step: Complete
 
-**<name> is planner-ready.**
+✓ Read the handoff brief (<brief path>)
+✓ Created the code repo (+ GitHub: <owner>/<name>)
+✓ Created the planning repo (<parent>/<name>-planning)
+✓ Seeded .env (task prefix: <PREFIX>)
+✓ Seeded the backlog (<N> tasks from the brief)
+✓ Verified the agentive CLI
+✓ Verified the agentive-workflow plugin
+✗ <anything outstanding> — run: <exact remedy command>
 
-  Code repo:      <parent>/<name>            <github URL or "not yet pushed">
-  Planning repo:  <parent>/<name>-planning   (private planning; manages the code repo)
-  Doctor verdict: <the door's doctor tail, relayed verbatim>
-  Task prefix:    <PREFIX>
-  Backlog seeded: <N> tasks from the brief's next steps
+Doctor tail (verbatim):
+<the door's doctor output>
 
-**Next action**: open a new tab in <parent>/<name>-planning and paste:
+You can now start working on <name>. Open a new terminal tab in
+<parent>/<name>-planning and paste:
 
   claude --agent planner "Triage the backlog and recommend what to start."
 ```
 
-That launch line must carry its opening message. A session cannot speak
-first, so a bare `claude --agent planner` opens an idle prompt and the
-operator cannot tell whether anything loaded (KIT-0075; hit again live
-under native `--agent`, 2026-08-11). The same rule applies anywhere you
-send someone to an interview-first agent: ship the first message with the
-command, or say "the agent waits for your first message — type `begin`".
+With doctor FAILs (or no CLI to run it), the closing block is instead:
+
+```
+Resolve the ✗ items above, re-run `agentive doctor` in
+<parent>/<name>-planning, THEN open the planner tab.
+```
+
+The same launch-carries-its-prompt rule applies anywhere you send
+someone to an interview-first agent: ship the first message with the
+command, or say "the agent waits for your first message — type
+`begin`". (New-session hops are kept here because agent identity is
+fixed at session launch — this session cannot become the planner.)
 
 ## Edge cases
 

--- a/.claude/commands/babysit-pr.md
+++ b/.claude/commands/babysit-pr.md
@@ -1,13 +1,22 @@
 ---
 description: Monitor a PR through bot reviews, triage threads, fix issues, and repeat until clean
 argument-hint: "[optional PR number]"
-version: 1.0.0
+version: 1.1.0
 origin: agentive-starter-kit
-last-updated: 2026-03-25
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Babysit PR
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/babysit-pr` — monitors a PR through bot-review cycles: wait,
+> triage, fix, push, repeat until clean (max 10 cycles).
+> Reads: PR reviews/threads/checks via `gh` · Writes: commits and
+> pushes to the PR branch, thread replies/resolutions on GitHub
+> Source: [babysit-pr.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/babysit-pr.md) · Docs: [review-fix workflow](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/REVIEW-FIX-WORKFLOW.md)
 
 Monitor the current PR (or PR `$ARGUMENTS`) through bot review cycles.
 Wait for bots, triage findings, fix issues, push, and repeat until the PR

--- a/.claude/commands/check-bots.md
+++ b/.claude/commands/check-bots.md
@@ -1,14 +1,23 @@
 ---
 description: Check if BugBot and CodeRabbit have posted reviews on the current PR
 argument-hint: "[optional PR number] [--repo owner/name]"
-version: 1.1.0
+version: 1.2.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-04-20
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Check Bot Review Status
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/check-bots` — reports whether BugBot and CodeRabbit have
+> reviewed the current PR's HEAD commit.
+> Reads: PR reviews/checks via `gh` (`scripts/core/check-bots.sh`),
+> `CLAUDE.md` target-repo pointer · Writes: nothing
+> Source: [check-bots.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/check-bots.md) · Docs: [review-fix workflow](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/REVIEW-FIX-WORKFLOW.md)
 
 Check bot review status for the current PR (or PR `$ARGUMENTS` if specified).
 

--- a/.claude/commands/check-ci.md
+++ b/.claude/commands/check-ci.md
@@ -13,7 +13,7 @@ created-by: "@movito with planner2"
 other output or tool call:**
 
 > 🧭 `/check-ci` — verifies GitHub Actions status for a branch and
-> reports a PASS/FAIL/IN-PROGRESS verdict.
+> reports PASS, FAIL, IN PROGRESS, or MIXED.
 > Reads: workflow runs via `gh` (`scripts/core/verify-ci.sh`),
 > `CLAUDE.md` target-repo pointer · Writes: nothing (unless you ask
 > it to retrigger CI, which it announces first)

--- a/.claude/commands/check-ci.md
+++ b/.claude/commands/check-ci.md
@@ -1,6 +1,6 @@
 ---
 description: Verify GitHub Actions CI/CD status for a branch
-version: 1.5.0
+version: 1.6.0
 origin: dispatch-kit
 origin-version: 0.3.2
 last-updated: 2026-08-11
@@ -8,6 +8,16 @@ created-by: "@movito with planner2"
 ---
 
 # Check CI/CD Status
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/check-ci` — verifies GitHub Actions status for a branch and
+> reports a PASS/FAIL/IN-PROGRESS verdict.
+> Reads: workflow runs via `gh` (`scripts/core/verify-ci.sh`),
+> `CLAUDE.md` target-repo pointer · Writes: nothing (unless you ask
+> it to retrigger CI, which it announces first)
+> Source: [check-ci.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/check-ci.md)
 
 Verify that GitHub Actions workflows have passed for a specific branch.
 

--- a/.claude/commands/check-spec.md
+++ b/.claude/commands/check-spec.md
@@ -1,13 +1,22 @@
 ---
 description: Check Spec Compliance
-version: 1.7.0
+version: 1.8.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-08-09
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Check Spec Compliance
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/check-spec` — traces every task requirement to code and tests
+> before you commit; reports PASS/PARTIAL/FAIL.
+> Reads: the task spec in `.kit/tasks/`, the full diff and changed
+> files · Writes: optionally `.adversarial/inputs/<TASK-ID>-spec-compliance-input.md`
+> Source: [check-spec.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/check-spec.md) · Docs: [task completion protocol](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md)
 
 Verify that all task requirements are implemented before committing.
 

--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,14 +1,23 @@
 ---
 description: Commit all changes, push to remote, and open a pull request
 argument-hint: "[optional commit message override]"
-version: 1.0.0
+version: 1.1.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-02-27
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Commit, Push, and Open PR
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/commit-push-pr` — stages your changes, commits, pushes, and
+> opens a pull request, then runs an informational preflight.
+> Reads: git status/diff/log · Writes: a commit on the current
+> branch, a push to origin, a GitHub PR
+> Source: [commit-push-pr.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/commit-push-pr.md) · Docs: [commit protocol](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/COMMIT-PROTOCOL.md)
 
 ## Step 1: Gather context
 

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -17,9 +17,11 @@ other output or tool call:**
 
 > 🧭 `/new-project` — interviews you in plain language and creates
 > your new project, via the setup door or the intake agent.
-> Reads: `./scripts/local/bootstrap --help`, your operator preset ·
-> Writes: the new project's directory (door route) — nothing in this
-> repo
+> Reads: `./scripts/local/bootstrap --help`, your operator preset;
+> on the prototype route, your brief file and code folder (to
+> validate them) · Writes: the new project's directory (door route);
+> the intake route only prints a handoff — nothing in this repo
+> either way
 > Source: [new-project.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/new-project.md) · Docs: [starting a project](https://github.com/movito/agentive-starter-kit/blob/main/docs/STARTING-A-PROJECT.md)
 
 Create a new project from this kit — the front door to the factory

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -1,8 +1,8 @@
 ---
 description: Interview the user and create their new project through the setup door or the intake agent
-version: 1.1.0
+version: 1.2.0
 origin: agentive-starter-kit
-last-updated: 2026-07-28
+last-updated: 2026-08-11
 created-by: "@movito with feature-developer-f5 (KIT-0067)"
 distribution: builder-only
 ---
@@ -11,6 +11,16 @@ distribution: builder-only
 
 > **Builder-side command**: operates the kit factory; not distributed
 > via `scripts/.core-manifest.json` (intended — see KIT-0077).
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/new-project` — interviews you in plain language and creates
+> your new project, via the setup door or the intake agent.
+> Reads: `./scripts/local/bootstrap --help`, your operator preset ·
+> Writes: the new project's directory (door route) — nothing in this
+> repo
+> Source: [new-project.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/new-project.md) · Docs: [starting a project](https://github.com/movito/agentive-starter-kit/blob/main/docs/STARTING-A-PROJECT.md)
 
 Create a new project from this kit — the front door to the factory
 flow described in `docs/STARTING-A-PROJECT.md`. Interview the user in
@@ -87,8 +97,10 @@ Before handing off, confirm the brief is a readable, non-empty file
 and the code path is a directory — a dangling or wrong-kind path
 should be caught here, not by the intake agent one tab later.
 
-Then hand off — agents run in a **new tab**, never in this session.
-Print the invocation for the user:
+Then hand off to a new tab — and say why when you print it: **agent
+identity is fixed at session launch**, so this session cannot become
+`project-intake` mid-flight, and the intake's contract needs a fresh
+context of its own. Print the invocation for the user:
 
 ```text
 ⚠️ LAUNCH
@@ -149,7 +161,11 @@ handoff — do not run the door yourself on this route.
 ## Step 3: finish loudly
 
 End with the LAUNCH line for wherever work continues (the door route:
-the created project; on a planning shape, that's the planning repo):
+the created project; on a planning shape, that's the planning repo).
+State the reason for the hop alongside it: the planner must run **in
+the created project's own directory** with the project's files and
+CLAUDE.md around it, and agent identity is per-session — this session
+cannot become the planner:
 
 ```text
 ⚠️ LAUNCH

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,14 +1,23 @@
 ---
 description: Check all 7 completion gates before requesting human review
 argument-hint: "[optional --pr PR_NUMBER --task TASK_ID --repo owner/name]"
-version: 1.4.0
+version: 1.5.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-08-09
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Preflight Check
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/preflight` — runs all 7 completion gates and presents a
+> PASS/FAIL table with a READY / NOT READY verdict.
+> Reads: CI, bot reviews, and threads via `gh`; `.kit/` review
+> artifacts in the planning repo · Writes: nothing
+> Source: [preflight.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/preflight.md) · Docs: [task completion protocol](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md)
 
 Run all 7 completion gates and present a PASS/FAIL table.
 

--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -1,13 +1,22 @@
 ---
 description: Run a structured session retrospective after completing a task
-version: 1.3.0
+version: 1.4.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-08-09
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Session Retrospective
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/retro` — runs a structured session retrospective: scorecard
+> metrics, reflections, incident closure.
+> Reads: PR metrics via `gh`, this session's history · Writes:
+> `.kit/context/retros/<TASK-ID>-retro.md` in the planning repo
+> Source: [retro.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/retro.md) · Docs: [task completion protocol](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md)
 
 Run a structured retro for the current task session. Collects metrics from the PR and produces formatted output for the planner to archive.
 

--- a/.claude/commands/setup-preset.md
+++ b/.claude/commands/setup-preset.md
@@ -1,8 +1,8 @@
 ---
 description: Interview the user and author their setup-door preset in the visible config home
-version: 1.1.0
+version: 1.2.0
 origin: agentive-starter-kit
-last-updated: 2026-07-28
+last-updated: 2026-08-11
 created-by: "@movito with feature-developer-f5 (KIT-0058)"
 distribution: builder-only
 ---
@@ -11,6 +11,17 @@ distribution: builder-only
 
 > **Builder-side command**: operates the kit factory; not distributed
 > via `scripts/.core-manifest.json` (intended — see KIT-0077).
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/setup-preset` — interviews you in plain language and writes
+> your setup-door preset, so future project creation runs on your
+> answers.
+> Reads: `./scripts/local/bootstrap --help`, any existing preset ·
+> Writes: `<kit-parent>/agentive-config/preset` (secrets by path
+> reference only — never values)
+> Source: [setup-preset.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/setup-preset.md) · Docs: [starting a project](https://github.com/movito/agentive-starter-kit/blob/main/docs/STARTING-A-PROJECT.md)
 
 Author (or update) the operator preset for the setup door
 (`scripts/local/bootstrap`) by interviewing the user in plain

--- a/.claude/commands/setup-preset.md
+++ b/.claude/commands/setup-preset.md
@@ -19,7 +19,8 @@ other output or tool call:**
 > your setup-door preset, so future project creation runs on your
 > answers.
 > Reads: `./scripts/local/bootstrap --help`, any existing preset ·
-> Writes: `<kit-parent>/agentive-config/preset` (secrets by path
+> Writes: `preset` under `$AGENTIVE_KIT_CONFIG_DIR` when set;
+> otherwise `<kit-parent>/agentive-config/preset` (secrets by path
 > reference only — never values)
 > Source: [setup-preset.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/setup-preset.md) · Docs: [starting a project](https://github.com/movito/agentive-starter-kit/blob/main/docs/STARTING-A-PROJECT.md)
 

--- a/.claude/commands/start-task.md
+++ b/.claude/commands/start-task.md
@@ -1,14 +1,24 @@
 ---
 description: Create feature branch and start a task (move from todo to in-progress)
 argument-hint: "<TASK-ID>"
-version: 1.0.0
+version: 1.1.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-02-27
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Start Task
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/start-task` — creates the feature branch and moves the task
+> from todo to in-progress.
+> Reads: `.kit/tasks/2-todo/`, git state · Writes: a new
+> `feature/<TASK-ID>-…` branch, the task file's move to
+> `.kit/tasks/3-in-progress/`
+> Source: [start-task.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/start-task.md) · Docs: [task folders](https://github.com/movito/agentive-starter-kit/blob/main/.kit/tasks/README.md)
 
 Start working on task `$ARGUMENTS`.
 

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,13 +1,21 @@
 ---
 description: Show active tasks, recent events, and project progress
-version: 1.0.0
+version: 1.1.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-02-27
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Status Dashboard
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/status` — shows a read-only dashboard of active tasks, recent
+> commits, and project progress.
+> Reads: `.kit/tasks/` status folders, `git log` · Writes: nothing
+> Source: [status.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/status.md) · Docs: [task folders](https://github.com/movito/agentive-starter-kit/blob/main/.kit/tasks/README.md)
 
 Show the current state of the project.
 

--- a/.claude/commands/triage-threads.md
+++ b/.claude/commands/triage-threads.md
@@ -1,14 +1,24 @@
 ---
 description: Fetch and triage all review threads on the current PR
 argument-hint: "[optional PR number] [--repo owner/name]"
-version: 1.1.0
+version: 1.2.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-04-20
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Triage Review Threads
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/triage-threads` — fetches all review threads on the PR,
+> presents a fix/resolve triage table, and (after your confirmation)
+> applies the verdicts.
+> Reads: PR threads via `gh` / `agentive review-helper` · Writes:
+> after confirmation only — commits, thread replies/resolutions
+> Source: [triage-threads.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/triage-threads.md) · Docs: [review-fix workflow](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/REVIEW-FIX-WORKFLOW.md)
 
 Triage all unresolved review threads on the current PR (or PR `$ARGUMENTS` if specified).
 

--- a/.claude/commands/triage-threads.md
+++ b/.claude/commands/triage-threads.md
@@ -16,8 +16,9 @@ other output or tool call:**
 > 🧭 `/triage-threads` — fetches all review threads on the PR,
 > presents a fix/resolve triage table, and (after your confirmation)
 > applies the verdicts.
-> Reads: PR threads via `gh` / `agentive review-helper` · Writes:
-> after confirmation only — commits, thread replies/resolutions
+> Reads: PR threads via `gh` / `agentive review-helper`, `CLAUDE.md`
+> target-repo pointer · Writes: after confirmation only — commits
+> pushed to the PR branch, thread replies/resolutions on GitHub
 > Source: [triage-threads.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/triage-threads.md) · Docs: [review-fix workflow](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/REVIEW-FIX-WORKFLOW.md)
 
 Triage all unresolved review threads on the current PR (or PR `$ARGUMENTS` if specified).

--- a/.claude/commands/wait-for-bots.md
+++ b/.claude/commands/wait-for-bots.md
@@ -1,14 +1,23 @@
 ---
 description: Wait for BugBot and CodeRabbit to post reviews (polling with backoff)
 argument-hint: "[optional PR number]"
-version: 1.0.0
+version: 1.1.0
 origin: dispatch-kit
 origin-version: 0.3.2
-last-updated: 2026-02-27
+last-updated: 2026-08-11
 created-by: "@movito with planner2"
 ---
 
 # Wait for Bot Reviews
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/wait-for-bots` — polls until BugBot and CodeRabbit have both
+> reviewed the PR's HEAD (30 s interval, 15 min timeout).
+> Reads: PR reviews via `scripts/core/wait-for-bots.sh` polling ·
+> Writes: nothing
+> Source: [wait-for-bots.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/wait-for-bots.md) · Docs: [review-fix workflow](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/REVIEW-FIX-WORKFLOW.md)
 
 Wait for both bots to review the current PR. Polls every 30 seconds for up
 to 15 minutes.

--- a/.claude/commands/wrap-up.md
+++ b/.claude/commands/wrap-up.md
@@ -12,8 +12,9 @@ other output or tool call:**
 
 > 🧭 `/wrap-up` — finalizes the session: runs `/retro`, moves the
 > task to done if the PR merged, and prints a verified summary.
-> Reads: PR state via `gh`, task/starter files in `.kit/` · Writes:
-> the retro file, a task-file move (merged PRs only)
+> Reads: PR state via `gh`, `CLAUDE.md` target-repo pointer, the
+> current branch, task/starter files in `.kit/` · Writes: the retro
+> file, a task-file move (merged PRs only)
 > Source: [wrap-up.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/wrap-up.md) · Docs: [task completion protocol](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md)
 
 > **Builder-side command**: operates the kit factory; not distributed

--- a/.claude/commands/wrap-up.md
+++ b/.claude/commands/wrap-up.md
@@ -1,11 +1,20 @@
 ---
 description: Finalize session — run retro, move the task to done, and confirm completion
-version: 2.2.0
+version: 2.3.0
 last-updated: 2026-08-11
 distribution: builder-only
 ---
 
 # /wrap-up — Finalize Session
+
+**First response — open with this transparency header, before any
+other output or tool call:**
+
+> 🧭 `/wrap-up` — finalizes the session: runs `/retro`, moves the
+> task to done if the PR merged, and prints a verified summary.
+> Reads: PR state via `gh`, task/starter files in `.kit/` · Writes:
+> the retro file, a task-file move (merged PRs only)
+> Source: [wrap-up.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/wrap-up.md) · Docs: [task completion protocol](https://github.com/movito/agentive-starter-kit/blob/main/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md)
 
 > **Builder-side command**: operates the kit factory; not distributed
 > via `scripts/.core-manifest.json` (intended — see KIT-0077).

--- a/.kit/context/reviews/KIT-0101-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0101-evaluator-review.md
@@ -1,0 +1,56 @@
+# KIT-0101 — Evaluator Review Record (PR 1: R1–R4)
+
+**Date**: 2026-08-11
+**Input**: `.adversarial/inputs/KIT-0101-code-review-input.md`
+(`--format diff` — prose-dominated sweep per the handoff's policy)
+**Tier**: `code-reviewer-fast` ONLY — the deep tier
+(`code-reviewer`, `claude-code`) is **skipped by planner policy**
+(handoff "Test approach": fast-tier-only on this journey's
+prose-shaped diffs; KIT-0069/KIT-0073 precedent — the deep tier's
+spend buys nothing on prose sweeps). This record IS the Gate 5
+artifact; tree-grounded verification before merge is the real gate
+for this PR shape (bots + the R4 journey replay in the PR body).
+**Log**: `.adversarial/logs/KIT-0101-code-review-input--code-reviewer-fast.md`
+**Verdict**: CONCERNS — 3 findings, all dispositioned below.
+Per the prose-sweep rule, each was reproduced against the tree
+before disposition; none survived.
+
+## Findings and dispositions
+
+1. **[ROBUSTNESS] "intake infers doctor pass/fail by grepping
+   [PASS]/[FAIL] strings — brittle"** — **DECLINED (misreads
+   unchanged code)**. Verified against the tree: `run_doctor_tail`
+   derives its verdict from doctor's EXIT CODE
+   (`case "$doctor_exit"`, `scripts/local/bootstrap:924` — the
+   KIT-0046 F3 exit contract), not from output strings, and the
+   intake reads the relayed `Doctor verdict:` line the door prints
+   from that code. The evaluator reconstructed the unchanged
+   function from a diff-only input — the exact KIT-0069 failure
+   mode this record's tier policy anticipates.
+
+2. **[ROBUSTNESS] "printed install instructions might fail when the
+   user runs them"** — **DECLINED (by design)**. The KIT-0083
+   degradation pattern: when a dependency is absent the door cannot
+   execute the remedy, so it verifies-or-instructs, never assumes
+   and never hard-fails. A door that tried to run `uv tool install`
+   on the operator's behalf is out of scope and contrary to the
+   pattern the tests pin.
+
+3. **[TESTING] "no pytest coverage of the intake agent's composed
+   Step 5 output"** — **DECLINED (not machine-testable; covered by
+   R4)**. `project-intake` is an agent prose body — its composed
+   LLM output cannot be asserted in pytest. The task designates the
+   journey replay (R4) as the acceptance mechanism for exactly this
+   surface; the replay step log is recorded in the PR body. The
+   door-side halves of the contract ARE pinned
+   (`test_scaffold_acceptance.py` headline assertion,
+   `test_setup_door.py` forced-missing-CLI test).
+
+## Notes
+
+- One deliberate deviation from the F10 mock, flagged (not silent):
+  the closing launch command uses `claude --agent planner` (the
+  journey's consistent agent name across `new-project.md`,
+  `STARTING-A-PROJECT.md`, and scaffold seeds) where the operator's
+  mock showed `planner-f5`. Same opening prompt, same format rules.
+  Planner may override.

--- a/.kit/context/workflows/COMMAND-UX-CONTRACT.md
+++ b/.kit/context/workflows/COMMAND-UX-CONTRACT.md
@@ -1,0 +1,85 @@
+# The Command UX Contract
+
+**Origin**: KIT-0101 (operator findings F7/F9/F10, live cold-start use,
+2026-08-11). This is the single authority for how user-invocable
+commands present themselves. Command bodies carry their own concrete
+header (they are self-contained — plugin copies must not depend on
+this file existing downstream); this doc defines the pattern they
+instantiate.
+
+## 1. The transparency header (R1 / F7)
+
+Every **user-invocable** command (everything in `.claude/commands/`)
+instructs its executing agent to open its FIRST response with a
+transparency header — before any other output or tool call. Skills
+with `user-invocable: false` are internal machinery and are out of
+scope.
+
+The format, exactly three lines in one blockquote:
+
+```markdown
+> 🧭 `/<name>` — <one line: what this command does>.
+> Reads: <what it reads, where> · Writes: <what it writes, where — or "nothing">
+> Source: [<name>.md](<kit GitHub URL>) · Docs: [<page>](<kit GitHub URL>)
+```
+
+Binding rules:
+
+- **Truthful at print time**: the Reads/Writes line names the real
+  surfaces the command touches — a displayed fact is a claim
+  (the `displayed_commands_are_contracts` rule).
+- **Writes: nothing** is stated explicitly for read-only commands —
+  silence about writes is what the header exists to end.
+- **The Docs link** points at the most relevant explainer page; where
+  no genuinely relevant page exists, the Source link alone is
+  acceptable (never link a page just to fill the slot).
+
+### The dual-home link decision (recorded once, here)
+
+Twelve of the fourteen commands ship to consumers via the
+`agentive-workflow` plugin; two (`/new-project`, `/setup-preset`) are
+kit-side only. **All Source links point at the kit canonical**
+(`https://github.com/movito/agentive-starter-kit/blob/main/...`),
+never at the marketplace copy. Why:
+
+1. The marketplace file is a *derived artifact* — regenerated and
+   namespace-transformed every release, so deep links to it rot or
+   point mid-transform.
+2. The kit file is the body both homes share; its history and issues
+   live in the kit repo.
+3. Two commands have no marketplace copy at all — one URL scheme
+   covers the whole set, and the kit→marketplace refresh needs no
+   per-release link rewriting.
+
+## 2. Session hops: collapse or give the live reason (R2 / F9)
+
+Any instruction that sends the operator to a new session/tab must
+either be **collapsed** (the current session does the work inline) or
+**kept with a one-sentence reason stated in the text**. The two live
+reasons:
+
+- **Agent identity is fixed at session launch** — the current session
+  cannot become another agent mid-flight.
+- **A different contract needs fresh context** — the new role must not
+  inherit this session's working state.
+
+The launcher-era rationale (persona fragility) died with native
+`--agent` support — never cite it. A bare "open a new session with
+X" with no reason is a defect.
+
+## 3. The completion contract (R3 / F10)
+
+A flow's completion summary is ONE checklist ending in ONE command
+(format operator-specified, KIT-0100 §F10):
+
+- every ✓ line is a claim **verified at print time**, never assumed;
+- anything outstanding appears **in the same list** as ✗ with the
+  exact remedy command — "done" and "still needed" never contradict
+  across two messages;
+- the single closing launch command carries its opening prompt (a
+  session cannot speak first) and is printed **only when the doctor
+  has no FAILs** — otherwise the last line is the re-run instruction.
+
+Implemented in: `project-intake` Step 5 and the setup door's tail
+(`scripts/local/bootstrap` — contract strings pinned by
+`tests/test_scaffold_acceptance.py`).

--- a/.kit/context/workflows/COMMAND-UX-CONTRACT.md
+++ b/.kit/context/workflows/COMMAND-UX-CONTRACT.md
@@ -38,7 +38,11 @@ Binding rules:
 
 Twelve of the fourteen commands ship to consumers via the
 `agentive-workflow` plugin; two (`/new-project`, `/setup-preset`) are
-kit-side only. **All Source links point at the kit canonical**
+kit-side only. (The plugin is a separate channel from
+`scripts/.core-manifest.json` script sync — a command whose
+frontmatter says `distribution: builder-only` / "not distributed via
+the manifest" can still ship in the plugin; `/wrap-up` does.)
+**All Source links point at the kit canonical**
 (`https://github.com/movito/agentive-starter-kit/blob/main/...`),
 never at the marketplace copy. Why:
 

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -255,9 +255,11 @@ That printed path **is** the navigation mechanism: open a new Claude
 Code tab (or terminal) at that path and continue there. Two habits
 make this work:
 
-- **Agents run in new tabs, never in your main thread.** The main
-  session is for coordination; an agent invocation gets its own tab so
-  its context stays clean and yours stays yours.
+- **Agents run in new tabs, never in your main thread.** Agent
+  identity is fixed at session launch — a running session cannot
+  become another agent mid-flight — so an agent invocation gets its
+  own tab; a different contract starts on fresh context, and your
+  coordination thread stays yours.
 - **One tab per working directory.** A planning repo tab plans; a code
   repo tab codes. The printed LAUNCH path always tells you which one
   you're opening.

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -900,10 +900,21 @@ run_doctor_tail() {
         echo "Install complete: shape=$SHAPE profile=$PROFILE → $TARGET"
         return 0
     else
-        echo "Doctor not run — install the lifecycle CLI (see above), then:"
-        echo "    cd $TARGET && agentive doctor"
+        echo "Doctor not run — the lifecycle CLI is not installed."
         echo
         echo "Install complete: shape=$SHAPE profile=$PROFILE → $TARGET"
+        echo
+        # KIT-0101 R3 (KIT-0100 F10b): a missing CLI is the ONE gap
+        # that cascades (no doctor, no evaluator provisioning, no
+        # preflight), so it is the HEADLINE next step, not an inline
+        # notice. The install line must stay byte-identical to the
+        # verify_packages one — tests/test_scaffold_acceptance.py
+        # pins both, and pins move with wording in the same commit.
+        echo "━━━ NEXT STEP (required): install the lifecycle CLI ━━━"
+        echo "Nothing below works until this is done — doctor, evaluator"
+        echo "provisioning, and preflight all run through it:"
+        echo "    Install the lifecycle CLI: uv tool install agentive-kit"
+        echo "    cd $TARGET && agentive doctor"
         return 0
     fi
     local verdict

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -895,7 +895,10 @@ run_doctor_tail() {
         # upgrade instruction beats a misleading "FAILURES" verdict.
         echo "Doctor not run — the installed agentive CLI predates 'agentive doctor'."
         echo "    uv tool upgrade agentive-kit"
-        echo "    cd $TARGET && agentive doctor"
+        # %q: the line is pasted into a shell, so TARGET must be
+        # escaped — spaces or metacharacters in an operator-supplied
+        # path would otherwise break or execute (CodeRabbit, PR #125)
+        printf '    cd -- %q && agentive doctor\n' "$TARGET"
         echo
         echo "Install complete: shape=$SHAPE profile=$PROFILE → $TARGET"
         return 0
@@ -914,7 +917,8 @@ run_doctor_tail() {
         echo "Nothing below works until this is done — doctor, evaluator"
         echo "provisioning, and preflight all run through it:"
         echo "    Install the lifecycle CLI: uv tool install agentive-kit"
-        echo "    cd $TARGET && agentive doctor"
+        # %q as above — this line is a pasteable command, not display text
+        printf '    cd -- %q && agentive doctor\n' "$TARGET"
         return 0
     fi
     local verdict

--- a/tests/test_scaffold_acceptance.py
+++ b/tests/test_scaffold_acceptance.py
@@ -17,6 +17,9 @@ Contract strings the door must print (defined HERE first, the test
 being the contract's origin):
 - lifecycle CLI verified:    a line starting ``agentive CLI:``
 - lifecycle CLI absent:      ``Install the lifecycle CLI: uv tool install agentive-kit``
+- CLI-absent headline:       ``NEXT STEP (required): install the lifecycle CLI``
+  (KIT-0101 R3: the missing CLI is the one gap that cascades, so the
+  tail elevates it to the headline next step, after "Install complete:")
 - agent plugin verified:     ``agent plugin: verified``
 - agent plugin absent:       a line starting ``Install the agent plugin:``
 Absence of a package is always an instruction, never a hard failure
@@ -176,6 +179,13 @@ class TestScaffoldInvariants:
             or "Install the lifecycle CLI: uv tool install agentive-kit" in out
             or "uv tool upgrade agentive-kit" in out
         ), "door must run doctor or instruct installing/upgrading the CLI"
+        # KIT-0101 R3: when the CLI is absent (the install line fired),
+        # the tail must ALSO elevate it to the headline next step —
+        # an inline notice alone reproduced the 2026-08-11 cascade.
+        if "Install the lifecycle CLI: uv tool install agentive-kit" in out:
+            assert (
+                "NEXT STEP (required): install the lifecycle CLI" in out
+            ), "missing CLI must be the headline next step, not an inline notice"
 
     @BOTH_SHAPES
     def test_evaluator_path_pass_or_instructive(self, request, shape):

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -1354,6 +1354,9 @@ class TestMissingDependencyInstructions:
         assert "Install complete:" in out
         # The exact contract lines (test_scaffold_acceptance docstring)
         assert "Install the lifecycle CLI: uv tool install agentive-kit" in out
+        # KIT-0101 R3: the missing CLI is the one gap that cascades —
+        # the tail must elevate it to the headline next step
+        assert "NEXT STEP (required): install the lifecycle CLI" in out
         assert "Install the agent plugin:" in out
         assert "claude plugin marketplace add movito/agentive-skills" in out
         assert "claude plugin install agentive-workflow@agentive-skills" in out


### PR DESCRIPTION
## Summary

PR 1 of 2 for KIT-0101 (PR 2 = R5, the starter-template authority). Plugin release 2.0.3 follows the pair; drift guard red-by-design until then.

- **R1 (F7)** — transparency-header pattern defined once (`.kit/context/workflows/COMMAND-UX-CONTRACT.md`, incl. the dual-home link decision: Source links point at the kit canonical, never the derived marketplace copy) and swept across **all 14** user-invocable commands. Version frontmatter bumped on each.
- **R2 (F9)** — every session hop in the /new-project → intake → planner journey collapsed-or-reasoned in-text. Live reasons only (agent identity fixed at launch; fresh context for a different contract); the dead launcher-era persona rationale is nowhere cited.
- **R3 (F10)** — `project-intake` Step 5 is ONE verified checklist ending in ONE launch command, implementing the operator's format verbatim (✓ = verified at print time; ✗ inline with exact remedy; doctor tail relayed verbatim; closing command only when doctor has no FAILs). Door tail: a missing `agentive` CLI is now the **headline** NEXT STEP block. Contract pins updated in the same commit (`test_scaffold_acceptance.py`, `test_setup_door.py`).
- **R4** — journey replay recorded below.

One flagged (non-silent) deviation from the F10 mock: the closing command uses `claude --agent planner` (the journey's consistent agent name) where the mock showed `planner-f5`. See the review record; planner may override.

## R4 — journey replay step log (2026-08-11, against the fixed surfaces)

| Step | Surface | 2026-08-11 friction | Now |
|------|---------|--------------------|----|
| 1. `/setup-preset` | setup-preset.md | "typing a command and seeing stuff happen" — silent start | First response MUST open with the 🧭 header (what/reads/writes/links) before any tool call |
| 2. `/new-project` | new-project.md | same silent start; unexplained "new tab" hop to intake | 🧭 header; hop carries its reason in the printed text (identity fixed at launch; intake's contract needs fresh context); LAUNCH line carries the opening prompt (F8, KIT-0100) |
| 3. intake | project-intake.md Step 5 | intake said "plan" while the terminal said "install" — contradictory endings | Single F10 checklist: ✗ items (incl. everything the door left open) live IN the completion list with exact remedies; launch command prints ONLY with no doctor FAILs, else the last line is the re-run instruction |
| 4. door tail | scripts/local/bootstrap | missing `agentive` CLI was an inline notice that silently cascaded | Live run (PATH without agentive/claude): tail now ENDS with `━━━ NEXT STEP (required): install the lifecycle CLI ━━━` + exact commands, after "Install complete:". Happy-path run: doctor runs, verdict line unchanged |
| 5. first planner session | STARTING-A-PROJECT.md | bare "agents run in new tabs" rule with no why | Tab-handoff habit now states the live reason (identity fixed at launch) |

Both door runs executed live during this session (missing-CLI env and full-toolchain env); tails captured and matching the pinned strings.

## Grep proofs (end state)

- `grep -L "transparency header" .claude/commands/*.md` → empty (all 14 carry the block); `grep -c "🧭" .claude/commands/*.md` → 1 per file, 14 files.
- `grep -rn "open a new session with|never in this session|never in the main thread|never in your main thread"` over commands + intake + STARTING-A-PROJECT → single hit: the tab-handoff bullet that now states the live reason. Zero bare hops.
- `grep -rn "persona|launcher"` over the journey surfaces → zero (dead rationale not cited).

## Test plan

- [x] Full suite green locally: 1206 passed, 13 skipped (3.14)
- [x] `TestMissingDependencyInstructions` + `test_scaffold_acceptance.py` green (27 passed) — new headline pin exercised via forced-missing-CLI PATH
- [x] Evaluator (fast tier per policy, `--format diff`): CONCERNS, 3 findings, all reproduced against the tree and dispositioned DECLINED — record at `.kit/context/reviews/KIT-0101-evaluator-review.md`
- [ ] CI green on GitHub
- [ ] Bots triaged, all threads resolved

Task spec: `.kit/tasks/3-in-progress/KIT-0101-cold-start-ux-contract.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent/command contract changes plus bootstrap messaging; no runtime auth or data-path changes. Test pins lock the new CLI-absent tail wording.
> 
> **Overview**
> **KIT-0101** codifies cold-start operator UX in `.kit/context/workflows/COMMAND-UX-CONTRACT.md` and applies it across the `/setup-preset` → `/new-project` → `project-intake` → planner journey.
> 
> **Transparency (R1):** All **14** user-invocable `.claude/commands/*` files now require a first-response 🧭 block (what it does, reads/writes, kit-canonical source + docs links); command versions bumped.
> 
> **Session hops (R2):** `new-project`, `project-intake`, and `docs/STARTING-A-PROJECT.md` explain *why* a new tab is needed (agent identity fixed at launch; fresh context)—replacing bare “open a new session” wording.
> 
> **Completion (R3):** `project-intake` Step 5 becomes one **verified** ✓/✗ checklist, verbatim doctor tail, and a single planner launch command only when doctor has no FAILs. `scripts/local/bootstrap` prints a **headline** `NEXT STEP (required): install the lifecycle CLI` when `agentive` is missing, with shell-safe `cd -- %q` paste lines; scaffold acceptance tests pin the new strings.
> 
> Also adds `.kit/context/reviews/KIT-0101-evaluator-review.md` for the fast-tier review record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4f8cd07c51d6b158aad1c50f265930338392ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->