### PR TITLE
feat(KIT-0104): bootstrap becomes an exec shim; agentive new --no-kit (PR 2 of 3)

### DIFF
--- a/.kit/context/KIT-0104-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0104-REVIEW-STARTER.md
@@ -56,3 +56,68 @@ root. `bootstrap` untouched (exec shim = PR 2).
 - Merge gate: yours. After merge: provision PR 2's worktree/branch
   off updated main (shim + `new --no-kit` + the two follow-up tasks
   pinned to next minor), then PR 3 (prose sweep + KIT-0094).
+
+---
+
+# PR 2 of 3: the shim + `new --no-kit`
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/130
+**Branch**: `feature/KIT-0104-pr2-shim` (head `052ccac`)
+**Status**: CI green (3.10/3.12/3.14 + lint) on head, CodeRabbit
+APPROVED (latest review), BugBot pass, **8/8 threads resolved**,
+preflight 7/7 PASS, evaluator trio run pre-PR (PR 2 section of
+`.kit/context/reviews/KIT-0104-evaluator-review.md`).
+**Task**: stays 3-in-progress by design — PR 3 (prose sweep +
+KIT-0094 rider) remains.
+
+## What this PR is
+
+`scripts/local/bootstrap` → exec shim over the packaged door (execs
+the checkout's own `packages/agentive-kit/src`; help defers; one
+legacy branch, `--adopt --design-materials`, until KIT-0105);
+`agentive new <dir> --no-kit` = rung 0 from the `new` verb; the two
+pinned follow-ups filed (`1-backlog/KIT-0107` shim removal,
+`1-backlog/KIT-0108` engine consolidation — both 0.10.0).
+
+## Where to spend review attention
+
+1. `scripts/local/bootstrap` (~190 lines) — the whole shim; the
+   materials branch is the only behavior it owns.
+2. `door/__init__.py` rung-0 generalization (~40 lines) — mkdir
+   hoist + `if opts.no_kit:` branch + masking-class acks.
+3. `tests/test_setup_door.py::TestShimStatic` — the F2 grep proof as
+   a permanent test.
+4. `tests/test_bootstrap_shapes.py::TestShimEquivalence` — the
+   structural guarantee (tree-snapshot equality shim vs direct).
+
+## Recorded decisions and deviations
+
+- **Budget**: 832 additions / 3,263 deletions — over the 500 target;
+  operator approved one PR in-session (2026-08-13): the shim breaks
+  the legacy characterization instantly, so no green split lands
+  under budget.
+- **Deviations said out loud**: no TTY mode prompt in the shim (bare
+  `bootstrap` → exit 2); `--design-materials` accepts no companion
+  flags (fixed adopt/single/python); second mode flag refused
+  (stricter-loud than the old last-wins).
+- **Retirements riding the shim** (PR 1 operator decisions): legacy
+  copy-adopt gone (adopt = packaged-mode); `--no-kit` = rung 0 both
+  verbs (old seeded-record `--no-kit` gone).
+
+## Bot rounds
+
+Round 1: 7 threads (1 BugBot Medium — materials branch was missing
+the old door's kit-root refusal, fixed `7971aef`; 6 CodeRabbit minor,
+all fixed same commit). Round 2: 1 thread (equals-form targets get
+the flag-value guard, fixed `052ccac`). Round 3: clean, CodeRabbit
+APPROVED. Every thread replied + resolved.
+
+## Next (planner)
+
+- Merge gate: yours. After merge: provision PR 3's worktree/branch
+  off updated main (prose sweep F5/F6 + KIT-0094 passenger; the
+  CHANGELOG entry from this PR can be extended there).
+- Deep-evaluator NOTE for your radar (dispositioned, not actioned):
+  a root-anchored target (`agentive new /x`) resolves the preset home
+  to `/agentive-config` — edge of the PR 1 target-parent anchor
+  decision; seeding still requires the directory to already exist.

--- a/.kit/context/reviews/KIT-0104-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0104-evaluator-review.md
@@ -114,3 +114,89 @@ throughout, "test coverage genuinely strong". Actionable triage:
 Trio complete pre-PR (KIT-0035 ordering honored). Fix commits:
 `d7239d9` (fast-gate), plus the deep-tier fix commit following this
 record. All 148 door tests + full suite green after fixes.
+
+---
+
+# PR 2 section — the shim + `new --no-kit` (2026-08-13)
+
+**Change shape**: logic (bash shim rewrite + door rung-0
+generalization) → full trio per the tier rule.
+**Input**: `.adversarial/inputs/KIT-0104-code-review-input.md`
+regenerated via `agentive review-input KIT-0104 --format full`
+(10,140 lines — full post-change contents; no data-store files in this
+diff, so no exclusions needed).
+**Diff**: 832 additions / 3,263 deletions across 11 files (operator
+approved shipping as one PR over the 500-addition target: the test
+rewrite is indivisible from the shim — the shim breaks the legacy
+characterization instantly — and no green split lands under budget).
+
+## Verdicts
+
+| Evaluator | Verdict | Outcome |
+|---|---|---|
+| code-reviewer-fast (gemini-2.5-flash) | CONCERNS | 3 minor robustness notes — all declined with parity evidence (below) |
+| code-reviewer (o3-class) | FAIL | Both "blocking bugs" REFUTED against main's door; 0 findings actioned |
+| claude-code | APPROVED | 1 remediation taken (PKG_SRC probe); rest self-remediated in the report |
+
+## Dispositions
+
+### code-reviewer-fast (CONCERNS)
+
+1. `config_home` doesn't type-check a file-valued
+   `AGENTIVE_KIT_CONFIG_DIR` — PR 1 code, unchanged in this diff; the
+   evaluator's own analysis shows graceful degradation (no preset
+   loaded, no seeding). DECLINED, out of diff scope.
+2. `~user/dir` unexpanded in the shim's materials branch — byte-parity
+   with the historical door (`${TARGET/#\~/$HOME}` is the same
+   expression main uses); the branch is deprecated and dies with the
+   shim (KIT-0107). DECLINED, parity.
+3. No explicit `-x` probe on `engine-materials.sh` before exec — same
+   property as main's door (`exec "$ENGINE_MATERIALS"`); the file is
+   tracked +x. DECLINED, parity on a dying branch.
+
+### code-reviewer deep (FAIL — refuted)
+
+1. "Dash-leading target is a regression from the bash door (GNU getopt
+   allowed `--`)" — **wrong premise**: main's door never used getopt;
+   its hand-rolled parser dies `unknown argument` on any `-*`
+   non-flag, and `reject_flaglike` (a BugBot-driven guard, PR #81)
+   explicitly REFUSES dash-leading targets. Verified against
+   `git show main:scripts/local/bootstrap` (lines 364, 958-961).
+   Parity, not regression. REFUTED.
+2. "`ensure_git_identity` ignores local/.git-config and `GIT_AUTHOR_*`
+   env identity" — main's door checks exactly `--global`/`--system`
+   (line 524ff) and unsets ALL `GIT_*` at the top; the packaged door
+   mirrors both. The scrub is the deliberate KIT-0048 defense, not a
+   bug. REFUTED (parity + documented design).
+3. "`_scrubbed_env` kills legitimate `GIT_AUTHOR_*`" — same as 2:
+   deliberate, inherited, documented. REFUTED.
+4. "config_home can resolve to `/agentive-config` for a root-anchored
+   target" — real edge of the PR 1 target-parent anchor decision
+   (operator-approved 2026-08-13); seeding only touches a directory
+   that ALREADY exists and never creates it. Not this diff's code.
+   NOTED for the planner; no action in PR 2.
+5. "`AGENTIVE_KIT_CONFIG_DIR=~` seeds guard files into `$HOME`" —
+   requires the operator to point the TRUSTED override at `~`
+   (the design names the value operator-owned); same semantics as
+   main's `${VAR/#\~/$HOME}`. PR 1 code. DECLINED, out of scope.
+6. "Rung-0 `_seed_check_hook` silently preserves a pre-existing
+   non-executable hook" — preservation IS the contract: the hook is
+   consumer-owned after seeding (KIT-0050 N4;
+   `test_rebootstrap_preserves_customized_hook` pins it, and the
+   function says so out loud). REFUTED (by design).
+
+### claude-code (APPROVED)
+
+- PKG_SRC probe deepened to `agentive_kit/cli.py` (was the package
+  dir) so a hollowed-out checkout gets the install instruction, not a
+  traceback — ACTIONED in the shim.
+- PYTHONPATH trust assumption: kit-side developer tool, documented in
+  the shim header. ACCEPTED as noted.
+- TOCTOU on `--new` mkdir, `compgen` portability, `O_NOFOLLOW`
+  platform note, unreachable `preset_path=None` arm — each marked "no
+  change needed" by the evaluator itself. ACCEPTED.
+
+Trio complete pre-PR (KIT-0035 ordering honored). Fix commit for the
+probe follows this record. Full suite green (1110 passed, 13 skipped);
+grep proof of matrix single-ownership pinned as
+`tests/test_setup_door.py::TestShimStatic`.

--- a/.kit/tasks/1-backlog/KIT-0107-remove-the-bootstrap-shim.md
+++ b/.kit/tasks/1-backlog/KIT-0107-remove-the-bootstrap-shim.md
@@ -35,16 +35,17 @@ together here.
   `test_entrance_shims.py`) or, if KIT-0105 has not landed, STOP and
   re-sequence — the kit must not lose its only materials path.
 - **F3 — the packaged door's `--design-materials` refusal drops its
-  "while the shim lasts" pointer** (`agentive_kit/door/__init__.py`)
-  and points only at project-intake.
+  "while the shim lasts" pointer**
+  (`packages/agentive-kit/src/agentive_kit/door/__init__.py`) and
+  points only at project-intake.
 - **F4 — test/module sweep.** `tests/test_setup_door.py` and
   `tests/test_bootstrap_shapes.py` pin the SHIM contract — they retire
   with it (their packaged coverage already lives in
   `tests/agentive_kit/test_door_*`). `tests/test_scaffold_acceptance.py`
   re-anchors `run_door` onto the packaged CLI. Module-skip guards that
-  key on the bootstrap path (`test_door_data_sync.py`,
-  `test_bots_conformance.py`, `test_project_script.py`,
-  `test_entrance_shims.py`) need a new kit-repo sentinel.
+  key on the bootstrap path (`tests/test_door_data_sync.py`,
+  `tests/test_bots_conformance.py`, `tests/test_project_script.py`,
+  `tests/test_entrance_shims.py`) need a new kit-repo sentinel.
 - **F5 — prose sweep by class**: every surface naming
   `scripts/local/bootstrap` as a live entrance (CLAUDE.md Key Scripts
   table, docs/, `.claude/commands/new-project.md`, agent files) moves

--- a/.kit/tasks/1-backlog/KIT-0107-remove-the-bootstrap-shim.md
+++ b/.kit/tasks/1-backlog/KIT-0107-remove-the-bootstrap-shim.md
@@ -1,0 +1,64 @@
+# KIT-0107: Remove the bootstrap shim (and the materials branch with it)
+
+**Status**: Backlog
+**Priority**: medium — **pinned to the next minor kit release (0.10.0)**;
+an unenforced "one release later" is how six doors became six
+(KIT-ADR-0027 P3)
+**Type**: Deprecation removal
+**Estimated Effort**: 2-3 hours
+**Created**: 2026-08-13
+**Source**: KIT-0104 F3 (KIT-ADR-0030) — the door moved into the
+agentive-kit package as `agentive new` / `agentive adopt`;
+`scripts/local/bootstrap` stayed behind as a thin exec shim for one
+minor release, printing its own removal notice pointing at this task.
+
+## Overview
+
+`scripts/local/bootstrap` is an exec shim over
+`python3 -m agentive_kit.cli new|adopt` (it prefers the checkout's own
+`packages/agentive-kit/src`). It carries exactly one piece of behavior
+of its own: the `--adopt <dir> --design-materials` branch, which still
+drives `scripts/local/engine-materials.sh` directly because the
+interactive materials flow cannot ship as package data. Both die
+together here.
+
+## Requirements
+
+- **F1 — delete the shim.** `scripts/local/bootstrap` goes away; the
+  packaged verbs are the only door. Add the path to
+  `tests/test_entrance_shims.py::TestOldEntrancesRemoved` so a
+  resurrected copy hard-fails.
+- **F2 — the materials flow retires with it.** By then the
+  `project-intake` agent (KIT-0105, blocked on KIT-0104) is the
+  materials successor. Remove `engine-materials.sh` + its tests
+  (`tests/test_engine_materials.py`, the materials E2E in
+  `test_entrance_shims.py`) or, if KIT-0105 has not landed, STOP and
+  re-sequence — the kit must not lose its only materials path.
+- **F3 — the packaged door's `--design-materials` refusal drops its
+  "while the shim lasts" pointer** (`agentive_kit/door/__init__.py`)
+  and points only at project-intake.
+- **F4 — test/module sweep.** `tests/test_setup_door.py` and
+  `tests/test_bootstrap_shapes.py` pin the SHIM contract — they retire
+  with it (their packaged coverage already lives in
+  `tests/agentive_kit/test_door_*`). `tests/test_scaffold_acceptance.py`
+  re-anchors `run_door` onto the packaged CLI. Module-skip guards that
+  key on the bootstrap path (`test_door_data_sync.py`,
+  `test_bots_conformance.py`, `test_project_script.py`,
+  `test_entrance_shims.py`) need a new kit-repo sentinel.
+- **F5 — prose sweep by class**: every surface naming
+  `scripts/local/bootstrap` as a live entrance (CLAUDE.md Key Scripts
+  table, docs/, `.claude/commands/new-project.md`, agent files) moves
+  to the packaged verbs. Grep the class, not the instances.
+
+## Acceptance
+
+- [ ] `scripts/local/bootstrap` and `scripts/local/engine-materials.sh`
+      are gone; `TestOldEntrancesRemoved` covers both
+- [ ] No live surface instructs running `scripts/local/bootstrap`
+- [ ] Full suite green on a tree with no shim
+
+## Notes
+
+- Pinned pair: KIT-0108 (engine consolidation) shares the 0.10.0 pin;
+  landing them together deletes the `door/engines/` duplication and the
+  shim in one release.

--- a/.kit/tasks/1-backlog/KIT-0108-consolidate-the-door-engines.md
+++ b/.kit/tasks/1-backlog/KIT-0108-consolidate-the-door-engines.md
@@ -47,8 +47,10 @@ guard retires with the duplication it guarded.
 
 ## Acceptance
 
-- [ ] No file exists in two byte-pinned homes (grep proof in the PR
-      body: the `_SYNC_SOURCES` map is gone or empty)
+- [ ] Each engine has exactly one source path — pinned by an
+      EXECUTABLE assertion that fails while both the kit-tree and
+      packaged copies exist (an absent `_SYNC_SOURCES` map proves
+      nothing on its own; grep proof in the PR body as a supplement)
 - [ ] `agentive new` / `agentive adopt` E2E suite green with no
       kit-tree engine copies
 - [ ] The full suite is green on both macOS (bash 3.2/BSD) and CI Linux

--- a/.kit/tasks/1-backlog/KIT-0108-consolidate-the-door-engines.md
+++ b/.kit/tasks/1-backlog/KIT-0108-consolidate-the-door-engines.md
@@ -1,0 +1,61 @@
+# KIT-0108: Consolidate the door engines into the package
+
+**Status**: Backlog
+**Priority**: medium — **pinned to the next minor kit release (0.10.0)**,
+the same pin as KIT-0107 (the arch-review-fast disposition on KIT-0104:
+the engines-as-data interim needs a filed exit, and a missed pin is the
+parent ADR's revisit trigger)
+**Type**: Architecture / packaging
+**Estimated Effort**: 1-2 days
+**Created**: 2026-08-13
+**Source**: KIT-0104 F2 (KIT-ADR-0030) — the port shipped the Python
+front as the matrix's single owner while `engine-scaffold.sh` and
+`engine-consumer.sh` ride along as packaged data, byte-pinned to their
+kit-tree twins by `tests/test_door_data_sync.py`. That duplication is
+an interim, and this task is its filed exit.
+
+## Overview
+
+Today every engine edit must land in two homes in the same commit
+(`scripts/local/engine-*.sh` ↔
+`packages/agentive-kit/src/agentive_kit/door/engines/`), and the data
+store under `door/data/` byte-mirrors ~15 kit-tree sources. The sync
+guard makes the duplication safe, not cheap. Consolidate: the engines'
+behavior moves into `agentive_kit.door` (or the engines become
+package-only), the kit tree stops carrying a second copy, and the sync
+guard retires with the duplication it guarded.
+
+## Requirements
+
+- **F1 — one home per engine.** Either port the two engines' behavior
+  to Python inside `agentive_kit.door` (preferred — ends the bash 3.2 /
+  BSD-userland constraint for good) or make the packaged copies the
+  ONLY copies with the kit tree consuming them from the package. No
+  byte-pinned twins either way.
+- **F2 — the faux-kit-root staging disappears** once no engine resolves
+  `SCRIPT_DIR/../..` (`stage_door_root` and `_STAGE_MAP` shrink or go).
+- **F3 — `tests/test_door_data_sync.py` retires** with the duplication;
+  its "no extra files" direction survives wherever a data store remains.
+- **F4 — behavior pinned before the port**: the existing
+  `tests/agentive_kit/test_door_e2e.py` suite is the characterization
+  net; it must pass unchanged (or with deliberate, listed diffs) after
+  consolidation.
+- **F5 — kit-tree callers survive**: anything still invoking
+  `scripts/local/engine-*.sh` directly (materials flow until KIT-0107,
+  `.kit`-internal tooling, tests) is re-pointed or retired in the same
+  PR.
+
+## Acceptance
+
+- [ ] No file exists in two byte-pinned homes (grep proof in the PR
+      body: the `_SYNC_SOURCES` map is gone or empty)
+- [ ] `agentive new` / `agentive adopt` E2E suite green with no
+      kit-tree engine copies
+- [ ] The full suite is green on both macOS (bash 3.2/BSD) and CI Linux
+
+## Notes
+
+- Pinned pair: KIT-0107 (shim removal) shares the 0.10.0 pin.
+- Scope guard: this is the follow-up KIT-0104 explicitly declared out
+  of its own scope ("port, not rewrite") — the rewrite happens HERE,
+  against the E2E net, never mid-port.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The door ships in the package — KIT-ADR-0030** (KIT-0104, PRs
+  #129 + the shim PR): the setup door is now `agentive new` /
+  `agentive adopt` — same flags, same resolution chain (preset home
+  anchors to the TARGET's parent in the packaged world), same engines
+  running as packaged data, byte-pinned to their kit-tree twins by
+  `tests/test_door_data_sync.py`. Project creation no longer requires
+  standing in a kit checkout. `scripts/local/bootstrap` is a thin exec
+  shim over the packaged door (removal pinned to 0.10.0 — KIT-0107;
+  engine consolidation filed as KIT-0108) and keeps exactly one legacy
+  branch, `--adopt --design-materials`, until project-intake (KIT-0105)
+  succeeds it. Two deliberate retirements ride the shim: **adopt is
+  packaged-mode** (content scaffold + record; the legacy copy-adopt
+  that rsync'd the toolchain is gone) and **`--no-kit` is rung 0 from
+  BOTH verbs** (KIT-ADR-0032: plain repo + check hook, no `.kit/`, no
+  record — `new --no-kit` is the KIT-0104 F4 addition; the old
+  seeded-record `--no-kit` is gone). The shape × profile matrix has
+  exactly one implementation: the package.
 - **The door switches to package-install mode — KIT-ADR-0028 phase 2**
   (KIT-0093, agentive-kit 0.3.0): `bootstrap --new` (both shapes)
   scaffolds CONTENT — `.kit/` skeleton with workflow docs,

--- a/packages/agentive-kit/src/agentive_kit/door/__init__.py
+++ b/packages/agentive-kit/src/agentive_kit/door/__init__.py
@@ -37,9 +37,10 @@ here and in the KIT-0104 PR body):
 - **No kit-clone ``.env`` carry-over offer**: keys reach a new project
   via the preset's ``env-source`` (the packaged channel) or by operator
   hand — there is no kit checkout to copy from.
-- **``--no-kit`` adopt is rung 0** (KIT-ADR-0032): check hook + git
-  init only. No ``.kit/``, no CLAUDE.md, no kit-install record — a
-  plain repo, reported as success, never as a deficiency.
+- **``--no-kit`` is rung 0 from BOTH verbs** (KIT-ADR-0032; the ``new``
+  side is KIT-0104 F4): check hook + git init only. No ``.kit/``, no
+  CLAUDE.md, no kit-install record — a plain repo, reported as
+  success, never as a deficiency.
 
 Engine data staging: the engines resolve their source tree from their
 own location (``SCRIPT_DIR/../..``), so the door stages a faux kit
@@ -517,12 +518,6 @@ def validate_combo(opts: "DoorOptions") -> bool:
             )
             return False
     if opts.mode == "new":
-        if opts.no_kit:
-            print(
-                "Error: --no-kit applies to --adopt (single shape) only",
-                file=sys.stderr,
-            )
-            return False
         if opts.design_materials == "yes":
             print(
                 "Error: --design-materials applies to --adopt only",
@@ -533,6 +528,16 @@ def validate_combo(opts: "DoorOptions") -> bool:
         if opts.name or opts.prefix:
             print("Error: --name/--prefix apply to --new only", file=sys.stderr)
             return False
+    if opts.no_kit and (opts.name or opts.prefix):
+        # rung 0 gets no scaffold, so the flags would be silently
+        # dropped — an error, never a drop (the masking class; the
+        # KIT-0104 F4 counterpart of the --bots + --no-kit guard)
+        print(
+            "Error: --name/--prefix shape the kit scaffold, and --no-kit "
+            "targets get no scaffold (rung 0) — drop one of the flags",
+            file=sys.stderr,
+        )
+        return False
     if opts.effective_profile == "none":
         if opts.with_venv == "yes":
             print(
@@ -656,7 +661,7 @@ Flags (every interactive question has one — non-TTY runs never hang):
   --target-path / --target-github
                        product-repo pointer (planning only)
   --no-kit             rung 0 (KIT-ADR-0032): plain repo, no .kit/, no
-                       kit install (adopt, single shape only)
+                       kit install (single shape; both verbs)
   --bots <b>           declare which review bots run on this project:
                        'coderabbit bugbot' (or a subset) | 'none'
                        (comma or space separated). Recorded as a
@@ -1326,7 +1331,7 @@ def _git_init_commit(target: Path, message: str) -> None:
 
 
 def _seed_check_hook(opts: DoorOptions, staged_root: Path) -> None:
-    """Rung-0 check-hook seeding (adopt --no-kit): the hook is
+    """Rung-0 check-hook seeding (--no-kit, both verbs): the hook is
     toolchain-level, not kit-workflow-level, so rung 0 still gets it —
     but the record's writer (the consumer engine) is not run, because
     rung 0 records nothing (KIT-ADR-0032: no kit install)."""
@@ -1385,8 +1390,24 @@ def _orchestrate(opts: DoorOptions, staged_root: Path) -> None:
         f"profile={opts.effective_profile} target={target}"
     )
 
-    if opts.mode == "adopt" and opts.no_kit:
-        # ── Rung 0 (KIT-ADR-0032): plain repo — no .kit/, no record ──
+    if opts.mode == "new":
+        # exist_ok=False: main() already refused an existing target, so
+        # a directory appearing between that check and here is a race —
+        # fail loud rather than scaffold into it (claude-code
+        # evaluator, this PR)
+        try:
+            target.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
+            _die_usage(
+                opts.mode,
+                f"--new target already exists: {target} (use 'agentive "
+                "adopt' for existing directories)",
+            )
+
+    if opts.no_kit:
+        # ── Rung 0 (KIT-ADR-0032): plain repo — no .kit/, no record.
+        #    Reachable from BOTH verbs (KIT-0104 F4): adopt opts out of
+        #    the kit workflow, new creates a blank project. ──
         _seed_check_hook(opts, staged_root)
         if not (target / ".git").exists():
             _git_init_commit(
@@ -1401,13 +1422,19 @@ def _orchestrate(opts: DoorOptions, staged_root: Path) -> None:
         if opts.with_evaluators == "yes":
             print(
                 "Evaluators not installed — --no-kit targets carry no "
-                ".adversarial config (rung 0); adopt without --no-kit to "
+                ".adversarial config (rung 0); re-run without --no-kit to "
                 "get the kit workflow"
             )
         if opts.with_venv == "yes":
             print(
                 "venv setup skipped: rung-0 targets ship no setup-dev.sh — "
                 "create one when your pyproject exists (python3 -m venv .venv)"
+            )
+        if opts.env_source:
+            print(
+                "env-source not applied — rung-0 targets carry no .env "
+                "scaffold (no .gitignore to keep secrets out of git); add "
+                "keys by hand once the repo has one"
             )
         print()
         print(
@@ -1438,19 +1465,6 @@ def _orchestrate(opts: DoorOptions, staged_root: Path) -> None:
     if opts.target_github:
         scaffold_args += ["--target-github", opts.target_github]
 
-    if opts.mode == "new":
-        # exist_ok=False: main() already refused an existing target, so
-        # a directory appearing between that check and here is a race —
-        # fail loud rather than scaffold into it (claude-code
-        # evaluator, this PR)
-        try:
-            target.mkdir(parents=True, exist_ok=False)
-        except FileExistsError:
-            _die_usage(
-                opts.mode,
-                f"--new target already exists: {target} (use 'agentive "
-                "adopt' for existing directories)",
-            )
     rc = _run_engine(staged_root, "engine-scaffold.sh", scaffold_args)
     if rc != 0:
         _die_install(f"scaffold engine failed (exit {rc})")

--- a/packages/agentive-kit/src/agentive_kit/door/__init__.py
+++ b/packages/agentive-kit/src/agentive_kit/door/__init__.py
@@ -695,9 +695,10 @@ AGENTIVE_KIT_CONFIG_DIR overrides the location (an override, never a
 search chain — a TRUSTED, operator-owned value). Author a preset
 conversationally with the /setup-preset command.
 
-Every --new target ends with a present, mode-0600, gitignored .env —
-copied from the preset's env-source when set, else seeded from the
-scaffold's .env.template. API keys move only by OPERATOR action.
+Every --new target with a kit install ends with a present, mode-0600,
+gitignored .env — copied from the preset's env-source when set, else
+seeded from the scaffold's .env.template. Rung 0 (--no-kit) has no
+scaffold, so it gets no .env. API keys move only by OPERATOR action.
 
 Exit contract:
   0  install succeeded — the doctor verdict is REPORTED, never encoded

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -71,22 +71,30 @@ MATERIALS=0
 HELP=0
 PASS=()
 
+set_mode() {  # one mode per run — a second flag would silently drop
+    # the first target (the masking class; CodeRabbit, this PR)
+    if [ -n "$MODE" ]; then
+        die_usage "only one mode flag is allowed (--new or --adopt, once)"
+    fi
+    MODE="$1"
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --new)
-            MODE="new"
+            set_mode new
             shift
             reject_flaglike --new "${1:-}"
             TARGET="${1:-}"
             ;;
-        --new=*)   MODE="new"; TARGET="${1#--new=}" ;;
+        --new=*)   set_mode new; TARGET="${1#--new=}" ;;
         --adopt)
-            MODE="adopt"
+            set_mode adopt
             shift
             reject_flaglike --adopt "${1:-}"
             TARGET="${1:-}"
             ;;
-        --adopt=*) MODE="adopt"; TARGET="${1#--adopt=}" ;;
+        --adopt=*) set_mode adopt; TARGET="${1#--adopt=}" ;;
         --design-materials)
             MATERIALS=1
             PASS+=("$1")
@@ -119,6 +127,14 @@ if [ "$MATERIALS" -eq 1 ] && [ "$HELP" -eq 0 ]; then
     TARGET="${TARGET/#\~/$HOME}"
     [ -d "$TARGET" ] ||
         die_usage "--adopt target does not exist: $TARGET"
+    # The old door refused the kit checkout as a target before any
+    # adopt handoff; the packaged path still does. This branch bypasses
+    # the package, so it needs the guard itself — otherwise
+    # `--adopt . --design-materials` from the kit root would rsync the
+    # kit onto itself (BugBot, this PR).
+    TARGET="$(cd "$TARGET" && pwd)"
+    [ "$TARGET" = "$PROJECT_ROOT" ] &&
+        die_usage "target is the kit source repo itself ($PROJECT_ROOT)"
     # The flow is fixed (adopt, single shape, python profile) and runs
     # entirely kit-side. Any other flag alongside it would be silently
     # dropped by the engine — refused loudly instead (the masking

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -142,7 +142,10 @@ if [ "$MATERIALS" -eq 1 ] && [ "$HELP" -eq 0 ]; then
 fi
 
 # ── Everything else: exec the packaged door ──
-if [ ! -d "$PKG_SRC/agentive_kit" ]; then
+# Probe a real module file, not just the directory — a hollowed-out or
+# half-synced checkout fails here with the instruction instead of a
+# Python traceback (claude-code evaluator, this PR).
+if [ ! -f "$PKG_SRC/agentive_kit/cli.py" ]; then
     echo "Error: packaged door source not found at $PKG_SRC" >&2
     echo "       This shim runs from an agentive-starter-kit checkout; from" >&2
     echo "       anywhere else, install the CLI and use it directly:" >&2

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -1,1230 +1,164 @@
 #!/usr/bin/env bash
-# bootstrap — the one setup door (KIT-0053, KIT-ADR-0027 P3)
+# bootstrap — exec shim over the packaged setup door (KIT-0104 F3)
 #
-# The single kit-side entrance for creating or adopting a project. It
-# RESOLVES the install questions, VALIDATES the shape×profile matrix,
-# and ORCHESTRATES the engines; the engines do the work, and the
-# consumer engine remains the only writer of the CLAUDE.md kit-install
-# record. Kit-side only: runs from an agentive-starter-kit clone
-# against a target; never ships on any sync tier or consumer rsync.
+# The door ships in the agentive-kit package as `agentive new` /
+# `agentive adopt` (KIT-ADR-0030). This shim keeps the historical
+# kit-side invocation working for one more minor release:
 #
-# Usage:
-#   scripts/local/bootstrap --new <dir>   [--shape single|planning] [--profile python|none]
-#   scripts/local/bootstrap --adopt <dir> [--shape single|planning] [--profile python|none]
+#   scripts/local/bootstrap --new <dir>   [flags]  →  agentive new <dir> [flags]
+#   scripts/local/bootstrap --adopt <dir> [flags]  →  agentive adopt <dir> [flags]
 #
-# Examples (one per matrix cell):
-#   bootstrap --new ~/Github/my-app                        # single+python (default)
-#   bootstrap --new ~/Github/my-notes --profile none       # single+none (docs-only)
-#   bootstrap --new ~/Github/my-planning --shape planning \
-#             --target-path ../my-product --target-github acme/my-product
-#   bootstrap --adopt ~/Github/existing-app                # single+python
-#   bootstrap --adopt ~/Github/docs-repo --profile none    # single+none
-#   bootstrap --adopt ~/Github/coord-repo --shape planning # planning+none (forced)
-#   bootstrap --adopt ~/Github/materials --design-materials  # bootstrap-agent flow
+# Everything else — the flag surface, the shape × profile matrix,
+# preset resolution, help text, the 0/1/2 exit contract — lives in the
+# package (single owner: agentive_kit/door, per KIT-ADR-0027 P3).
+# This file deliberately carries NO copy of any of it: `--help` is
+# answered by the package, and the shim execs the CHECKOUT'S OWN
+# package source (packages/agentive-kit/src), so a kit checkout's
+# bootstrap always behaves like the code it sits next to — never like
+# an older installed wheel.
 #
-# Shape × profile legality (single owner: THIS file — doctor and every
-# other reader consult the recorded pair, never re-derive the matrix):
+# One legacy branch stays here: `--adopt <dir> --design-materials`
+# (the interactive bootstrap-agent flow). It rsyncs a kit working tree
+# and execs a claude session, which cannot ship as package data; its
+# successor is the project-intake agent (KIT-ADR-0031 / KIT-0105), and
+# the branch dies with this shim.
 #
-#   |          | python      | none         |
-#   |----------|-------------|--------------|
-#   | single   | ✔ (default) | ✔ (docs-only)|
-#   | planning | ✘           | ✔ (forced)   |
-#
-# Flags (every interactive question has one — non-TTY runs never hang):
-#   --new <dir>          create <dir> (must not exist): packaged content
-#                        scaffold — .kit/ skeleton + records + pins;
-#                        scripts come from agentive-kit, agents from
-#                        the plugin (verified or instructed, KIT-0093)
-#   --adopt <dir>        install into an existing directory
-#   --shape <s>          single (default) | planning
-#   --profile <p>        python | none (default: by shape, see matrix)
-#   --name / --prefix    project name / task prefix (--new, single only)
-#   --target-path / --target-github
-#                        product-repo pointer (planning only)
-#   --no-kit             skip the .kit workflow (adopt, single only)
-#   --bots <b>           declare which review bots run on this project:
-#                        'coderabbit bugbot' (or a subset) | 'none'
-#                        (comma or space separated). Recorded as a
-#                        `bots:` line in the kit-install region; the
-#                        preflight gates SKIP declared-absent bots.
-#                        No flag/answer = no line = both bots expected
-#                        (today's behavior; zero migration).
-#   --design-materials / --no-design-materials
-#                        (adopt, single+python) run the bootstrap-agent
-#                        materials flow / silence its detection hint
-#   --with-evaluators / --without-evaluators
-#                        answer the evaluator-install offer (provisions
-#                        the evaluator library + the adversarial CLI)
-#   --with-venv / --without-venv
-#                        answer the venv offer (profile python only)
-#   --no-preset          ignore the operator preset for this run (the
-#                        stranger path — behaves as if no preset exists)
-#
-# Resolution chain (F5): CLI flag → operator preset
-# (<kit-parent>/agentive-config/preset — see "Operator preset" below)
-# → kit default → interactive prompt (TTY only). On --adopt of a target that
-# already carries a kit-install record, the record's values win over
-# the preset for shape/profile/bots/target-pointer (the record is the
-# project's identity; divergence is `project doctor --against-preset`'s
-# INFO surface, never a silent re-answer). Required answers missing in
-# a non-TTY run fail with usage (exit 2); optional offers default to
-# "skip, with notice".
-#
-# Operator preset (KIT-0056, relocated KIT-0058; ADR-0027 P7): flat
-# `key: value` lines, one per line, '#' comments allowed. Recognized
-# keys (exactly the door's questions, nothing else): shape, profile,
-# bots, evaluators (yes|no), venv (yes|no), target-path,
-# target-github, env-source. `env-source: <path>` names an
-# operator-owned .env template (chmod 600 expected); on --new the door
-# copies it to the target's .env (mode 0600), never printing or
-# staging it. Unknown keys WARN and are skipped; a malformed line
-# fails loud naming the line. Flat keys only is a conscious v1
-# boundary of the format. The preset lives at
-# <kit-parent>/agentive-config/preset — a VISIBLE sibling of the kit's
-# primary clone (worktree-safe via --git-common-dir), never inside any
-# repo: no sync tier, rsync, or export touches it. The
-# AGENTIVE_KIT_CONFIG_DIR env var overrides the location (tests,
-# unusual layouts) — an override, never a search chain, and a
-# TRUSTED, operator-owned value (never source it from an untrusted
-# environment: the door reads and seeds whatever it names). On first use
-# of an existing config home the door seeds .gitignore + README
-# guardrails (idempotent, never overwriting, never creating the
-# folder itself). Author a preset conversationally with the
-# /setup-preset command; example file: docs/preset.example.
-#
-# Working .env from day one (KIT-0084): every --new target ends with a
-# present, mode-0600, gitignored .env — copied from the preset's
-# env-source when set, else seeded from the target's own .env.template.
-# The door then fills PROJECT_NAME (target basename) and TASK_PREFIX
-# (single shape: the export engine's derived prefix; planning shape:
-# left EMPTY until intake decides it — `project doctor` warns while it
-# is empty or the old 'TASK' placeholder). API keys move only by
-# OPERATOR action: with no env-source, a TTY run asks consent before
-# copying the kit checkout's .env, and a non-TTY run prints the exact
-# copy command and continues. Agents must never copy key material into
-# a project — the permission classifier blocks it, by design.
-#
-# Exit contract (F6):
-#   0  install succeeded — the doctor verdict is REPORTED prominently,
-#      never encoded (a fresh repo with doctor WARNs still installed)
-#   1  install failed (an engine or record step errored)
-#   2  usage error or illegal shape/profile combination
-#
-# Every non-materials run finishes with `project doctor` in the target
-# (P4). The --design-materials path execs an interactive claude
-# session, so doctor cannot follow it — run it in the target afterward.
+# Removal is pinned to the next minor kit release:
+# .kit/tasks/1-backlog/KIT-0107-remove-the-bootstrap-shim.md
 
 set -e
 set -o pipefail
 IFS=$' \t\n'
 
-# The door commits into $TARGET on --new; a leaked GIT_DIR would
+# The materials engine commits into $TARGET; a leaked GIT_DIR would
 # redirect that at the real repository (the KIT-0048 incident class).
+# The packaged door scrubs GIT_* for itself — this covers the one
+# branch that never reaches it.
 for _git_var in $(compgen -A variable | grep '^GIT_' || true); do
     unset "$_git_var"
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-ENGINE_CONSUMER="$SCRIPT_DIR/engine-consumer.sh"
 ENGINE_MATERIALS="$SCRIPT_DIR/engine-materials.sh"
-ENGINE_SCAFFOLD="$SCRIPT_DIR/engine-scaffold.sh"
+PKG_SRC="$PROJECT_ROOT/packages/agentive-kit/src"
 
-# ─────────────────────────────────────────
-# F2 — the matrix, door-owned data
-# ─────────────────────────────────────────
-readonly LEGAL_PAIRS="single:python single:none planning:none"
-
-legal_pairs_human() {
-    echo "single+python (default), single+none, planning+none (forced)"
+notice() {
+    echo "Notice: scripts/local/bootstrap is now a shim over the packaged door" >&2
+    echo "        (agentive new / agentive adopt) and is removed in the next" >&2
+    echo "        minor release — KIT-0107 (.kit/tasks/1-backlog/)." >&2
 }
 
-# ─────────────────────────────────────────
-# Resolution chain (F5)
-# ─────────────────────────────────────────
-# The operator-preset layer (KIT-0056 fills the KIT-0053 P7 seam). ALL
-# resolution logic stays inside resolve_setting below — the preset is
-# one layer of that one chain; never a second resolver anywhere.
-PRESET_KEYS="shape profile bots evaluators venv target-path target-github env-source"
-PRESET_DATA=""   # "key=value" lines once loaded (empty = no preset)
-PRESET_PATH=""   # set when a preset file was loaded (for messages)
-# defaults so the sourced function layer works without main()
-NO_PRESET="${NO_PRESET:-0}"
-REC_SHAPE=""
-REC_PROFILE=""
-REC_BOTS=""
-REC_TARGET_PATH=""
-REC_TARGET_GITHUB=""
-
-config_home() {
-    # F1 (KIT-0058, ADR-0027 P7 amendment): the operator config home
-    # is a VISIBLE sibling of the kit's primary clone —
-    # <kit-parent>/agentive-config/ — resolved worktree-safely via
-    # --git-common-dir (the common dir names the primary clone's .git
-    # even from a linked worktree). AGENTIVE_KIT_CONFIG_DIR is the
-    # ONLY override — an override, never a search chain. This
-    # function LOCATES and writes nothing (seed_config_home is the
-    # writer); rc 1 when the kit checkout is not a git clone (no
-    # sibling to name — the preset layer then has nothing to read).
-    if [ -n "${AGENTIVE_KIT_CONFIG_DIR:-}" ]; then
-        # leading-~ expansion, the env-source precedent — an env file
-        # can carry a literal tilde the shell never expanded (o3)
-        printf '%s\n' "${AGENTIVE_KIT_CONFIG_DIR/#\~/$HOME}"
-        return 0
-    fi
-    local common
-    # KIT-0080: --path-format=absolute needs git >= 2.31; Apple's system
-    # git (2.30.1) echoes the flag back as an output line and exits 0.
-    # That made this resolve to the relative garbage ./agentive-config,
-    # so a correctly-authored operator preset was SILENTLY ignored on
-    # every door run on stock macOS (S3 — misprovisioned planning
-    # repos). Plain --git-common-dir is portable; its output is relative
-    # to the -C directory, so absolutize there.
-    # Emptiness-checked BEFORE joining: on failure the substitution is
-    # empty, which would otherwise resolve to $PROJECT_ROOT — a
-    # confident wrong home instead of the rc 1 that tells the preset
-    # layer there is nothing to read. A relative answer is joined by
-    # STRING, not `cd`+`pwd`, so a symlinked checkout keeps its logical
-    # path (doctor's mirror of this resolver does the same, and the
-    # equivalence test pins the two together).
-    local raw
-    raw="$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)" || return 1
-    [ -n "$raw" ] || return 1
-    case "$raw" in
-        /*) common="$raw" ;;
-        *)  common="$PROJECT_ROOT/$raw" ;;
-    esac
-    # Two levels: $common is <primary-clone>/.git, so one dirname gives
-    # the clone root and the second its PARENT, the visible sibling's
-    # home.
-    printf '%s\n' "$(dirname "$(dirname "$common")")/agentive-config"
-}
-
-load_preset() {
-    # Malformed lines fail loud naming the line — never a silent
-    # partial read (the record-reader face of the masking class:
-    # partial reads poison dependent answers together). Unknown keys
-    # WARN and are skipped (forward compatibility), never an error.
-    local home file
-    [ "$NO_PRESET" -eq 1 ] && return 0
-    home="$(config_home)" || return 0
-    file="$home/preset"
-    [ -f "$file" ] || return 0
-    if [ ! -r "$file" ]; then
-        # set -e would kill the read loop anyway — but with bash's raw
-        # "Permission denied", not a diagnosis
-        echo "Error: preset exists but is not readable: $file — fix its permissions, or pass --no-preset" >&2
-        exit 2
-    fi
-    local lineno=0 line key value data="" seen=" "
-    while IFS= read -r line || [ -n "$line" ]; do
-        lineno=$((lineno + 1))
-        line="${line%$'\r'}"  # CRLF tolerance (kit_markers precedent)
-        case "$line" in
-            ''|'#'*) continue ;;
-        esac
-        case "$line" in
-            *:*) ;;
-            *)
-                echo "Error: malformed preset line $lineno in $file: '$line' (expected 'key: value')" >&2
-                exit 2
-                ;;
-        esac
-        key="${line%%:*}"
-        value="${line#*:}"
-        key="$(printf '%s' "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-        value="$(printf '%s' "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-        case " $PRESET_KEYS " in
-            *" $key "*) ;;
-            *)
-                echo "Warning: unknown preset key '$key' (line $lineno in $file) — ignored" >&2
-                continue
-                ;;
-        esac
-        case "$seen" in
-            *" $key "*)
-                echo "Error: duplicate preset key '$key' (line $lineno in $file) — a preset answers each question once" >&2
-                exit 2
-                ;;
-        esac
-        seen="$seen$key "
-        data="$data$key=$value"$'\n'
-    done < "$file"
-    PRESET_DATA="$data"
-    PRESET_PATH="$file"
-}
-
-preset_get() {  # $1 key → value on stdout; rc 1 when unanswered
-    # pure parameter expansion — no sed, so a key name can never
-    # alter the match program (claude-code review, this PR)
-    [ -n "$PRESET_DATA" ] || return 1
-    local line
-    while IFS= read -r line; do
-        case "$line" in
-            "$1="*)
-                [ -n "${line#*=}" ] || return 1  # empty = unanswered
-                printf '%s\n' "${line#*=}"
-                return 0
-                ;;
-        esac
-    done <<< "$PRESET_DATA"
-    return 1
-}
-
-normalize_bots() {  # $1 raw (comma/space separated) → canonical, rc 1 on invalid/empty
-    # Case-insensitive by the _check_declared precedent ('# Shapes:
-    # Single' matches shape 'single') — every bots reader (this, the
-    # project script's _normalize_bots, preflight) shares the rule so
-    # one input can never be valid to one reader and invalid to another.
-    local raw tok cr=0 bb=0 none=0
-    raw="$(printf '%s' "$1" | tr ',' ' ' | tr '[:upper:]' '[:lower:]')"
-    # read-loop, not `for tok in $raw`: an unquoted for would glob a
-    # token like '*' into filenames before validation (CodeRabbit)
-    while IFS= read -r tok; do
-        [ -n "$tok" ] || continue
-        case "$tok" in
-            coderabbit) cr=1 ;;
-            bugbot)     bb=1 ;;
-            none)       none=1 ;;
-            *)
-                echo "Error: unknown bot '$tok' (expected: coderabbit, bugbot, or none)" >&2
-                return 1
-                ;;
-        esac
-    done <<EOF
-$(printf '%s\n' "$raw" | tr ' ' '\n')
-EOF
-    if [ "$none" -eq 1 ]; then
-        if [ "$cr" -eq 1 ] || [ "$bb" -eq 1 ]; then
-            echo "Error: 'none' cannot be combined with bot names (got: $1)" >&2
-            return 1
-        fi
-        echo "none"
-        return 0
-    fi
-    if [ "$cr" -eq 1 ] && [ "$bb" -eq 1 ]; then echo "coderabbit bugbot"
-    elif [ "$cr" -eq 1 ]; then echo "coderabbit"
-    elif [ "$bb" -eq 1 ]; then echo "bugbot"
-    else return 1  # empty → unanswered, caller decides
-    fi
-}
-
-kit_default() {  # $1 key, $2 shape context (for profile)
-    case "$1" in
-        shape) echo "single" ;;
-        profile)
-            case "${2:-}" in
-                planning) echo "none" ;;
-                *) echo "python" ;;
-            esac
-            ;;
-        *) return 1 ;;  # no kit default — falls to the prompt layer
-    esac
-}
-
-resolve_setting() {  # $1 key, $2 cli value, $3 shape context → stdout
-    local v rec=""
-    if [ -n "$2" ]; then
-        echo "$2"
-        return 0
-    fi
-    # Adopt of a recorded target: a question the record already
-    # answered is not open, so the preset layer is not consulted for
-    # it — the chain falls through to the kit default exactly as on a
-    # preset-less machine (N1). The record itself is preserved by the
-    # engine; preset divergence is doctor --against-preset's INFO
-    # surface, never a silent re-answer.
-    case "$1" in
-        shape)   rec="$REC_SHAPE" ;;
-        profile) rec="$REC_PROFILE" ;;
-        bots)    rec="$REC_BOTS" ;;
-    esac
-    # empty-but-successful preset output counts as unanswered — a
-    # preset that echoes nothing must fall through, not resolve to ""
-    if [ -z "$rec" ] && v="$(preset_get "$1")" && [ -n "$v" ]; then
-        echo "$v"
-        return 0
-    fi
-    if v="$(kit_default "$1" "${3:-}")"; then
-        echo "$v"
-        return 0
-    fi
-    return 1  # unanswered — caller prompts (TTY) or fails/skips
-}
-
-# ─────────────────────────────────────────
-# Validation (pure — no filesystem access)
-# ─────────────────────────────────────────
 die_usage() {
     echo "Error: $1" >&2
-    echo "Run 'scripts/local/bootstrap --help' for usage and examples." >&2
+    echo "Run 'scripts/local/bootstrap --help' for usage (answered by the package)." >&2
     exit 2
 }
 
 reject_flaglike() {  # $1 flag, $2 captured value — a following flag is
     # not a value ('--new --shape planning' must not adopt '--shape'
-    # as its target; BugBot, PR #81; -* also catches short options
-    # like -h). Empty stays allowed: the later required-answer
-    # handling prompts or fails with its own message.
+    # as its target; BugBot, PR #81). Empty stays allowed: the package
+    # prompts (TTY) or fails with its own message.
     case "$2" in
         -*) die_usage "$1 requires a value (got the flag '$2' instead)" ;;
     esac
 }
 
-validate_values() {  # $1 shape, $2 profile ("" = unresolved) → 0/message+1
+# ── Translate the historical mode flags to package verbs ──
+MODE=""
+TARGET=""
+MATERIALS=0
+HELP=0
+PASS=()
+
+while [ $# -gt 0 ]; do
     case "$1" in
-        single|planning) ;;
+        --new)
+            MODE="new"
+            shift
+            reject_flaglike --new "${1:-}"
+            TARGET="${1:-}"
+            ;;
+        --new=*)   MODE="new"; TARGET="${1#--new=}" ;;
+        --adopt)
+            MODE="adopt"
+            shift
+            reject_flaglike --adopt "${1:-}"
+            TARGET="${1:-}"
+            ;;
+        --adopt=*) MODE="adopt"; TARGET="${1#--adopt=}" ;;
+        --design-materials)
+            MATERIALS=1
+            PASS+=("$1")
+            ;;
+        --help|-h)
+            HELP=1
+            PASS+=("$1")
+            ;;
         *)
-            echo "Error: unknown shape: '$1' (expected: single | planning)" >&2
-            return 1
+            PASS+=("$1")
             ;;
     esac
-    case "$2" in
-        python|none|"") ;;
-        *)
-            echo "Error: unknown profile: '$2' (expected: python | none)" >&2
-            return 1
-            ;;
-    esac
-    return 0
-}
+    if [ $# -gt 0 ]; then shift; fi
+done
 
-validate_pair() {  # $1 shape, $2 profile → 0 legal / message + 1
-    case " $LEGAL_PAIRS " in
-        *" $1:$2 "*) return 0 ;;
-    esac
-    echo "Error: illegal shape/profile combination: $1 + $2" >&2
-    echo "       Legal pairs: $(legal_pairs_human)" >&2
-    return 1
-}
-
-# Cross-flag legality. Reads the resolved globals; returns 0 or prints
-# the offending pairing and returns 1 (main converts to exit 2).
-validate_combo() {
-    if [ "$SHAPE" = "planning" ]; then
-        [ "$NO_KIT" -eq 1 ] &&
-            { echo "Error: --no-kit contradicts --shape planning (the planning shape IS the kit workflow)" >&2; return 1; }
-        [ "$DESIGN_MATERIALS" = "yes" ] &&
-            { echo "Error: --design-materials applies to single-shape adopts only" >&2; return 1; }
-        [ -n "$NAME" ] || [ -n "$PREFIX" ] &&
-            { echo "Error: --name/--prefix apply to '--new --shape single' exports only" >&2; return 1; }
+if [ -z "$MODE" ]; then
+    if [ "$HELP" -eq 1 ]; then
+        MODE="new"  # bare --help: defer to the package's new-verb help
     else
-        [ -n "$TARGET_PATH" ] || [ -n "$TARGET_GITHUB" ] &&
-            { echo "Error: --target-path/--target-github apply to the planning shape only" >&2; return 1; }
+        die_usage "mode is required: --new <dir> or --adopt <dir>"
     fi
-    if [ "$MODE" = "new" ]; then
-        [ "$NO_KIT" -eq 1 ] &&
-            { echo "Error: --no-kit applies to --adopt (single shape) only" >&2; return 1; }
-        [ "$DESIGN_MATERIALS" = "yes" ] &&
-            { echo "Error: --design-materials applies to --adopt only" >&2; return 1; }
-    else
-        [ -n "$NAME" ] || [ -n "$PREFIX" ] &&
-            { echo "Error: --name/--prefix apply to --new only" >&2; return 1; }
-    fi
-    if [ "$EFFECTIVE_PROFILE" = "none" ]; then
-        [ "$WITH_VENV" = "yes" ] &&
-            { echo "Error: --with-venv requires profile python (effective profile: none)" >&2; return 1; }
-        [ "$DESIGN_MATERIALS" = "yes" ] &&
-            { echo "Error: --design-materials requires profile python (the materials flow runs setup-dev)" >&2; return 1; }
-    fi
-    if [ "$DESIGN_MATERIALS" = "yes" ] && [ "$NO_KIT" -eq 1 ]; then
-        # the materials engine ships the full kit workflow — honoring
-        # --no-kit there is impossible, so ignoring it silently would
-        # drop what the operator asked for (the masking class)
-        echo "Error: --no-kit contradicts --design-materials (the materials flow installs the full kit workflow)" >&2
-        return 1
-    fi
-    return 0
-}
+fi
 
-usage() {
-    # print the header block: line 2 up to the first non-comment,
-    # non-blank line (order-insensitive to what that line is)
-    sed -n '2,/^[^#]/p' "${BASH_SOURCE[0]}" | sed '$d' | sed 's/^# \{0,1\}//'
-}
-
-# ─────────────────────────────────────────
-# Prompt layer (TTY only)
-# ─────────────────────────────────────────
-is_tty() { [ -t 0 ]; }
-
-prompt_yn() {  # $1 question → "yes"/"no"
-    local ans
-    read -r -p "$1 [y/N] " ans
-    case "$ans" in
-        [Yy]*) echo "yes" ;;
-        *) echo "no" ;;
-    esac
-}
-
-# ─────────────────────────────────────────
-# Orchestration helpers
-# ─────────────────────────────────────────
-load_record() {
-    # Adopt of a target that already carries a kit-install record:
-    # load its values ONCE, before resolution, so resolve_setting can
-    # keep the preset out of already-answered questions. Reads via
-    # kit_markers, the record's one reader library. An unreadable
-    # record loads nothing here — the engine and doctor fail loud on
-    # it; the door's conflict checks simply have nothing to compare.
-    REC_SHAPE=""
-    REC_PROFILE=""
-    REC_BOTS=""
-    REC_TARGET_PATH=""
-    REC_TARGET_GITHUB=""
-    [ "$MODE" = "adopt" ] || return 0
-    [ -f "$TARGET/CLAUDE.md" ] || return 0
-    local rec
-    rec="$(python3 "$SCRIPT_DIR/kit_markers.py" extract "$TARGET/CLAUDE.md" kit-install 2>/dev/null)" || return 0
-    # leading/trailing-whitespace tolerant, like the Python reader's
-    # line.strip() — an indented hand-edited line must not be visible
-    # to one reader and invisible to another (o3, this PR)
-    REC_SHAPE="$(record_field "$rec" shape)"
-    REC_PROFILE="$(record_field "$rec" profile)"
-    REC_BOTS="$(record_field "$rec" bots)"
-    REC_TARGET_PATH="$(record_field "$rec" target_path)"
-    REC_TARGET_GITHUB="$(record_field "$rec" target_github)"
-    return 0
-}
-
-record_field() {  # $1 region text, $2 key → first value, whitespace-trimmed
-    printf '%s\n' "$1" |
-        sed -n "s/^[[:space:]]*$2:[[:space:]]*//p" | head -1 |
-        sed 's/[[:space:]]*$//'
-}
-
-check_record_conflict() {
-    # EXPLICIT flags that contradict the existing record are an error,
-    # never a silent preserve (CodeRabbit PR #81; the PR #78
-    # target-pointer precedent). Only the door can do this — it alone
-    # knows whether a value was operator-given or defaulted. (Preset
-    # values never reach here: resolve_setting keeps the preset out of
-    # recorded questions.)
-    if [ -n "$SHAPE_CLI" ] && [ -n "$REC_SHAPE" ] && [ "$SHAPE_CLI" != "$REC_SHAPE" ]; then
-        die_usage "--shape $SHAPE_CLI conflicts with the target's existing kit-install record (shape: $REC_SHAPE) — update the record first, or drop the flag"
-    fi
-    if [ -n "$PROFILE_CLI" ] && [ -n "$REC_PROFILE" ] && [ "$PROFILE_CLI" != "$REC_PROFILE" ]; then
-        die_usage "--profile $PROFILE_CLI conflicts with the target's existing kit-install record (profile: $REC_PROFILE) — update the record first, or drop the flag"
-    fi
-    if [ -n "$BOTS_CLI" ] && [ -n "$REC_BOTS" ]; then
-        # compare NORMALIZED forms — 'BugBot CodeRabbit' in the record
-        # is the same declaration as --bots 'coderabbit bugbot', not a
-        # conflict (BugBot, this PR). An unnormalizable record keeps
-        # its raw text: the inevitable mismatch then routes the
-        # operator to fix the record, which is the right advice.
-        local rec_bots_canon
-        rec_bots_canon="$(normalize_bots "$REC_BOTS" 2>/dev/null)" || rec_bots_canon="$REC_BOTS"
-        if [ "$BOTS_CLI" != "$rec_bots_canon" ]; then
-            die_usage "--bots '$BOTS_CLI' conflicts with the target's existing kit-install record (bots: $REC_BOTS) — update the record first, or drop the flag"
-        fi
-    fi
-    return 0
-}
-
-ensure_git_identity() {
-    # Fail fast with a real message when the install will commit into
-    # the target but git has no identity — otherwise the engine dies
-    # mid-run with git's "Please tell me who you are" (o3 finding).
-    # Commits need BOTH user.name and user.email (BugBot); --global
-    # includes the XDG config scope.
-    local key
-    for key in user.name user.email; do
-        if git config --global --get "$key" >/dev/null 2>&1; then
-            continue
-        fi
-        if git config --system --get "$key" >/dev/null 2>&1; then
-            continue
-        fi
-        echo "Error: git identity incomplete ($key unset) — this install commits into the target." >&2
-        echo "       Set it first:" >&2
-        echo "         git config --global user.name  'Your Name'" >&2
-        echo "         git config --global user.email you@example.com" >&2
-        exit 1
-    done
-}
-
-seed_config_home() {
-    # F2 (KIT-0058): defensive seeding on FIRST USE — an orchestrate
-    # step, distinct from config_home (resolve locates and writes
-    # nothing; accepted arch-review finding). Idempotent, never
-    # overwrites an existing file, and never creates the folder
-    # itself (N3: creating it is the operator engaging the preset
-    # flow — /setup-preset guides that; no drive-by dirs on
-    # preset-less runs). A seeding failure warns and continues:
-    # guardrails are a courtesy, never the install's critical path.
-    local home
-    [ "$NO_PRESET" -eq 1 ] && return 0
-    home="$(config_home)" || return 0
-    [ -d "$home" ] || return 0
-    # temp-then-mv (the TEMP-THEN-COMMIT pattern): never-overwrite
-    # means an interrupted partial write would otherwise stick forever
-    # (claude-code review, this PR)
-    if [ ! -e "$home/.gitignore" ]; then
-        if printf 'env.source\n*.env\n' > "$home/.gitignore.tmp" 2>/dev/null &&
-           mv "$home/.gitignore.tmp" "$home/.gitignore" 2>/dev/null; then
-            echo "Seeded $home/.gitignore (env.source and *.env stay out of git)"
-        else
-            rm -f "$home/.gitignore.tmp" 2>/dev/null || true
-            echo "Warning: could not seed $home/.gitignore — check the folder's permissions" >&2
-        fi
-    fi
-    if [ ! -e "$home/README.md" ]; then
-        if cat > "$home/README.md.tmp" 2>/dev/null <<'CONFIG_README'
-# agentive-config
-
-Operator config for the agentive-starter-kit setup door — a visible
-sibling of the kit checkout, personal and per-machine, never
-distributed by any sync or export path. `preset` pre-answers the
-door's questions (author it conversationally with /setup-preset;
-format reference: docs/preset.example in the kit). Keeping this
-folder in a PRIVATE git repo is welcome — the seeded .gitignore
-keeps `env.source` and `*.env` out of git, and `project doctor`
-warns if the remote is not private. Secrets stay in `env.source`
-(chmod 600), referenced by path from the preset — never committed,
-never pasted into chat.
-CONFIG_README
-        then
-            if mv "$home/README.md.tmp" "$home/README.md" 2>/dev/null; then
-                echo "Seeded $home/README.md (what this folder is; private-repo pattern welcome)"
-            else
-                rm -f "$home/README.md.tmp" 2>/dev/null || true
-                echo "Warning: could not seed $home/README.md — check the folder's permissions" >&2
-            fi
-        else
-            rm -f "$home/README.md.tmp" 2>/dev/null || true
-            echo "Warning: could not seed $home/README.md — check the folder's permissions" >&2
-        fi
-    fi
-    return 0
-}
-
-copy_env_into_target() {  # $1 source file — the ONE writer of $TARGET/.env
-    # Shared discipline for every .env seeding path (KIT-0084): the
-    # copy is refused unless .env is gitignored in the target; the file
-    # is BORN 0600 (umask-first — no window at looser permissions,
-    # claude-code review, PR #83); contents are NEVER printed, logged,
-    # or staged.
-    if ! git -C "$TARGET" check-ignore -q .env; then
-        echo "Error: .env is not gitignored in the target — refusing to seed secrets into it" >&2
-        exit 1
-    fi
-    (
-        umask 077
-        cat "$1" > "$TARGET/.env"
-    )
-    chmod 600 "$TARGET/.env"
-}
-
-apply_env_source() {  # $1 source path (from the preset) — --new only (F6)
-    # Secrets by reference: the preset names an operator-owned .env
-    # template; the door copies it 0600 (discipline lives in
-    # copy_env_into_target).
-    local src="${1/#\~/$HOME}"
-    if [ ! -f "$src" ] || [ ! -r "$src" ]; then
-        # defense in depth — main pre-validated both before any work
-        echo "Error: preset env-source missing or unreadable: $src" >&2
-        exit 1
-    fi
-    local mode
-    mode="$(stat -f '%Lp' "$src" 2>/dev/null || stat -c '%a' "$src" 2>/dev/null || echo unknown)"
-    if [ "$mode" != "600" ]; then
-        echo "Warning: env-source $src is mode $mode (0600 expected) — tighten it: chmod 600 $src" >&2
-    fi
-    copy_env_into_target "$src"
-    echo "Seeded .env from preset env-source (mode 0600, gitignored; contents never printed)"
-}
-
-seed_env_from_template() {  # KIT-0084 F1 — --new with no env-source preset
-    # Fallback seeding: the target's own .env.template. It carries no
-    # secrets, but the seeded file will — so the same discipline as
-    # the env-source path applies from birth.
-    if [ ! -f "$TARGET/.env.template" ]; then
-        echo "Warning: no .env.template in the target — .env not seeded; create it by hand (chmod 600)" >&2
-        return 0
-    fi
-    copy_env_into_target "$TARGET/.env.template"
-    echo "Seeded .env from .env.template (mode 0600, gitignored) — API keys still to be added"
-}
-
-offer_env_carryover() {  # KIT-0084 F3 — operator-consented key carry-over
-    # Key material moves ONLY by operator action. The door runs under
-    # the operator's own hands, so a TTY consent question is the
-    # acceptable surface; agents must never copy keys into a project
-    # (the permission classifier blocks it — correctly, so a non-TTY
-    # run prints the exact command for the operator and continues).
-    local kit_env="$PROJECT_ROOT/.env"
-    if [ ! -f "$kit_env" ] || [ ! -r "$kit_env" ]; then
-        echo "No API keys seeded — add them to $TARGET/.env ('project doctor' names what is missing)"
-        return 0
-    fi
-    # same source-mode courtesy warning as apply_env_source (claude-code
-    # review, this PR)
-    local mode
-    mode="$(stat -f '%Lp' "$kit_env" 2>/dev/null || stat -c '%a' "$kit_env" 2>/dev/null || echo unknown)"
-    if [ "$mode" != "600" ]; then
-        echo "Warning: $kit_env is mode $mode (0600 expected) — tighten it: chmod 600 $kit_env" >&2
-    fi
-    if is_tty; then
-        local ans
-        ans="$(prompt_yn "Copy the kit clone's .env — the WHOLE file, all keys and settings — from $kit_env into the new project's .env?")"
-        if [ "$ans" = "yes" ]; then
-            copy_env_into_target "$kit_env"
-            echo "Seeded .env from $kit_env (mode 0600, gitignored; contents never printed)"
-        else
-            # install -m 600: the copy is BORN 0600 — a cp+chmod pair
-            # would open a window at the source's mode (CodeRabbit)
-            echo "Keys not copied — add them to $TARGET/.env yourself, or run:"
-            echo "    install -m 600 \"$kit_env\" \"$TARGET/.env\""
-            echo "  (then re-check PROJECT_NAME/TASK_PREFIX in it — 'project doctor' flags them)"
-        fi
-    else
-        echo "API keys not seeded (non-interactive) — as the operator, run:"
-        echo "    install -m 600 \"$kit_env\" \"$TARGET/.env\""
-        echo "  (operator-only: agents must never copy key material; then re-check"
-        echo "   PROJECT_NAME/TASK_PREFIX in it and re-run 'project doctor')"
-    fi
-}
-
-fill_env_identity() {  # KIT-0084 F2 — PROJECT_NAME/TASK_PREFIX, --new only
-    # Callers must have seeded $TARGET/.env via copy_env_into_target
-    # (which verifies the gitignore) — this rewrite adds no new file.
-    [ -f "$TARGET/.env" ] || return 0
-    local name prefix=""
-    name="$(basename "$TARGET")"
-    if [ "$SHAPE" = "single" ]; then
-        # the export engine already derived and recorded the prefix
-        # (from --prefix or the name's initials) — read the recorded
-        # value rather than re-deriving it here
-        prefix="$(python3 - "$TARGET/.kit/context/current-state.json" 2>/dev/null <<'PYEOF'
-import json
-import sys
-
-try:
-    with open(sys.argv[1], encoding="utf-8") as f:
-        value = json.load(f)["project"]["task_prefix"]
-except (OSError, ValueError, KeyError):
-    value = None
-# a JSON null must yield nothing, never the string "None" (fast-v2
-# evaluator, this PR)
-if isinstance(value, str):
-    print(value)
-PYEOF
-)" || prefix=""
-        [ -n "$prefix" ] || prefix="$PREFIX"
-    fi
-    # newlines/CRs in a folder name or prefix would smuggle extra
-    # assignments into .env, and quote characters cannot be written
-    # into a dotenv line faithfully — strip them (o3 + CodeRabbit
-    # reviews, this PR; the values are operator-owned, so this is
-    # hardening, not a trust boundary)
-    name="${name//[$'\n'$'\r'\"\']/}"
-    prefix="${prefix//[$'\n'$'\r'\"\']/}"
-    # planning shape: no prefix exists at door time — written EMPTY,
-    # never 'TASK'; intake decides it and doctor warns meanwhile.
-    # Rewrite in memory (no temp file: a leaked temp beside .env would
-    # not be gitignored), values passed via ENVIRON — never
-    # interpolated into the awk program.
-    # first assignment rewritten, later DUPLICATES dropped — dotenv
-    # parsers are last-assignment-wins, so a surviving duplicate would
-    # silently override the identity just written (fast-v2 evaluator,
-    # this PR)
-    # indentation and an `export ` prefix tolerated to stay in step
-    # with the doctor's reader (fast-v2 round 2; CodeRabbit). Values
-    # carrying '#', spaces, or tabs are written double-quoted so a
-    # dotenv parser (and the doctor) reads them back intact — safe
-    # because quote characters were stripped above.
-    local content
-    content="$(ENV_NAME="$name" ENV_PREFIX="$prefix" awk '
-        function emit(k, v) {
-            if (v ~ /[# \t]/) print k "=\"" v "\""
-            else print k "=" v
-        }
-        /^[[:space:]]*(export[[:space:]]+)?PROJECT_NAME=/ {
-            if (!seen_name++) emit("PROJECT_NAME", ENVIRON["ENV_NAME"])
-            next
-        }
-        /^[[:space:]]*(export[[:space:]]+)?TASK_PREFIX=/ {
-            if (!seen_prefix++) emit("TASK_PREFIX", ENVIRON["ENV_PREFIX"])
-            next
-        }
-        { print }
-        END {
-            if (!seen_name) emit("PROJECT_NAME", ENVIRON["ENV_NAME"])
-            if (!seen_prefix) emit("TASK_PREFIX", ENVIRON["ENV_PREFIX"])
-        }
-    ' "$TARGET/.env")"
-    # command substitution strips trailing newlines; printf restores
-    # exactly one — trailing blank lines collapse, which is fine here.
-    # Temp-then-mv so a failed write never truncates the operator's
-    # .env (CodeRabbit); the temp lives inside .git/ when possible so
-    # an interrupted run can never leave stageable key material.
-    local tmpdir="$TARGET"
-    [ -d "$TARGET/.git" ] && tmpdir="$TARGET/.git"
-    local tmp
-    tmp="$(mktemp "$tmpdir/.env-rewrite.XXXXXX")" || {
-        echo "Error: could not create temp file for the .env rewrite" >&2
-        exit 1
-    }
-    if ! printf '%s\n' "$content" > "$tmp"; then
-        rm -f "$tmp"
-        echo "Error: .env rewrite failed — the seeded .env is untouched" >&2
-        exit 1
-    fi
-    chmod 600 "$tmp"
-    mv "$tmp" "$TARGET/.env"
-    echo "Project identity written to .env: PROJECT_NAME=$name TASK_PREFIX=${prefix:-(empty — set at intake; doctor warns until then)}"
-}
-
-run_offers() {
-    if [ "$WITH_EVALUATORS" = "" ]; then
-        if is_tty; then
-            WITH_EVALUATORS="$(prompt_yn "Install adversarial evaluators now? (library + CLI)")"
-        else
-            echo "Offer skipped (non-interactive): evaluators (library + CLI) — pass --with-evaluators to install"
-            WITH_EVALUATORS="no"
-        fi
-    fi
-    if [ "$WITH_EVALUATORS" = "yes" ]; then
-        # Copied-scripts targets (adopt/legacy) keep their own
-        # installer; packaged scaffolds use the installed CLI; a
-        # missing CLI degrades to an instruction (KIT-0083 pattern).
-        if [ -x "$TARGET/scripts/core/project" ]; then
-            (cd "$TARGET" && ./scripts/core/project install-evaluators) ||
-                echo "Warning: evaluator install failed — doctor will flag it; re-run './scripts/core/project install-evaluators' in the target"
-        elif command -v agentive >/dev/null 2>&1; then
-            (cd "$TARGET" && agentive install-evaluators) ||
-                echo "Warning: evaluator install failed — doctor will flag it; re-run 'agentive install-evaluators' in the target"
-        else
-            echo "Evaluators not installed — install the lifecycle CLI first (see above), then run 'agentive install-evaluators' in the target"
-        fi
-    fi
-
-    # EFFECTIVE_PROFILE, not PROFILE: a profile:none-recorded adopt
-    # resolves PROFILE to the python default, but its venv offer (TTY
-    # prompt AND the non-TTY --with-venv hint) would be wrong — the
-    # record has no Python toolchain (BugBot round 3, PR #83)
-    if [ "$EFFECTIVE_PROFILE" = "python" ]; then
-        if [ ! -f "$TARGET/scripts/optional/setup-dev.sh" ]; then
-            # Packaged scaffolds ship no setup-dev.sh — an explicit
-            # venv answer is acknowledged out loud, never silently
-            # dropped (the masking class), and the default path says
-            # so once too (BugBot, PR #116: silence here while the
-            # adopt flow prints its offer notice reads as an omission).
-            if [ "$WITH_VENV" = "yes" ]; then
-                echo "venv setup skipped: this scaffold ships no setup-dev.sh — create one when your pyproject exists (python3 -m venv .venv)"
-            else
-                echo "venv: not offered — packaged scaffolds ship no setup-dev.sh; create one when your pyproject exists (python3 -m venv .venv)"
-            fi
-        else
-            if [ "$WITH_VENV" = "" ]; then
-                if is_tty; then
-                    WITH_VENV="$(prompt_yn "Set up the Python venv now (setup-dev.sh)?")"
-                else
-                    echo "Offer skipped (non-interactive): venv — pass --with-venv to set up"
-                    WITH_VENV="no"
-                fi
-            fi
-            if [ "$WITH_VENV" = "yes" ]; then
-                (cd "$TARGET" && bash scripts/optional/setup-dev.sh) ||
-                    echo "Warning: venv setup failed — run 'bash scripts/optional/setup-dev.sh' in the target"
-            fi
-        fi
-    fi
-}
-
-verify_packages() {
-    # KIT-0093 (ADR-0028 phase 2): the two package installs are
-    # VERIFIED or INSTRUCTED, never assumed and never a hard failure
-    # (the KIT-0083 degradation pattern). The exact strings below are
-    # a contract — tests/test_scaffold_acceptance.py defines them.
-    echo
-    echo "━━━ package verification ━━━"
-    if command -v agentive >/dev/null 2>&1; then
-        local ver
-        ver="$(agentive --version 2>/dev/null | head -1)" || ver=""
-        echo "agentive CLI: ${ver:-found on PATH} (verified)"
-    else
-        echo "Install the lifecycle CLI: uv tool install agentive-kit"
-        echo "  (task lifecycle, doctor, preflight, evaluator provisioning)"
-    fi
-    # Plugin detection reuses the doctor 50-plugin-source.sh approach:
-    # the local plugin registry, marketplace source anchored to GitHub
-    # (a Directory source silently defeats version pins — KIT-0030).
-    local plugin_ok=0 mkt plugins
-    if command -v claude >/dev/null 2>&1; then
-        if mkt="$(claude plugin marketplace list 2>/dev/null)" &&
-           printf '%s\n' "$mkt" | grep -qiE '^[[:space:]]*source: *(github \(|https://github\.com/)movito/agentive-skills([[:space:]]*\)|$)'; then
-            if plugins="$(claude plugin list 2>/dev/null)" &&
-               printf '%s\n' "$plugins" | grep -qiE 'agentive-workflow([@ (]|$)'; then
-                plugin_ok=1
-            fi
-        fi
-    fi
-    if [ "$plugin_ok" -eq 1 ]; then
-        echo "agent plugin: verified (agentive-workflow via the agentive-skills marketplace)"
-    else
-        echo "Install the agent plugin:"
-        echo "    claude plugin marketplace add movito/agentive-skills"
-        echo "    claude plugin install agentive-workflow@agentive-skills"
-        if ! command -v claude >/dev/null 2>&1; then
-            echo "  (needs the Claude Code CLI on PATH first)"
-        fi
-    fi
-}
-
-run_doctor_tail() {
-    echo
-    echo "━━━ project doctor (${TARGET}) ━━━"
-    local doctor_exit=0
-    # Copied-scripts targets (adopt/legacy) run their own doctor;
-    # packaged scaffolds run the installed CLI's; a missing CLI
-    # degrades to the instruction (already printed by verify_packages).
-    if [ -x "$TARGET/scripts/core/project" ]; then
-        set +e
-        (cd "$TARGET" && ./scripts/core/project doctor)
-        doctor_exit=$?
-        set -e
-    elif command -v agentive >/dev/null 2>&1 &&
-         agentive help 2>/dev/null | grep -q '^  doctor'; then
-        set +e
-        (cd "$TARGET" && agentive doctor)
-        doctor_exit=$?
-        set -e
-    elif command -v agentive >/dev/null 2>&1; then
-        # An installed pre-0.3 CLI has no doctor subcommand yet — an
-        # upgrade instruction beats a misleading "FAILURES" verdict.
-        echo "Doctor not run — the installed agentive CLI predates 'agentive doctor'."
-        echo "    uv tool upgrade agentive-kit"
-        # %q: the line is pasted into a shell, so TARGET must be
-        # escaped — spaces or metacharacters in an operator-supplied
-        # path would otherwise break or execute (CodeRabbit, PR #125)
-        printf '    cd -- %q && agentive doctor\n' "$TARGET"
-        echo
-        echo "Install complete: shape=$SHAPE profile=$PROFILE → $TARGET"
-        return 0
-    else
-        echo "Doctor not run — the lifecycle CLI is not installed."
-        echo
-        echo "Install complete: shape=$SHAPE profile=$PROFILE → $TARGET"
-        echo
-        # KIT-0101 R3 (KIT-0100 F10b): a missing CLI is the ONE gap
-        # that cascades (no doctor, no evaluator provisioning, no
-        # preflight), so it is the HEADLINE next step, not an inline
-        # notice. The install line must stay byte-identical to the
-        # verify_packages one — tests/test_scaffold_acceptance.py
-        # pins both, and pins move with wording in the same commit.
-        echo "━━━ NEXT STEP (required): install the lifecycle CLI ━━━"
-        echo "Nothing below works until this is done — doctor, evaluator"
-        echo "provisioning, and preflight all run through it:"
-        echo "    Install the lifecycle CLI: uv tool install agentive-kit"
-        # %q as above — this line is a pasteable command, not display text
-        printf '    cd -- %q && agentive doctor\n' "$TARGET"
-        return 0
-    fi
-    local verdict
-    # doctor's exit contract (KIT-0046 F3): 1 = at least one FAIL,
-    # 2 = warnings only. (The two were swapped here until KIT-0056 —
-    # a FAILing doctor reported as "WARNINGS".)
-    case "$doctor_exit" in
-        0) verdict="all checks passed" ;;
-        1) verdict="FAILURES (see above) — install still succeeded; fix before working" ;;
-        2) verdict="WARNINGS (see above) — install still succeeded" ;;
-        *) verdict="doctor could not run (exit $doctor_exit)" ;;
-    esac
-    echo
-    echo "Doctor verdict: $verdict"
-    echo "Install complete: shape=$SHAPE profile=$PROFILE → $TARGET"
-}
-
-main() {
-    MODE=""
-    TARGET=""
-    SHAPE_CLI=""
-    PROFILE_CLI=""
-    NAME=""
-    PREFIX=""
-    TARGET_PATH=""
-    TARGET_GITHUB=""
-    NO_KIT=0
-    DESIGN_MATERIALS=""
-    WITH_EVALUATORS=""
-    WITH_VENV=""
-    BOTS_CLI=""
-    BOTS=""
-    NO_PRESET=0
-
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            --new)              shift; MODE="new";   TARGET="${1:-}"; reject_flaglike --new "$TARGET" ;;
-            --new=*)            MODE="new";   TARGET="${1#--new=}" ;;
-            --adopt)            shift; MODE="adopt"; TARGET="${1:-}"; reject_flaglike --adopt "$TARGET" ;;
-            --adopt=*)          MODE="adopt"; TARGET="${1#--adopt=}" ;;
-            --shape)            shift; SHAPE_CLI="${1:-}"; reject_flaglike --shape "$SHAPE_CLI" ;;
-            --shape=*)          SHAPE_CLI="${1#--shape=}" ;;
-            --profile)          shift; PROFILE_CLI="${1:-}"; reject_flaglike --profile "$PROFILE_CLI" ;;
-            --profile=*)        PROFILE_CLI="${1#--profile=}" ;;
-            --name)             shift; NAME="${1:-}"; reject_flaglike --name "$NAME" ;;
-            --name=*)           NAME="${1#--name=}" ;;
-            --prefix)           shift; PREFIX="${1:-}"; reject_flaglike --prefix "$PREFIX" ;;
-            --prefix=*)         PREFIX="${1#--prefix=}" ;;
-            --target-path)      shift; TARGET_PATH="${1:-}"; reject_flaglike --target-path "$TARGET_PATH" ;;
-            --target-path=*)    TARGET_PATH="${1#--target-path=}" ;;
-            --target-github)    shift; TARGET_GITHUB="${1:-}"; reject_flaglike --target-github "$TARGET_GITHUB" ;;
-            --target-github=*)  TARGET_GITHUB="${1#--target-github=}" ;;
-            --no-kit)           NO_KIT=1 ;;
-            --bots)             shift; BOTS_CLI="${1:-}"; reject_flaglike --bots "$BOTS_CLI" ;;
-            --bots=*)           BOTS_CLI="${1#--bots=}" ;;
-            --no-preset)        NO_PRESET=1 ;;
-            --design-materials)    DESIGN_MATERIALS="yes" ;;
-            --no-design-materials) DESIGN_MATERIALS="no" ;;
-            --with-evaluators)     WITH_EVALUATORS="yes" ;;
-            --without-evaluators)  WITH_EVALUATORS="no" ;;
-            --with-venv)           WITH_VENV="yes" ;;
-            --without-venv)        WITH_VENV="no" ;;
-            --help|-h)          usage; exit 0 ;;
-            *)                  die_usage "unknown argument: $1" ;;
-        esac
-        if [ $# -gt 0 ]; then shift; fi
-    done
-
-    # ── Resolve (CLI → preset → kit default → prompt) ──
-    if [ -n "$BOTS_CLI" ]; then
-        BOTS_CLI="$(normalize_bots "$BOTS_CLI")" || die_usage "invalid --bots value"
-    fi
-    load_preset
-    if [ -n "$PRESET_PATH" ]; then
-        echo "Preset: $PRESET_PATH (pass --no-preset to ignore it)"
-    fi
-    # First-use guardrail seeding (F2) — right after the read, so an
-    # engaged config home gains its .gitignore before any operator
-    # git-init happens around it. No-ops on the stranger path (N2).
-    seed_config_home
-
-    if [ -z "$MODE" ]; then
-        if is_tty; then
-            local pick
-            read -r -p "Create a new project or adopt an existing directory? [new/adopt] " pick
-            case "$pick" in
-                new|adopt) MODE="$pick" ;;
-                *) die_usage "mode is required: --new <dir> or --adopt <dir>" ;;
-            esac
-        else
-            die_usage "mode is required: --new <dir> or --adopt <dir>"
-        fi
-    fi
-    if [ -z "$TARGET" ]; then
-        if is_tty; then
-            read -r -p "Target directory: " TARGET
-        fi
-        [ -n "$TARGET" ] || die_usage "target directory is required (--$MODE <dir>)"
-    fi
+# ── The one legacy branch: the design-materials flow ──
+if [ "$MATERIALS" -eq 1 ] && [ "$HELP" -eq 0 ]; then
+    [ "$MODE" = "adopt" ] ||
+        die_usage "--design-materials applies to --adopt only"
+    [ -n "$TARGET" ] ||
+        die_usage "target directory is required (--adopt <dir>)"
     TARGET="${TARGET/#\~/$HOME}"
-
-    load_record
-
-    SHAPE="$(resolve_setting shape "$SHAPE_CLI")"
-    validate_values "$SHAPE" "$PROFILE_CLI" || exit 2
-    if [ "$SHAPE" = "planning" ] && [ "$PROFILE_CLI" = "python" ]; then
-        validate_pair planning python || exit 2
-    fi
-    PROFILE="$(resolve_setting profile "$PROFILE_CLI" "$SHAPE")"
-    validate_pair "$SHAPE" "$PROFILE" || exit 2
-    if [ "$SHAPE" = "planning" ] && [ -z "$PROFILE_CLI" ]; then
-        echo "planning shape → profile none (forced; the only legal pair)"
-    fi
-    # The EFFECTIVE profile: on adopt of a recorded target the record
-    # wins over the resolved default (the engine preserves it), so
-    # every Python-toolchain surface — the venv offer, the preset venv
-    # answer, --with-venv, --design-materials — must key on THIS, not
-    # on the resolved PROFILE, or a docs-only recorded project gets
-    # offered setup-dev.sh (BugBot rounds 2-3, PR #83).
-    EFFECTIVE_PROFILE="$PROFILE"
-    [ -n "$REC_PROFILE" ] && EFFECTIVE_PROFILE="$REC_PROFILE"
-    validate_combo || exit 2
-
-    # Preset may answer the planning shape's target-pointer questions —
-    # but only when neither a flag nor the target's record already did
-    # (same record-beats-preset rule as resolve_setting).
-    if [ "$SHAPE" = "planning" ]; then
-        local pv
-        if [ -z "$TARGET_PATH" ] && [ -z "$REC_TARGET_PATH" ] && pv="$(preset_get target-path)"; then
-            TARGET_PATH="$pv"
-        fi
-        if [ -z "$TARGET_GITHUB" ] && [ -z "$REC_TARGET_GITHUB" ] && pv="$(preset_get target-github)"; then
-            TARGET_GITHUB="$pv"
-        fi
-    fi
-
-    if [ -n "$TARGET_GITHUB" ] && ! printf '%s' "$TARGET_GITHUB" | grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
-        die_usage "--target-github must look like owner/repo (got: $TARGET_GITHUB)"
-    fi
-
-    # ── Target checks ──
-    if [ "$MODE" = "new" ]; then
-        [ -e "$TARGET" ] && die_usage "--new target already exists: $TARGET (use --adopt for existing directories)"
-    else
-        [ -d "$TARGET" ] || die_usage "--adopt target does not exist: $TARGET (use --new to create one)"
-        TARGET="$(cd "$TARGET" && pwd)"
-        [ "$TARGET" = "$PROJECT_ROOT" ] &&
-            die_usage "target is the kit source repo itself ($PROJECT_ROOT)"
-    fi
-
-    # ── Design-material detection (adopt, single: a git-less target is
-    #    materials-shaped — bootstrap.sh's historical precondition) ──
-    if [ "$MODE" = "adopt" ] && [ "$SHAPE" = "single" ] && [ -z "$DESIGN_MATERIALS" ]; then
-        if [ ! -e "$TARGET/.git" ] && [ "$PROFILE" = "python" ]; then
-            if is_tty; then
-                DESIGN_MATERIALS="$(prompt_yn "Target has no git repo — treat its contents as design materials and launch the bootstrap-agent flow?")"
-            else
-                echo "Hint: target has no git repo — if it holds design materials, re-run with --design-materials for the bootstrap-agent flow"
-                DESIGN_MATERIALS="no"
-            fi
-        else
-            DESIGN_MATERIALS="no"
-        fi
-    fi
-
-    # ── Bots declaration (KIT-0056, ADR-0027 P5) ──
-    # CLI → preset → TTY prompt. Unanswered = no `bots:` line = both
-    # bots expected (today's behavior — zero migration, N1). A target
-    # whose record already declares bots keeps its declaration (the
-    # engine preserves the region; a conflicting flag errors below).
-    if [ "$DESIGN_MATERIALS" != "yes" ] && [ -z "$REC_BOTS" ]; then
-        local bots_raw
-        if [ -n "$BOTS_CLI" ]; then
-            BOTS="$BOTS_CLI"  # already normalized at parse time
-        elif bots_raw="$(preset_get bots)"; then
-            BOTS="$(normalize_bots "$bots_raw")" ||
-                die_usage "invalid preset key 'bots: $bots_raw'"
-        elif is_tty; then
-            read -r -p "Which bots review PRs here? [coderabbit bugbot / none — Enter = expect both, record nothing] " bots_raw
-            if [ -n "$bots_raw" ]; then
-                BOTS="$(normalize_bots "$bots_raw")" || die_usage "invalid bots answer"
-            fi
-        fi
-    fi
-
-    # ── Preset offer answers + env-source (validated BEFORE any work
-    #    — a bad preset value must abort a pristine run, not a
-    #    half-installed target) ──
-    local offer
-    if [ -z "$WITH_EVALUATORS" ] && offer="$(preset_get evaluators)"; then
-        case "$offer" in
-            yes|no) WITH_EVALUATORS="$offer" ;;
-            *) die_usage "preset key 'evaluators' must be yes or no (got: $offer)" ;;
+    [ -d "$TARGET" ] ||
+        die_usage "--adopt target does not exist: $TARGET"
+    # The flow is fixed (adopt, single shape, python profile) and runs
+    # entirely kit-side. Any other flag alongside it would be silently
+    # dropped by the engine — refused loudly instead (the masking
+    # class). --no-kit keeps its historical message.
+    for extra in "${PASS[@]}"; do
+        case "$extra" in
+            --design-materials) ;;
+            --no-kit)
+                die_usage "--no-kit contradicts --design-materials (the materials flow installs the full kit workflow)"
+                ;;
+            *)
+                die_usage "'$extra' cannot be combined with --design-materials (the materials flow is fixed: adopt, single shape, python profile)"
+                ;;
         esac
-    fi
-    # The venv answer keys on EFFECTIVE_PROFILE (see its definition):
-    # a preset 'venv: yes' must never run setup-dev.sh on a project
-    # whose record says profile: none (BugBot round 2). Ignoring the
-    # answer is said out loud — never a silent drop.
-    if [ "$PROFILE" = "python" ] && [ -z "$WITH_VENV" ] && offer="$(preset_get venv)"; then
-        # validate BEFORE deciding applicability — a malformed value
-        # fails loud even when the answer would be ignored (N2)
-        case "$offer" in
-            yes|no) ;;
-            *) die_usage "preset key 'venv' must be yes or no (got: $offer)" ;;
-        esac
-        if [ "$EFFECTIVE_PROFILE" != "python" ]; then
-            echo "Preset venv answer ignored — the target's record (profile: $EFFECTIVE_PROFILE) has no Python toolchain"
-        else
-            WITH_VENV="$offer"
-        fi
-    fi
-    ENV_SOURCE=""
-    if [ "$MODE" = "new" ] && offer="$(preset_get env-source)"; then
-        ENV_SOURCE="${offer/#\~/$HOME}"
-        [ -f "$ENV_SOURCE" ] ||
-            die_usage "preset env-source not found: $ENV_SOURCE — fix the preset (or drop the key)"
-        [ -r "$ENV_SOURCE" ] ||
-            die_usage "preset env-source is not readable: $ENV_SOURCE — fix its permissions"
-    fi
+    done
+    notice
+    echo "Handing off to the design-materials flow (ends in an interactive"
+    echo "bootstrap-agent session). Doctor cannot run after an exec — run"
+    echo "'./scripts/core/project doctor' in the target when the agent is done."
+    exec "$ENGINE_MATERIALS" "$TARGET"
+fi
 
-    # ── Orchestrate ──
-    if [ "$MODE" = "adopt" ]; then
-        check_record_conflict
-    fi
-    # a --new install (and an adopt of a git-less target) will commit
-    if [ "$MODE" = "new" ] || [ ! -e "$TARGET/.git" ]; then
-        ensure_git_identity
-    fi
-    echo "Setup door: mode=$MODE shape=$SHAPE profile=$PROFILE target=$TARGET"
+# ── Everything else: exec the packaged door ──
+if [ ! -d "$PKG_SRC/agentive_kit" ]; then
+    echo "Error: packaged door source not found at $PKG_SRC" >&2
+    echo "       This shim runs from an agentive-starter-kit checkout; from" >&2
+    echo "       anywhere else, install the CLI and use it directly:" >&2
+    echo "           uv tool install agentive-kit" >&2
+    echo "           agentive $MODE --help" >&2
+    exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: python3 is required (the door ships in the agentive-kit package)" >&2
+    exit 1
+fi
 
-    if [ "$MODE" = "adopt" ] && [ "$DESIGN_MATERIALS" = "yes" ]; then
-        echo "Handing off to the design-materials flow (ends in an interactive"
-        echo "bootstrap-agent session). Doctor cannot run after an exec — run"
-        echo "'./scripts/core/project doctor' in the target when the agent is done."
-        exec "$ENGINE_MATERIALS" "$TARGET"
-    fi
-
-    if [ "$MODE" = "new" ]; then
-        # ── Packaged-install mode (KIT-0093, ADR-0028 phase 2) ──
-        # Content + pins + record; the lifecycle scripts come from
-        # agentive-kit and the agent bodies from the plugin — nothing
-        # is copied. Same flow for BOTH shapes.
-        mkdir -p "$TARGET"
-        TARGET="$(cd "$TARGET" && pwd)"
-        set -- "$TARGET" --shape "$SHAPE" --profile "$PROFILE"
-        [ -n "$NAME" ] && set -- "$@" --name "$NAME"
-        [ -n "$PREFIX" ] && set -- "$@" --prefix "$PREFIX"
-        [ -n "$TARGET_PATH" ] && set -- "$@" --target-path "$TARGET_PATH"
-        [ -n "$TARGET_GITHUB" ] && set -- "$@" --target-github "$TARGET_GITHUB"
-        "$ENGINE_SCAFFOLD" "$@" ||
-            { echo "Error: scaffold engine failed (exit $?)" >&2; exit 1; }
-        # The consumer engine stays the ONE writer of the CLAUDE.md
-        # kit-install record (and seeds the per-repo check hook).
-        set -- --internal-record-only --packaged --shape "$SHAPE" --profile "$PROFILE"
-        # --name reaches the record step too, or CLAUDE.md would title
-        # from the basename while README/current-state carry the name
-        # (BugBot, PR #116).
-        [ -n "$NAME" ] && set -- "$@" --project-name "$NAME"
-        [ -n "$TARGET_PATH" ] && set -- "$@" --target-path "$TARGET_PATH"
-        [ -n "$TARGET_GITHUB" ] && set -- "$@" --target-github "$TARGET_GITHUB"
-        [ -n "$BOTS" ] && set -- "$@" --bots "$BOTS"
-        "$ENGINE_CONSUMER" "$@" "$TARGET" ||
-            { echo "Error: install record step failed (exit $?)" >&2; exit 1; }
-        if git -C "$TARGET" init --quiet -b main &&
-           git -C "$TARGET" add -A &&
-           git -C "$TARGET" commit --quiet -m "Initial commit: agentive project scaffold (shape: $SHAPE, profile: $PROFILE)"; then
-            echo "Scaffold committed (branch: main)."
-        else
-            # F6: a failed record step is an install failure — the
-            # scaffold is on disk but sits uncommitted
-            echo "Error: initial commit failed — commit the scaffold in the target yourself, then re-run doctor" >&2
-            exit 1
-        fi
-    else
-        set -- --shape "$SHAPE" --profile "$PROFILE"
-        [ "$NO_KIT" -eq 1 ] && set -- "$@" --no-kit
-        [ -n "$TARGET_PATH" ] && set -- "$@" --target-path "$TARGET_PATH"
-        [ -n "$TARGET_GITHUB" ] && set -- "$@" --target-github "$TARGET_GITHUB"
-        [ -n "$BOTS" ] && set -- "$@" --bots "$BOTS"
-        "$ENGINE_CONSUMER" "$@" "$TARGET" ||
-            { echo "Error: consumer engine failed (exit $?)" >&2; exit 1; }
-    fi
-
-    # ── Working .env from day one (KIT-0084) — --new only: seed from
-    #    the preset env-source (F6) or the target's template, offer the
-    #    operator key carry-over, then fill the identity fields ──
-    if [ "$MODE" = "new" ]; then
-        if [ -n "$ENV_SOURCE" ]; then
-            apply_env_source "$ENV_SOURCE"
-        else
-            seed_env_from_template
-            offer_env_carryover
-        fi
-        fill_env_identity
-    fi
-
-    verify_packages
-    run_offers
-    run_doctor_tail
-    exit 0
-}
-
-# Source guard: `source scripts/local/bootstrap` loads the functions
-# for tests (resolve/validate run with no filesystem access); direct
-# invocation runs main.
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    main "$@"
+notice
+export PYTHONPATH="$PKG_SRC${PYTHONPATH:+:$PYTHONPATH}"
+if [ -n "$TARGET" ]; then
+    exec python3 -m agentive_kit.cli "$MODE" "$TARGET" "${PASS[@]}"
+else
+    exec python3 -m agentive_kit.cli "$MODE" "${PASS[@]}"
 fi

--- a/scripts/local/bootstrap
+++ b/scripts/local/bootstrap
@@ -87,14 +87,22 @@ while [ $# -gt 0 ]; do
             reject_flaglike --new "${1:-}"
             TARGET="${1:-}"
             ;;
-        --new=*)   set_mode new; TARGET="${1#--new=}" ;;
+        --new=*)
+            set_mode new
+            TARGET="${1#--new=}"
+            reject_flaglike --new "$TARGET"
+            ;;
         --adopt)
             set_mode adopt
             shift
             reject_flaglike --adopt "${1:-}"
             TARGET="${1:-}"
             ;;
-        --adopt=*) set_mode adopt; TARGET="${1#--adopt=}" ;;
+        --adopt=*)
+            set_mode adopt
+            TARGET="${1#--adopt=}"
+            reject_flaglike --adopt "$TARGET"
+            ;;
         --design-materials)
             MATERIALS=1
             PASS+=("$1")

--- a/tests/agentive_kit/test_door_e2e.py
+++ b/tests/agentive_kit/test_door_e2e.py
@@ -283,12 +283,15 @@ class TestNewNoKit:
         assert not (target / ".adversarial").exists()
         assert not (target / ".env").exists()
         assert not (target / "scripts" / "core").exists()
-        # committed on main, single rung-0 commit
+        # committed on main, single rung-0 commit. env=env: the door
+        # ran GIT_*-scrubbed, so the probes must too — a runner-leaked
+        # GIT_DIR would point them at the wrong repo (CodeRabbit)
         branch = subprocess.run(
             ["git", "-C", str(target), "branch", "--show-current"],
             capture_output=True,
             text=True,
             timeout=30,
+            env=env,
         )
         assert branch.stdout.strip() == "main"
         log = subprocess.run(
@@ -296,6 +299,7 @@ class TestNewNoKit:
             capture_output=True,
             text=True,
             timeout=30,
+            env=env,
         )
         assert len(log.stdout.strip().splitlines()) == 1
         assert "rung-0" in log.stdout

--- a/tests/agentive_kit/test_door_e2e.py
+++ b/tests/agentive_kit/test_door_e2e.py
@@ -264,6 +264,110 @@ class TestNewPlanning:
         assert not (target / "tests").exists()
 
 
+class TestNewNoKit:
+    """KIT-0104 F4: rung 0 (KIT-ADR-0032) is reachable from the ``new``
+    verb too — a blank project, not a kit install."""
+
+    def test_new_no_kit_is_rung_zero(self, tmp_path):
+        env = _door_env(tmp_path)
+        target = tmp_path / "blank-proto"
+        result = run_door("new", str(target), "--no-kit", cwd=tmp_path, env=env)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "rung 0" in result.stdout.lower()
+        assert "Doctor not run (nothing to check)" in result.stdout
+        assert "Doctor verdict:" not in result.stdout
+        # check hook + git, NOTHING else — no .kit/, no record, no .env
+        assert (target / "scripts" / "local" / "checks.sh").is_file()
+        assert not (target / ".kit").exists()
+        assert not (target / "CLAUDE.md").exists()
+        assert not (target / ".adversarial").exists()
+        assert not (target / ".env").exists()
+        assert not (target / "scripts" / "core").exists()
+        # committed on main, single rung-0 commit
+        branch = subprocess.run(
+            ["git", "-C", str(target), "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert branch.stdout.strip() == "main"
+        log = subprocess.run(
+            ["git", "-C", str(target), "log", "--oneline"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert len(log.stdout.strip().splitlines()) == 1
+        assert "rung-0" in log.stdout
+
+    def test_new_no_kit_offers_acknowledged_never_dropped(self, tmp_path):
+        """Same masking-class contract as the adopt side: explicit
+        offer answers rung 0 cannot honor are acknowledged out loud."""
+        env = _door_env(tmp_path)
+        target = tmp_path / "blank-offers"
+        result = run_door(
+            "new",
+            str(target),
+            "--no-kit",
+            "--with-evaluators",
+            "--with-venv",
+            cwd=tmp_path,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "Evaluators not installed" in result.stdout
+        assert "venv setup skipped" in result.stdout
+        assert not (target / ".adversarial").exists()
+
+    def test_new_no_kit_with_bots_rejected_loud(self, tmp_path):
+        env = _door_env(tmp_path)
+        result = run_door(
+            "new",
+            str(tmp_path / "botsless"),
+            "--no-kit",
+            "--bots",
+            "coderabbit",
+            cwd=tmp_path,
+            env=env,
+        )
+        assert result.returncode == 2
+        assert "--no-kit targets record nothing" in (result.stdout + result.stderr)
+        assert not (tmp_path / "botsless").exists()
+
+    def test_new_no_kit_with_name_rejected_loud(self, tmp_path):
+        """--name/--prefix shape the scaffold rung 0 never gets — an
+        error, never a silent drop."""
+        env = _door_env(tmp_path)
+        result = run_door(
+            "new",
+            str(tmp_path / "named"),
+            "--no-kit",
+            "--name",
+            "X",
+            cwd=tmp_path,
+            env=env,
+        )
+        assert result.returncode == 2
+        assert "--no-kit targets get no scaffold" in (result.stdout + result.stderr)
+        assert not (tmp_path / "named").exists()
+
+    def test_new_no_kit_env_source_acknowledged_not_applied(self, tmp_path):
+        """A preset env-source cannot be honored on rung 0 (no
+        .gitignore to keep the secrets out of git) — said out loud."""
+        cfg = tmp_path / "cfg"
+        cfg.mkdir()
+        source = cfg / "env.source"
+        source.write_text("ANTHROPIC_API_KEY=sk-test\n", encoding="utf-8")
+        source.chmod(0o600)
+        (cfg / "preset").write_text("env-source: env.source\n", encoding="utf-8")
+        env = _door_env(tmp_path, config_dir=cfg)
+        target = tmp_path / "blank-preset"
+        result = run_door("new", str(target), "--no-kit", cwd=tmp_path, env=env)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "env-source not applied" in result.stdout
+        assert not (target / ".env").exists()
+
+
 class TestAdopt:
     def _make_repo(self, base: Path, name: str) -> Path:
         target = base / name

--- a/tests/agentive_kit/test_door_units.py
+++ b/tests/agentive_kit/test_door_units.py
@@ -391,6 +391,11 @@ class TestValidateCombo:
     def test_default_new_is_legal(self):
         assert door.validate_combo(_resolved_opts()) is True
 
+    @pytest.mark.parametrize("mode", ["new", "adopt"])
+    def test_no_kit_single_is_legal_from_both_verbs(self, mode):
+        """KIT-0104 F4: rung 0 is reachable from new AND adopt."""
+        assert door.validate_combo(_resolved_opts(mode=mode, no_kit=True)) is True
+
     @pytest.mark.parametrize(
         "kwargs,fragment",
         [
@@ -403,7 +408,14 @@ class TestValidateCombo:
                 },
                 "--no-kit contradicts --shape planning",
             ),
-            ({"mode": "new", "no_kit": True}, "--no-kit applies to --adopt"),
+            (
+                {"mode": "new", "no_kit": True, "name": "x"},
+                "--no-kit targets get no scaffold",
+            ),
+            (
+                {"mode": "new", "no_kit": True, "prefix": "XX"},
+                "--no-kit targets get no scaffold",
+            ),
             (
                 {"mode": "new", "design_materials": "yes"},
                 "--design-materials applies to --adopt",

--- a/tests/test_bootstrap_shapes.py
+++ b/tests/test_bootstrap_shapes.py
@@ -1,16 +1,23 @@
-"""Shape and profile tests for the setup door (KIT-0048, ADR-0027 P2).
+"""Shape tests for the bootstrap shim (KIT-0104 F3): through the shim
+you get the PACKAGED door, byte-for-byte.
 
-Characterization net first (N1): flagless-adopt and --shape single must
-stay byte-identical to each other for every subsequent edit; the
-flagless baseline invariants pin today's behavior. KIT-0053 put this
-coverage behind the bootstrap-consumer.sh shim; KIT-0054 (0.9.0)
-removed the shims, so the suite now exercises the door's own --adopt
-surface directly (the engine behavior underneath stays pinned;
-usage-error assertions carry the door's exit-2 contract).
+The characterization net this module used to carry pinned the legacy
+copy-adopt world (toolchain rsync'd from the kit tree). That world
+retired with the shim: ``bootstrap --adopt`` now reaches the packaged
+adopt (content scaffold + record, nothing copied) and ``--no-kit`` is
+KIT-ADR-0032's rung 0 (no ``.kit/``, no record) — both pinned here AS
+the new contract. The equivalence tests are the load-bearing ones:
+a shim run and a direct ``agentive`` run must produce identical trees,
+so the shim can never grow behavior of its own.
 
-Consumer-rsync boundary: this module reads scripts/local/ content, so it
-is excluded from the consumer tests/ rsync in engine-consumer.sh
-(exclude + rm -f sweep) and module-skips when the script is absent —
+Packaged-door behavior in depth (preset chain, record conflicts, .env
+seeding, exit contract) is covered once, in
+``tests/agentive_kit/test_door_units.py`` / ``test_door_e2e.py`` —
+this module only proves the shim is a faithful window onto it.
+
+Consumer-rsync boundary: this module reads scripts/local/ content, so
+it is excluded from the consumer tests/ rsync in engine-consumer.sh
+(exclude + rm -f sweep) and module-skips when the door is absent —
 the tests/test_kit_markers.py pattern.
 """
 
@@ -20,12 +27,14 @@ import hashlib
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOOR = REPO_ROOT / "scripts" / "local" / "bootstrap"
+PKG_SRC = REPO_ROOT / "packages" / "agentive-kit" / "src"
 
 if not DOOR.exists():
     pytest.skip(
@@ -39,31 +48,38 @@ for tool in ("bash", "git", "rsync"):
 
 # Nonexistent hermetic paths keep every door run hermetic (the
 # test_setup_door pattern): the operator's REAL config home must never
-# leak into the suite — a filled preset would change door answers and
-# break characterization. XDG_CONFIG_HOME stays pinned too (git's own
-# config lookup).
+# leak into the suite. XDG_CONFIG_HOME stays pinned too (git's own
+# config lookup) — tests that commit swap in a scratch identity.
 _HERMETIC_XDG = REPO_ROOT / "tests" / ".no-such-xdg"
 _HERMETIC_CONFIG = REPO_ROOT / "tests" / ".no-such-config-home"
 
 
-def _scrubbed_env() -> dict[str, str]:
-    """os.environ minus GIT_* — explicit defense in depth.
-
-    These helpers run from CLASS-scoped fixtures, which execute outside
-    the function-scoped conftest isolation; under the pre-commit hook the
-    ambient GIT_DIR would otherwise redirect bootstrap's git calls at the
-    REAL repository (the KIT-0048 corruption incident). The session-scoped
-    conftest fixture now covers this too — this scrub makes the helpers
-    safe regardless of who calls them from where.
-    """
+def _scrubbed_env(**extra: str) -> dict[str, str]:
+    """os.environ minus GIT_* (the KIT-0048 GIT_DIR leak class), plus
+    PYTHONPATH for the DIRECT package runs — the shim sets its own, but
+    ``python -m agentive_kit.cli`` in a child interpreter does not
+    inherit conftest's sys.path injection (the PR #129 CI lesson)."""
     env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{PKG_SRC}{os.pathsep}{existing}" if existing else str(PKG_SRC)
     env["XDG_CONFIG_HOME"] = str(_HERMETIC_XDG)
     env["AGENTIVE_KIT_CONFIG_DIR"] = str(_HERMETIC_CONFIG)
+    env.update(extra)
     return env
 
 
+def _git_identity(base: Path) -> Path:
+    xdg = base / "xdg-config"
+    (xdg / "git").mkdir(parents=True, exist_ok=True)
+    (xdg / "git" / "config").write_text(
+        "[user]\n\tname = Kit Test\n\temail = kit-test@example.invalid\n",
+        encoding="utf-8",
+    )
+    return xdg
+
+
 def make_consumer_dir(base: Path, name: str) -> Path:
-    """A scratch consumer dir, pre-inited so bootstrap skips git init
+    """A scratch adopt target, pre-inited so the engine skips git init
     (keeps runs timestamp-free and tree-comparable)."""
     target = base / name
     target.mkdir(parents=True)
@@ -76,13 +92,27 @@ def make_consumer_dir(base: Path, name: str) -> Path:
     return target
 
 
-def run_bootstrap(target: Path, *flags: str) -> subprocess.CompletedProcess:
+def run_shim(*args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """The historical invocation, through the shim."""
     return subprocess.run(
-        ["bash", str(DOOR), "--adopt", str(target), *flags],
+        ["bash", str(DOOR), *args],
         capture_output=True,
         text=True,
-        timeout=180,
-        env=_scrubbed_env(),
+        timeout=300,
+        stdin=subprocess.DEVNULL,
+        env=env or _scrubbed_env(),
+    )
+
+
+def run_direct(*args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """The packaged invocation, exactly as an installed CLI."""
+    return subprocess.run(
+        [sys.executable, "-m", "agentive_kit.cli", *args],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        stdin=subprocess.DEVNULL,
+        env=env or _scrubbed_env(),
     )
 
 
@@ -98,100 +128,95 @@ def tree_snapshot(root: Path) -> dict[str, str]:
     return snapshot
 
 
-class TestCharacterization:
-    """N1: pin current flagless behavior; single must equal flagless."""
+def _kit_install_region(target: Path) -> str:
+    text = (target / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "<!-- BEGIN KIT-LOCAL: kit-install -->" in text
+    return text.split("BEGIN KIT-LOCAL: kit-install")[1].split(
+        "END KIT-LOCAL: kit-install"
+    )[0]
 
-    def test_flagless_baseline_invariants(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "flagless")
-        result = run_bootstrap(target)
-        assert result.returncode == 0, result.stderr
-        # today's single-shape contract: full Python toolchain ships
-        for expected in (
+
+@pytest.mark.slow
+class TestShimEquivalence:
+    """The AC proof: a shim run and a direct run are the same install.
+
+    Identical basenames on purpose — the engines seed placeholders from
+    the target name, so differing names would differ by design.
+    """
+
+    def test_new_via_shim_identical_to_direct(self, tmp_path):
+        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
+        shim_target = tmp_path / "a" / "app"
+        direct_target = tmp_path / "b" / "app"
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        r1 = run_shim("--new", str(shim_target), env=env)
+        r2 = run_direct("new", str(direct_target), env=env)
+        assert r1.returncode == 0, r1.stderr + r1.stdout
+        assert r2.returncode == 0, r2.stderr + r2.stdout
+        assert tree_snapshot(shim_target) == tree_snapshot(direct_target)
+
+    def test_adopt_via_shim_identical_to_direct(self, tmp_path):
+        shim_target = make_consumer_dir(tmp_path / "a", "app")
+        direct_target = make_consumer_dir(tmp_path / "b", "app")
+        r1 = run_shim("--adopt", str(shim_target), "--profile", "none")
+        r2 = run_direct("adopt", str(direct_target), "--profile", "none")
+        assert r1.returncode == 0, r1.stderr + r1.stdout
+        assert r2.returncode == 0, r2.stderr + r2.stdout
+        assert tree_snapshot(shim_target) == tree_snapshot(direct_target)
+
+
+@pytest.fixture(scope="module")
+def adopted(tmp_path_factory):
+    target = make_consumer_dir(tmp_path_factory.mktemp("shim-adopt"), "app")
+    result = run_shim("--adopt", str(target))
+    assert result.returncode == 0, result.stderr + result.stdout
+    return target, result
+
+
+@pytest.mark.slow
+class TestPackagedAdoptThroughShim:
+    """The copy-adopt retirement, pinned: adopt through the shim is the
+    PACKAGED adopt — record + content scaffold, nothing copied."""
+
+    def test_record_and_hook_written(self, adopted):
+        target, result = adopted
+        region = _kit_install_region(target)
+        assert "shape: single" in region
+        assert "profile: python" in region
+        hook = target / "scripts" / "local" / "checks.sh"
+        assert hook.is_file()
+        assert os.access(hook, os.X_OK)
+
+    def test_kit_workflow_scaffolded_not_copied(self, adopted):
+        target, result = adopted
+        assert (target / ".kit" / "tasks" / "1-backlog").is_dir()
+        # the legacy copy-adopt shipset must be GONE: no toolchain
+        # copies, no script copies, no agent copies
+        for never in (
             "pyproject.toml",
             "conftest.py",
-            ".pre-commit-config.yaml",
-            "scripts/core/project",
-            "scripts/core/ci-check.sh",
-            "scripts/core/pattern_lint.py",
-            ".claude/agents/planner.md",
-            ".claude/agents/feature-developer.md",
-            ".kit/templates/TASK-STARTER-TEMPLATE.md",
+            "tests",
+            "scripts/core",
+            ".claude",
+            "scripts/local/kit_markers.py",
+            ".github",
         ):
-            assert (target / expected).is_file(), f"missing: {expected}"
-        assert (target / "tests").is_dir()
-        assert (target / ".kit" / "tasks" / "1-backlog").is_dir()
+            assert not (target / never).exists(), f"copy-adopt relic: {never}"
 
-    def test_shape_single_identical_to_flagless(self, tmp_path):
-        # identical basenames: the marker-merge seeds placeholders with
-        # the project name, so differing dir names would differ by design
-        flagless = make_consumer_dir(tmp_path / "a", "app")
-        single = make_consumer_dir(tmp_path / "b", "app")
-        r1 = run_bootstrap(flagless)
-        r2 = run_bootstrap(single, "--shape", "single")
-        assert r1.returncode == 0, r1.stderr
-        assert r2.returncode == 0, r2.stderr
-        assert tree_snapshot(flagless) == tree_snapshot(single)
-
-    def test_unknown_shape_rejected(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "bad")
-        result = run_bootstrap(target, "--shape", "pyramid")
-        assert result.returncode == 2  # door usage contract
-        assert "unknown shape" in (result.stdout + result.stderr).lower()
+    def test_doctor_tail_reported(self, adopted):
+        target, result = adopted
+        assert "Doctor verdict:" in result.stdout
+        assert "Install complete:" in result.stdout
 
 
-# The planning contract, both directions (F1: enumerated, tested).
-PLANNING_MUST_SHIP = (
-    "scripts/local/checks.sh",
-    "scripts/core/project",
-    "scripts/core/validate_task_status.py",
-    "scripts/core/doctor.d/10-gh-auth.sh",
-    "scripts/core/doctor.d/70-core-bare.sh",
-    "scripts/core/VERSION",
-    "scripts/local/kit_markers.py",
-    "scripts/local/new-worktree.sh",
-    ".claude/agents/planner.md",
-    ".claude/agents/feature-developer.md",
-    ".claude/commands/preflight.md",
-    ".kit/templates/TASK-STARTER-TEMPLATE.md",
-    ".adversarial/config.yml.template",
-    ".pre-commit-config.yaml",
-    ".env.template",
-    ".gitignore",
-    "CLAUDE.md",
-)
-
-PLANNING_MUST_NOT_SHIP = (
-    "pyproject.toml",
-    "conftest.py",
-    "tests",
-    "scripts/core/pattern_lint.py",
-    "scripts/core/ci-check.sh",
-    "scripts/optional",
-    ".github",
-    ".serena",
-    # The three one-release deprecation shims, removed at 0.3.1
-    # (KIT-0092). They shipped through 0.3.0; a planning repo
-    # bootstrapped now gets the `agentive` CLI instead, so their
-    # ABSENCE is the contract.
-    "scripts/core/preflight-check.sh",
-    "scripts/core/gh-review-helper.sh",
-    "scripts/core/prepare-review-input.sh",
-    # The copy-sync channel, retired at KIT-0102 (KIT-ADR-0028 phase 4).
-    # A new planning repo must NOT be born with a manifest pointing at a
-    # sync engine that no longer exists — their absence is the contract.
-    "scripts/.core-manifest.json",
-    "scripts/core/sync_from_manifest.py",
-)
-
-
-class TestPlanningShape:
-    """F1/F2/F4: the planning install ships coordination, not toolchain."""
-
-    @pytest.fixture(scope="class")
-    def planning(self, tmp_path_factory):
-        target = make_consumer_dir(tmp_path_factory.mktemp("shape"), "planning")
-        result = run_bootstrap(
-            target,
+@pytest.mark.slow
+class TestPlanningShapeThroughShim:
+    def test_planning_records_pointer_and_forces_none(self, tmp_path):
+        target = make_consumer_dir(tmp_path, "coord")
+        result = run_shim(
+            "--adopt",
+            str(target),
             "--shape",
             "planning",
             "--target-path",
@@ -200,405 +225,96 @@ class TestPlanningShape:
             "acme/my-product",
         )
         assert result.returncode == 0, result.stderr + result.stdout
-        return target
-
-    @pytest.mark.parametrize("rel", PLANNING_MUST_SHIP)
-    def test_ships(self, planning, rel):
-        assert (planning / rel).exists(), f"planning shape missing: {rel}"
-
-    @pytest.mark.parametrize("rel", PLANNING_MUST_NOT_SHIP)
-    def test_never_ships(self, planning, rel):
-        assert not (planning / rel).exists(), f"planning shape must not ship: {rel}"
-
-    def test_kit_install_region_written(self, planning):
-        text = (planning / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "<!-- BEGIN KIT-LOCAL: kit-install -->" in text
-        assert "<!-- END KIT-LOCAL: kit-install -->" in text
-        assert "shape: planning" in text
-        assert "target_path: ../my-product" in text
-        assert "target_github: acme/my-product" in text
-
-    def test_target_repository_section_seeded(self, planning):
-        text = (planning / "CLAUDE.md").read_text(encoding="utf-8")
+        region = _kit_install_region(target)
+        assert "shape: planning" in region
+        assert "profile: none" in region
+        assert "target_path: ../my-product" in region
+        assert "target_github: acme/my-product" in region
+        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
         assert "## Target Repository" in text
-        assert "- **Path**: `../my-product`" in text
-        assert "- **GitHub**: `acme/my-product`" in text
+        # planning ships no python toolchain
+        assert not (target / "pyproject.toml").exists()
 
-    def test_precommit_variant_is_python_free(self, planning):
-        text = (planning / ".pre-commit-config.yaml").read_text(encoding="utf-8")
-        assert "validate-task-status" in text
-        assert "black" not in text
-        assert "pytest" not in text
-        assert "flake8" not in text
+    def test_equals_form_flags_translate(self, tmp_path):
+        target = make_consumer_dir(tmp_path, "eqform")
+        result = run_shim(f"--adopt={target}", "--shape=planning", "--profile=none")
+        assert result.returncode == 0, result.stderr + result.stdout
+        region = _kit_install_region(target)
+        assert "shape: planning" in region
+        assert "profile: none" in region
 
-    def test_kit_agents_still_marker_merged(self, planning):
-        text = (planning / ".claude" / "agents" / "planner.md").read_text(
-            encoding="utf-8"
+
+@pytest.mark.slow
+class TestRungZeroThroughShim:
+    """--no-kit is rung 0 now (KIT-ADR-0032, both verbs): no .kit/, no
+    record — the legacy seeded-record --no-kit retired with the shim."""
+
+    def test_adopt_no_kit_is_rung_zero(self, tmp_path):
+        target = make_consumer_dir(tmp_path, "proto")
+        (target / "main.py").write_text("print('hi')\n", encoding="utf-8")
+        result = run_shim("--adopt", str(target), "--no-kit")
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "rung 0" in result.stdout.lower()
+        assert (target / "scripts" / "local" / "checks.sh").is_file()
+        assert not (target / ".kit").exists()
+        assert not (target / "CLAUDE.md").exists()
+        assert not (target / "scripts" / "core").exists()
+        assert "Doctor verdict:" not in result.stdout  # nothing to check
+
+    def test_new_no_kit_is_rung_zero(self, tmp_path):
+        """KIT-0104 F4 through the historical entrance."""
+        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
+        target = tmp_path / "blank"
+        result = run_shim("--new", str(target), "--no-kit", env=env)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "rung 0" in result.stdout.lower()
+        assert (target / "scripts" / "local" / "checks.sh").is_file()
+        assert not (target / ".kit").exists()
+        assert not (target / "CLAUDE.md").exists()
+        branch = subprocess.run(
+            ["git", "-C", str(target), "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
         )
-        assert "BEGIN KIT-LOCAL" in text
+        assert branch.stdout.strip() == "main"
 
-    def test_placeholder_pointer_without_flags(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "noflags")
-        result = run_bootstrap(target, "--shape", "planning")
-        assert result.returncode == 0, result.stderr
-        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "shape: planning" in text
-        assert "target_path:" in text  # placeholder form present
 
-    def test_existing_claude_md_gains_region_keeps_content(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "existing")
-        (target / "CLAUDE.md").write_text(
-            "# My Planning Repo\n\nHand-written intro.\n", encoding="utf-8"
+class TestExitContractPassThrough:
+    """The package's 0/1/2 contract survives the exec unchanged."""
+
+    def test_unknown_shape_exits_2(self, tmp_path):
+        target = make_consumer_dir(tmp_path, "bad")
+        result = run_shim("--adopt", str(target), "--shape", "pyramid")
+        assert result.returncode == 2
+        assert "unknown shape" in (result.stdout + result.stderr).lower()
+
+    def test_unknown_profile_exits_2(self, tmp_path):
+        target = make_consumer_dir(tmp_path, "badprof")
+        result = run_shim("--adopt", str(target), "--profile", "elixir")
+        assert result.returncode == 2
+        assert "unknown profile" in (result.stdout + result.stderr).lower()
+
+    def test_illegal_pair_exits_2_naming_pairs(self, tmp_path):
+        target = make_consumer_dir(tmp_path, "badcombo")
+        result = run_shim(
+            "--adopt", str(target), "--shape", "planning", "--profile", "python"
         )
-        result = run_bootstrap(target, "--shape", "planning")
-        assert result.returncode == 0, result.stderr
-        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "Hand-written intro." in text
-        assert "shape: planning" in text
-
-    def test_target_values_written_literally_no_expansion(self, tmp_path):
-        """claude-code review: $(...) in operator-supplied pointer values
-        must be written literally, never shell-expanded."""
-        target = make_consumer_dir(tmp_path, "hostile")
-        marker = tmp_path / "pwned"
-        result = run_bootstrap(
-            target,
-            "--shape",
-            "planning",
-            "--target-path",
-            f"../x$(touch {marker})",
-        )
-        assert result.returncode == 0, result.stderr
-        assert not marker.exists(), "command substitution executed!"
-        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "$(touch" in text  # literal, unexpanded
+        assert result.returncode == 2
+        assert "illegal shape/profile combination" in result.stderr
+        for pair in ("single+python", "single+none", "planning+none"):
+            assert pair in result.stderr
 
     def test_malformed_target_github_rejected(self, tmp_path):
         target = make_consumer_dir(tmp_path, "badgh")
-        result = run_bootstrap(
-            target, "--shape", "planning", "--target-github", "not a repo slug"
+        result = run_shim(
+            "--adopt",
+            str(target),
+            "--shape",
+            "planning",
+            "--target-github",
+            "not a repo slug",
         )
-        assert result.returncode == 2  # door usage contract
+        assert result.returncode == 2
         assert "owner/repo" in result.stdout + result.stderr
-
-    def test_existing_section_seeds_region_no_desync(self, tmp_path):
-        """BugBot PR #78: with a pre-existing ## Target Repository, the
-        kit-install region must seed FROM it — never from placeholders."""
-        target = make_consumer_dir(tmp_path, "seeded")
-        (target / "CLAUDE.md").write_text(
-            "# Repo\n\n## Target Repository\n\n"
-            "- **Path**: `../real-product`\n"
-            "- **GitHub**: `real/product`\n",
-            encoding="utf-8",
-        )
-        result = run_bootstrap(target, "--shape", "planning")
-        assert result.returncode == 0, result.stderr
-        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "target_path: ../real-product" in text
-        assert "target_github: real/product" in text
-
-    def test_prose_padded_section_still_seeds_region(self, tmp_path):
-        """BugBot round 2: bullets after introductory prose must still
-        be found (whole-section extraction, not a fixed -A window)."""
-        target = make_consumer_dir(tmp_path, "prose")
-        (target / "CLAUDE.md").write_text(
-            "# Repo\n\n## Target Repository\n\n"
-            "This planning repo coordinates the product repo below.\n"
-            "All code changes happen there; specs and reviews live here.\n"
-            "See docs/CROSS-REPO-PATTERN.md for the full pattern.\n\n"
-            "- **Path**: `../prose-product`\n"
-            "- **GitHub**: `prose/product`\n\n"
-            "## Another Section\n\n- **Path**: `../decoy`\n",
-            encoding="utf-8",
-        )
-        result = run_bootstrap(target, "--shape", "planning")
-        assert result.returncode == 0, result.stderr
-        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "target_path: ../prose-product" in text
-        assert "../decoy" not in text.split("kit-install")[1]
-
-    def test_conflicting_flags_with_existing_section_rejected(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "conflict")
-        (target / "CLAUDE.md").write_text(
-            "# Repo\n\n## Target Repository\n\n"
-            "- **Path**: `../real-product`\n"
-            "- **GitHub**: `real/product`\n",
-            encoding="utf-8",
-        )
-        result = run_bootstrap(
-            target, "--shape", "planning", "--target-path", "../other-product"
-        )
-        assert result.returncode == 1
-        assert "conflicts" in result.stdout + result.stderr
-
-
-PYTHON_SEED = REPO_ROOT / "scripts" / "local" / "templates" / "checks-python.sh"
-NONE_SEED = REPO_ROOT / "scripts" / "local" / "templates" / "checks-none.sh"
-
-
-class TestProfiles:
-    """KIT-0050 F3/F4/F6: hook seeding, install record, Project Rules."""
-
-    def test_default_single_seeds_python_hook(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "app")
-        result = run_bootstrap(target)
-        assert result.returncode == 0, result.stderr
-        hook = target / "scripts" / "local" / "checks.sh"
-        assert hook.is_file()
-        assert os.access(hook, os.X_OK)
-        # seeded content IS the template — moved, not rewritten
-        assert hook.read_bytes() == PYTHON_SEED.read_bytes()
-        # the record's only reader must ship alongside the record, or a
-        # non-default profile would be silently ignored by doctor
-        assert (target / "scripts" / "local" / "kit_markers.py").is_file()
-        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "shape: single" in claude
-        assert "profile: python" in claude
-        assert "<!-- BEGIN KIT-LOCAL: project-rules -->" in claude
-        assert "### Python" in claude  # python rules text seeded
-
-    def test_profile_none_seeds_loud_noop(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "docsrepo")
-        result = run_bootstrap(target, "--profile", "none")
-        assert result.returncode == 0, result.stderr
-        hook = target / "scripts" / "local" / "checks.sh"
-        assert hook.read_bytes() == NONE_SEED.read_bytes()
-        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "profile: none" in claude
-        assert "No project toolchain is configured" in claude
-        assert "### Python" not in claude  # no python rules for none
-
-    def test_profile_python_identical_to_flagless(self, tmp_path):
-        # characterization of the default: python IS the flagless profile
-        flagless = make_consumer_dir(tmp_path / "a", "app")
-        explicit = make_consumer_dir(tmp_path / "b", "app")
-        r1 = run_bootstrap(flagless)
-        r2 = run_bootstrap(explicit, "--profile", "python")
-        assert r1.returncode == 0, r1.stderr
-        assert r2.returncode == 0, r2.stderr
-        assert tree_snapshot(flagless) == tree_snapshot(explicit)
-
-    def test_planning_shape_forces_none(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "plan")
-        result = run_bootstrap(target, "--shape", "planning")
-        assert result.returncode == 0, result.stderr
-        hook = target / "scripts" / "local" / "checks.sh"
-        assert hook.read_bytes() == NONE_SEED.read_bytes()
-        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "profile: none" in claude
-
-    def test_planning_with_profile_python_rejected(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "badcombo")
-        result = run_bootstrap(target, "--shape", "planning", "--profile", "python")
-        assert result.returncode == 2  # door usage contract
-        assert "illegal shape/profile combination" in result.stdout + result.stderr
-
-    def test_unknown_profile_rejected(self, tmp_path):
-        target = make_consumer_dir(tmp_path, "badprof")
-        result = run_bootstrap(target, "--profile", "elixir")
-        assert result.returncode == 2  # door usage contract
-        assert "unknown profile" in (result.stdout + result.stderr).lower()
-
-    def test_no_kit_flag_still_seeds_hook_and_record(self, tmp_path):
-        # o3 review gap: no functional --no-kit run existed in the
-        # suite; also pins that the hook/record are toolchain-level,
-        # not kit-workflow-level (seeded even on opt-out)
-        target = make_consumer_dir(tmp_path, "nokit")
-        result = run_bootstrap(target, "--no-kit")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert (target / "scripts" / "core" / "ci-check.sh").is_file()
-        assert (target / "scripts" / "local" / "checks.sh").is_file()
-        assert not (target / ".claude" / "agents" / "planner.md").exists()
-        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "profile: python" in claude
-        # KIT-0067 F3: no planner shipped -> no planner self-direction
-        assert "first-session" not in claude
-
-    def test_no_kit_rebootstrap_removes_first_session_region(self, tmp_path):
-        # fast-gate evaluator (KIT-0067): --no-kit prunes the planner,
-        # so a first-session region from an earlier kit-enabled install
-        # must go with it — never a stale instruction to invoke an
-        # agent that no longer ships
-        target = make_consumer_dir(tmp_path, "downgrade")
-        assert run_bootstrap(target).returncode == 0
-        assert "first-session" in (target / "CLAUDE.md").read_text(encoding="utf-8")
-        result = run_bootstrap(target, "--no-kit")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "first-session region removed" in result.stdout
-        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "first-session" not in claude
-
-    def test_no_kit_rebootstrap_keeps_customized_first_session(self, tmp_path):
-        # fast-gate evaluator round 2 (KIT-0067): a CUSTOMIZED region
-        # body is consumer-owned — --no-kit removes only the kit's own
-        # unmodified seed, never consumer edits
-        target = make_consumer_dir(tmp_path, "customized")
-        assert run_bootstrap(target).returncode == 0
-        claude_path = target / "CLAUDE.md"
-        custom_line = "My own first-session ritual: read the runbook."
-        claude_path.write_text(
-            claude_path.read_text(encoding="utf-8").replace(
-                "First session in this repo: invoke the `planner` agent"
-                " (in a new tab) — it triages the backlog and recommends"
-                " what to start.",
-                custom_line,
-            ),
-            encoding="utf-8",
-        )
-        result = run_bootstrap(target, "--no-kit")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "first-session region customized — left in place" in result.stdout
-        assert custom_line in claude_path.read_text(encoding="utf-8")
-
-    def test_no_kit_rebootstrap_removes_legacy_first_session_body(self, tmp_path):
-        # KIT-0084 upgrade path: a consumer seeded BEFORE the body
-        # gained the doctor/env-keys sentence carries the legacy text
-        # verbatim — that is unmodified, not customized, and --no-kit
-        # must still remove it
-        legacy_body = (
-            "First session in this repo: invoke the `planner` agent"
-            " (in a new tab) — it triages the backlog and recommends"
-            " what to start."
-        )
-        target = make_consumer_dir(tmp_path, "legacy-body")
-        assert run_bootstrap(target).returncode == 0
-        claude_path = target / "CLAUDE.md"
-        seeded = claude_path.read_text(encoding="utf-8")
-        begin = "<!-- BEGIN KIT-LOCAL: first-session -->\n"
-        end = "<!-- END KIT-LOCAL: first-session -->"
-        head, rest = seeded.split(begin, 1)
-        _, tail = rest.split(end, 1)
-        claude_path.write_text(
-            head + begin + legacy_body + "\n" + end + tail, encoding="utf-8"
-        )
-        result = run_bootstrap(target, "--no-kit")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "first-session region removed" in result.stdout
-        assert "first-session" not in claude_path.read_text(encoding="utf-8")
-
-    def test_no_kit_malformed_marker_fails_loud_without_data_loss(self, tmp_path):
-        # CodeRabbit (this PR): a first-session BEGIN marker whose END
-        # marker is missing must abort the --no-kit re-bootstrap loudly
-        # — never let the removal awk eat the file to EOF
-        target = make_consumer_dir(tmp_path, "malformed")
-        assert run_bootstrap(target).returncode == 0
-        claude_path = target / "CLAUDE.md"
-        before = claude_path.read_text(encoding="utf-8")
-        claude_path.write_text(
-            before.replace("<!-- END KIT-LOCAL: first-session -->\n", ""),
-            encoding="utf-8",
-        )
-        mangled = claude_path.read_text(encoding="utf-8")
-        result = run_bootstrap(target, "--no-kit")
-        assert result.returncode == 1
-        assert "kit_markers extract first-session failed" in (
-            result.stdout + result.stderr
-        )
-        assert claude_path.read_text(encoding="utf-8") == mangled
-
-    def test_first_session_region_seeded_with_kit(self, tmp_path):
-        # KIT-0067 F3: the seeded CLAUDE.md closes with the planner
-        # self-direction region wherever the kit workflow (and thus
-        # the planner agent) ships
-        target = make_consumer_dir(tmp_path, "firstsession")
-        result = run_bootstrap(target)
-        assert result.returncode == 0, result.stderr + result.stdout
-        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "<!-- BEGIN KIT-LOCAL: first-session -->" in claude
-        assert "invoke the `planner` agent" in claude
-
-    def test_equals_form_flags_parse(self, tmp_path):
-        # o3 review gap: the --flag=value forms had no functional run
-        target = make_consumer_dir(tmp_path, "eqform")
-        result = run_bootstrap(target, "--shape=planning", "--profile=none")
-        assert result.returncode == 0, result.stderr + result.stdout
-        claude = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "shape: planning" in claude
-        assert "profile: none" in claude
-
-    def test_rebootstrap_preserves_customized_hook(self, tmp_path):
-        # N4's bootstrap half: the hook is consumer-owned after seeding
-        target = make_consumer_dir(tmp_path, "app")
-        assert run_bootstrap(target).returncode == 0
-        hook = target / "scripts" / "local" / "checks.sh"
-        custom = "#!/bin/bash\n# my js checks\nnpm test\n"
-        hook.write_text(custom, encoding="utf-8")
-        result = run_bootstrap(target)
-        assert result.returncode == 0, result.stderr
-        assert hook.read_text(encoding="utf-8") == custom
-        assert "preserved" in result.stdout
-
-    def test_rebootstrap_preserves_claude_md_regions(self, tmp_path):
-        # append-if-absent: consumer edits inside the regions survive a
-        # re-bootstrap byte-for-byte, and no duplicate regions appear
-        target = make_consumer_dir(tmp_path, "app")
-        assert run_bootstrap(target).returncode == 0
-        claude_md = target / "CLAUDE.md"
-        edited = claude_md.read_text(encoding="utf-8").replace(
-            "### Python", "### Python (consumer-tuned)"
-        )
-        claude_md.write_text(edited, encoding="utf-8")
-        result = run_bootstrap(target)
-        assert result.returncode == 0, result.stderr
-        text = claude_md.read_text(encoding="utf-8")
-        assert "### Python (consumer-tuned)" in text
-        assert text.count("BEGIN KIT-LOCAL: kit-install") == 1
-        assert text.count("BEGIN KIT-LOCAL: project-rules") == 1
-
-    @pytest.mark.parametrize(
-        "shape_args",
-        [
-            pytest.param((), id="single"),
-            pytest.param(
-                (
-                    "--shape",
-                    "planning",
-                    "--target-path",
-                    "../my-product",
-                    "--target-github",
-                    "acme/my-product",
-                ),
-                id="planning",
-            ),
-        ],
-    )
-    def test_rebootstrap_sweeps_retired_sync_machinery(self, tmp_path, shape_args):
-        """KIT-0102 (ADR-0028 phase 4): a consumer bootstrapped before the
-        retirement still carries the copy-sync machinery. RSYNC_BASE uses
-        --ignore-existing and the planning cp loop is [ ! -e ]-guarded, so
-        nothing removes those files on its own — the door sweeps them
-        explicitly. Without the sweep a re-bootstrapped repo keeps a dead
-        engine and a manifest pointing at it (code-reviewer-fast, KIT-0102).
-
-        Parametrized over BOTH shapes: the door calls sweep_retired_sync
-        from two places, and a single-shape-only test stays green if the
-        planning call is deleted or drifts (CodeRabbit, PR #127).
-        """
-        target = make_consumer_dir(tmp_path, "app")
-        assert run_bootstrap(target, *shape_args).returncode == 0
-
-        # plant the retired machinery exactly as a pre-KIT-0102 consumer
-        # would carry it
-        stale = {
-            target / "scripts" / "core" / "sync_from_manifest.py": "stale engine\n",
-            target / "scripts" / ".core-manifest.json": '{"core_version": "2.1.0"}\n',
-            target
-            / "scripts"
-            / "core"
-            / "doctor.d"
-            / "60-push-sync-token.sh": "stale check\n",
-        }
-        # the planning shape does not ship .github/, so the workflow sweep
-        # is only meaningful for the single shape
-        if not shape_args:
-            stale[target / ".github" / "workflows" / "sync-core-scripts.yml"] = (
-                "stale workflow\n"
-            )
-        for path, body in stale.items():
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(body, encoding="utf-8")
-
-        result = run_bootstrap(target, *shape_args)
-        assert result.returncode == 0, result.stderr
-        for path in stale:
-            assert not path.exists(), f"re-bootstrap left retired file: {path}"

--- a/tests/test_bots_conformance.py
+++ b/tests/test_bots_conformance.py
@@ -1,8 +1,9 @@
 """Cross-reader conformance for the bots declaration (KIT-0056 retro #2).
 
 ONE fixture table run through all three readers of the kit-install
-``bots:`` record — the setup door (``normalize_bots`` over
-``record_field``), the project script (``_doctor_install`` /
+``bots:`` record — the packaged door (``agentive_kit.door``'s
+``normalize_bots`` over ``load_record``; the bash front retired into
+an exec shim, KIT-0104), the project script (``_doctor_install`` /
 ``_normalize_bots``), and ``preflight-check.sh`` (Gates 2/3) — asserting
 they agree on validity and on the effective token set. KIT-0056's five
 reviewers found five faces of one seams-between-readers class; pairwise
@@ -42,9 +43,9 @@ PROJECT_SCRIPT = REPO_ROOT / "scripts" / "core" / "project"
 if not DOOR.exists() or not KIT_MARKERS.exists():
     pytest.skip("scripts/local absent (consumer checkout)", allow_module_level=True)
 
+from agentive_kit import door as pkg_door  # noqa: E402  (conftest sys.path)
 from test_preflight_check import proj  # noqa: E402,F401  (fixture re-export)
 from test_preflight_check import _baseline, _gates, _graphql  # noqa: E402
-from test_setup_door import _scrubbed_env, sourced  # noqa: E402
 
 # The project script is extensionless — exec it as a module, the
 # test_project_script.py pattern (distinct module name: no collision).
@@ -133,21 +134,27 @@ def _preflight_verdict(proj, lines: list[str]) -> tuple[bool, frozenset]:
         (local_dir / "kit_markers.py").unlink(missing_ok=True)
 
 
-def _door_verdict(lines: list[str]) -> tuple[bool, frozenset | None]:
-    """The door's reading: record_field (first key wins) + normalize_bots.
+def _door_verdict(tmp_path: Path, lines: list[str]) -> tuple[bool, frozenset | None]:
+    """The packaged door's reading: load_record (first key wins, empty
+    values skipped) + normalize_bots.
 
     Returns (False, None) for a not-valid declaration — the door refuses
     or re-asks instead of failing closed, so there is no effective set.
+    An absent/empty value is "unanswered" to the door, which matches the
+    table's not-valid rows (the door would re-ask, never fail closed).
     """
-    env = _scrubbed_env()
-    env["CONF_REGION"] = _region(lines)
-    result = sourced(
-        'raw="$(record_field "$CONF_REGION" bots)"; normalize_bots "$raw"',
-        env=env,
-    )
-    if result.returncode != 0:
+    root = tmp_path / "door-reader"
+    root.mkdir()
+    (root / "CLAUDE.md").write_text("# stub\n\n" + _region(lines), encoding="utf-8")
+    raw = pkg_door.load_record(root).get("bots")
+    if raw is None:
         return False, None
-    canonical = result.stdout.strip()
+    try:
+        canonical = pkg_door.normalize_bots(raw)
+    except ValueError:
+        return False, None
+    if canonical is None:
+        return False, None
     if canonical == "none":
         return True, frozenset()
     return True, frozenset(canonical.split())
@@ -159,7 +166,7 @@ def _door_verdict(lines: list[str]) -> tuple[bool, frozenset | None]:
 def test_three_readers_agree(case_id, lines, valid, effective, proj, tmp_path):
     project_valid, project_set = _project_verdict(tmp_path, lines)
     preflight_valid, preflight_set = _preflight_verdict(proj, lines)
-    door_valid, door_set = _door_verdict(lines)
+    door_valid, door_set = _door_verdict(tmp_path, lines)
 
     assert project_valid == valid, f"{case_id}: project reader disagrees on validity"
     assert preflight_valid == valid, f"{case_id}: preflight disagrees on validity"

--- a/tests/test_entrance_shims.py
+++ b/tests/test_entrance_shims.py
@@ -3,12 +3,15 @@
 KIT-0053 pinned the historical flag surfaces of create-project.sh and
 bootstrap.sh before turning them into shims over the one setup door.
 KIT-0054 (0.9.0) removed the shims and the door's --legacy-shim
-fidelity channel, so this module keeps only what outlives them: the
-export/materials engine e2e coverage (re-pinned on door flags) and the
-static call-graph direction (door -> engine, never the reverse).
-TestOldEntrancesRemoved guards the removal itself — the historical
-entrance paths must stay gone, so an old invocation hard-fails instead
-of silently resurrecting a second door.
+fidelity channel; KIT-0104 then moved the door itself into the
+agentive-kit package and turned bootstrap into an exec shim over it.
+This module keeps what outlives all of that: the scaffold/materials
+engine e2e coverage (now exercised THROUGH the shim, so it also proves
+the shim's translation) and the static call-graph direction (shim →
+package → engine, plus the shim's one direct materials-engine call —
+never the reverse). TestOldEntrancesRemoved guards the removals — the
+historical entrance paths must stay gone, so an old invocation
+hard-fails instead of silently resurrecting a second door.
 
 Consumer-rsync boundary: this module reads scripts/local/ content, so
 it is excluded from the consumer tests/ rsync in the consumer engine
@@ -299,18 +302,26 @@ def _command_lines(text: str) -> list[str]:
 
 
 class TestCallGraph:
-    """F3: the call graph is strictly door -> engine."""
+    """The call graph after KIT-0104: the shim execs the PACKAGE (which
+    drives the scaffold/consumer engines as staged data), and keeps one
+    direct engine call — the materials branch that dies with it."""
 
-    def test_door_calls_engines_not_old_entrances(self):
+    def test_shim_execs_the_package_and_only_the_materials_engine(self):
         commands = _command_lines(DOOR.read_text(encoding="utf-8"))
-        for engine in ENGINES:
-            assert any(
-                engine.name in line for line in commands
-            ), f"door must reference {engine.name} in a command position"
+        assert any(
+            "agentive_kit.cli" in line for line in commands
+        ), "shim must exec the packaged door (python -m agentive_kit.cli)"
+        assert any(
+            "engine-materials.sh" in line for line in commands
+        ), "the materials branch drives engine-materials.sh directly"
+        for packaged_engine in ("engine-consumer.sh", "engine-scaffold.sh"):
+            assert not any(
+                packaged_engine in line for line in commands
+            ), f"shim must not drive {packaged_engine} — the package does"
         for old_name in ("bootstrap-consumer.sh", "create-project.sh"):
             assert not any(
                 old_name in line for line in commands
-            ), f"door must never call removed entrance {old_name}"
+            ), f"shim must never call removed entrance {old_name}"
 
     def test_engines_do_not_call_the_door(self):
         for engine in ENGINES:

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -206,6 +206,15 @@ class TestTranslation:
         assert result.returncode == 2
         assert "target directory is required" in result.stderr
 
+    def test_second_mode_flag_refused_never_drops_first_target(self, tmp_path):
+        # CodeRabbit (this PR): '--new a --adopt b' must not silently
+        # drop 'a' (the masking class) — one mode per run
+        result = run_door(
+            "--new", str(tmp_path / "a"), "--adopt", str(tmp_path / "b"), timeout=30
+        )
+        assert result.returncode == 2
+        assert "only one mode flag is allowed" in result.stderr
+
     def test_mode_flag_must_not_swallow_following_flag(self):
         # BugBot PR #81: '--new --shape planning' must not adopt
         # '--shape' as the target directory
@@ -237,8 +246,9 @@ class TestTranslation:
 
 class TestMaterialsBranch:
     """The one legacy branch the shim keeps (dies with it, KIT-0107):
-    exactly `--adopt <dir> --design-materials [--no-preset]` — anything
-    else alongside is refused loudly, never silently dropped."""
+    exactly `--adopt <dir> --design-materials` — any other flag
+    alongside (including `--no-preset`: the materials engine reads no
+    preset) is refused loudly, never silently dropped."""
 
     def test_requires_adopt(self, tmp_path):
         result = run_door("--new", str(tmp_path / "x"), "--design-materials")
@@ -262,7 +272,18 @@ class TestMaterialsBranch:
             ["--shape", "planning"],
             ["--profile", "none"],
             ["--bots", "none"],
+            # the materials engine reads no preset, so the flag would
+            # be a silent no-op — refused like the rest (CodeRabbit)
+            ["--no-preset"],
         ):
             result = run_door("--adopt", str(target), "--design-materials", *extra)
             assert result.returncode == 2, extra
             assert "cannot be combined with --design-materials" in result.stderr, extra
+
+    def test_kit_checkout_target_refused(self):
+        """BugBot (this PR): the branch bypasses the package's
+        kit-checkout guard, so it carries the old door's own refusal —
+        the materials flow must never rsync the kit onto itself."""
+        result = run_door("--adopt", str(REPO_ROOT), "--design-materials")
+        assert result.returncode == 2
+        assert "kit source repo itself" in result.stderr

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -224,6 +224,15 @@ class TestTranslation:
         result = run_door("--new", "-h", timeout=30)
         assert result.returncode == 2
         assert "requires a value" in result.stderr
+        # equals-form arms validate the suffix the same way — a
+        # '--new=--help' must be a usage error, never help exit 0
+        # (CodeRabbit round 2)
+        result = run_door("--new=--help", timeout=30)
+        assert result.returncode == 2
+        assert "requires a value" in result.stderr
+        result = run_door("--adopt=-h", timeout=30)
+        assert result.returncode == 2
+        assert "requires a value" in result.stderr
 
     def test_equals_form_translates(self, tmp_path):
         # --adopt=<dir> reaches the package as a target: the run gets

--- a/tests/test_setup_door.py
+++ b/tests/test_setup_door.py
@@ -1,16 +1,30 @@
-"""Tests for scripts/local/bootstrap — the one setup door (KIT-0053).
+"""Tests for scripts/local/bootstrap — the exec shim over the packaged
+door (KIT-0104 F3).
 
-Three layers:
-- resolve/validate units run against the SOURCED door (no filesystem
-  side effects) — the F1 internal-decomposition contract;
-- the exit contract (F6): 0 install-ok / 1 install-failed / 2
-  usage-or-illegal, with illegal combos naming the legal pairs (F2);
-- scratch e2e per matrix cell x mode, each asserting the doctor tail
-  (P4) and the recorded shape/profile pair.
+The door lives in the agentive-kit package (``agentive new`` /
+``agentive adopt``); ``bootstrap`` only translates the historical
+``--new <dir>`` / ``--adopt <dir>`` flags to the package verbs and
+execs the checkout's own package source. This module pins the SHIM
+contract:
 
-Non-TTY discipline (N4): every subprocess here runs with stdin closed,
-so any prompt that leaked past the flag layer would hang and trip the
-timeout instead of silently passing.
+- flag translation (split and ``=`` forms, flag-swallowing guard);
+- help deferred to the package — no second copy of the matrix or the
+  flag table survives in the shim file (F2, asserted statically);
+- exit-code pass-through (the package's 0/1/2 contract);
+- the one legacy branch the shim keeps: ``--adopt --design-materials``
+  (dies with the shim — KIT-0107);
+- the removal notice on stderr.
+
+Everything the old door FRONT did — resolution chain, matrix
+validation, preset layer, record conflicts, .env seeding — is packaged
+code now, covered by ``tests/agentive_kit/test_door_units.py`` and
+``test_door_e2e.py``. Whole-flow coverage THROUGH the shim lives in
+``tests/test_bootstrap_shapes.py`` (packaged-contract shapes +
+shim-vs-direct equivalence) and ``tests/test_scaffold_acceptance.py``
+(per-shape acceptance, which imports this module's helpers).
+
+Non-TTY discipline (N4): every subprocess runs with stdin closed, so
+any prompt would hang and trip the timeout instead of silently passing.
 
 Consumer-rsync boundary: this module reads scripts/local/ content, so
 it is excluded from the consumer tests/ rsync in engine-consumer.sh
@@ -19,9 +33,7 @@ it is excluded from the consumer tests/ rsync in engine-consumer.sh
 
 from __future__ import annotations
 
-import json
 import os
-import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -43,12 +55,11 @@ for tool in ("bash", "git", "rsync"):
 
 
 # Nonexistent hermetic paths keep every door run hermetic (N1): the
-# operator's REAL config home (<kit-parent>/agentive-config/,
-# KIT-0058) must never leak into the suite — a filled preset would
-# change door answers and break characterization.
-# AGENTIVE_KIT_CONFIG_DIR is the door's one override; tests that need
-# a preset pass their own via extra (override wins). XDG_CONFIG_HOME
-# stays pinned too: git's own config lookup goes through it.
+# operator's REAL config home must never leak into the suite — a
+# filled preset would change door answers. AGENTIVE_KIT_CONFIG_DIR is
+# the door's one override; tests that need a preset pass their own via
+# extra (override wins). XDG_CONFIG_HOME stays pinned too: git's own
+# config lookup goes through it.
 _HERMETIC_XDG = REPO_ROOT / "tests" / ".no-such-xdg"
 _HERMETIC_CONFIG = REPO_ROOT / "tests" / ".no-such-config-home"
 
@@ -98,603 +109,6 @@ def run_door(
     )
 
 
-def sourced(snippet: str, env: dict | None = None) -> subprocess.CompletedProcess:
-    """Run a snippet with the door's functions loaded (no main)."""
-    return subprocess.run(
-        ["bash", "-c", f'source "{DOOR}"; {snippet}'],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        stdin=subprocess.DEVNULL,
-        env=env or _scrubbed_env(),
-    )
-
-
-def write_preset(base: Path, content: str) -> Path:
-    """A preset in a scratch config home (passed to the door via
-    AGENTIVE_KIT_CONFIG_DIR — never the real sibling folder, N1);
-    returns the config-home dir."""
-    cfg = base / "agentive-config"
-    cfg.mkdir(parents=True, exist_ok=True)
-    (cfg / "preset").write_text(content, encoding="utf-8")
-    return cfg
-
-
-class TestResolveValidateUnits:
-    """The sourced resolve/validate layer — no filesystem effects."""
-
-    @pytest.mark.parametrize(
-        "shape,profile",
-        [("single", "python"), ("single", "none"), ("planning", "none")],
-    )
-    def test_matrix_legal_cells(self, shape, profile):
-        result = sourced(f"validate_pair {shape} {profile}")
-        assert result.returncode == 0, result.stderr
-
-    def test_matrix_illegal_cell_names_legal_pairs(self):
-        result = sourced("validate_pair planning python")
-        assert result.returncode == 1
-        assert "illegal shape/profile combination" in result.stderr
-        for pair in ("single+python", "single+none", "planning+none"):
-            assert pair in result.stderr, f"rejection must name {pair}"
-
-    def test_kit_default_shape_is_single(self):
-        result = sourced('resolve_setting shape ""')
-        assert result.returncode == 0
-        assert result.stdout.strip() == "single"
-
-    @pytest.mark.parametrize(
-        "shape,expected", [("single", "python"), ("planning", "none")]
-    )
-    def test_kit_default_profile_follows_shape(self, shape, expected):
-        result = sourced(f'resolve_setting profile "" {shape}')
-        assert result.returncode == 0
-        assert result.stdout.strip() == expected
-
-    def test_cli_value_wins_over_default(self):
-        result = sourced("resolve_setting profile none single")
-        assert result.stdout.strip() == "none"
-
-    def test_preset_layer_unloaded_answers_nothing(self):
-        # No preset loaded (or --no-preset): the layer answers nothing —
-        # the machine behaves exactly like a preset-less machine (N1).
-        # (Guarded call: the sourced door sets -e, so a bare failing
-        # preset_get would exit the test shell before the echo.)
-        result = sourced('preset_get shape || echo "rc=$?"')
-        assert result.stdout.strip() == "rc=1"  # answers nothing, prints nothing
-
-    def test_unknown_values_rejected(self):
-        assert sourced('validate_values pyramid ""').returncode == 1
-        assert sourced("validate_values single elixir").returncode == 1
-
-    def test_empty_preset_answer_falls_through(self):
-        # o3 finding: a P7 preset that succeeds but echoes nothing must
-        # count as unanswered — the chain falls through to kit defaults
-        result = sourced('preset_get() { echo ""; }; resolve_setting shape ""')
-        assert result.returncode == 0
-        assert result.stdout.strip() == "single"
-
-
-class TestPresetUnits:
-    """KIT-0056 F5: the preset layer inside the ONE resolve chain —
-    CLI > preset > kit default (record short-circuits preset on adopt).
-    All sourced; the preset file lives in a scratch config home
-    (AGENTIVE_KIT_CONFIG_DIR), never the real sibling folder."""
-
-    def _env(self, tmp_path, content):
-        return _scrubbed_env(
-            AGENTIVE_KIT_CONFIG_DIR=str(write_preset(tmp_path, content))
-        )
-
-    def test_preset_beats_kit_default(self, tmp_path):
-        env = self._env(tmp_path, "shape: planning\n")
-        result = sourced('load_preset; resolve_setting shape ""', env=env)
-        assert result.returncode == 0, result.stderr
-        assert result.stdout.strip() == "planning"
-
-    def test_cli_beats_preset(self, tmp_path):
-        env = self._env(tmp_path, "shape: planning\n")
-        result = sourced("load_preset; resolve_setting shape single", env=env)
-        assert result.stdout.strip() == "single"
-
-    def test_record_short_circuits_preset(self, tmp_path):
-        # Adopt of a recorded target: the question is not open, so the
-        # preset is not consulted — the chain falls to the kit default
-        # exactly as on a preset-less machine (record wins; divergence
-        # is doctor --against-preset's INFO surface).
-        env = self._env(tmp_path, "profile: none\n")
-        result = sourced(
-            'load_preset; REC_PROFILE=none; resolve_setting profile "" single',
-            env=env,
-        )
-        assert result.stdout.strip() == "python"  # kit default, not the preset
-
-    def test_no_preset_flag_disables_the_layer(self, tmp_path):
-        env = self._env(tmp_path, "shape: planning\n")
-        result = sourced('NO_PRESET=1; load_preset; resolve_setting shape ""', env=env)
-        assert result.stdout.strip() == "single"
-
-    def test_unknown_key_warns_and_skips_never_errors(self, tmp_path):
-        env = self._env(tmp_path, "coffee: espresso\nshape: planning\n")
-        result = sourced('load_preset; resolve_setting shape ""', env=env)
-        assert result.returncode == 0, result.stderr
-        assert "unknown preset key 'coffee'" in result.stderr
-        assert "line 1" in result.stderr
-        # known keys after the unknown one still load (skip, not abort)
-        assert result.stdout.strip() == "planning"
-
-    def test_malformed_line_fails_loud_naming_the_line(self, tmp_path):
-        env = self._env(tmp_path, "shape: single\nprofile python\n")
-        result = sourced("load_preset", env=env)
-        assert result.returncode == 2
-        assert "malformed preset line 2" in result.stderr
-        assert "profile python" in result.stderr
-
-    def test_duplicate_key_fails_loud(self, tmp_path):
-        env = self._env(tmp_path, "shape: single\nshape: planning\n")
-        result = sourced("load_preset", env=env)
-        assert result.returncode == 2
-        assert "duplicate preset key 'shape'" in result.stderr
-
-    def test_empty_value_falls_through(self, tmp_path):
-        # an empty answer is unanswered, never a resolve to ""
-        env = self._env(tmp_path, "shape:\n")
-        result = sourced('load_preset; resolve_setting shape ""', env=env)
-        assert result.returncode == 0
-        assert result.stdout.strip() == "single"
-
-    def test_comments_and_blanks_ignored(self, tmp_path):
-        env = self._env(tmp_path, "# a comment\n\nshape: planning\n")
-        result = sourced('load_preset; resolve_setting shape ""', env=env)
-        assert result.stdout.strip() == "planning"
-
-    def test_env_not_gitignored_refuses_secret_copy(self, tmp_path):
-        # F6's hard guard, exercised directly: a target whose .env is
-        # NOT gitignored must refuse the copy outright — no .env file,
-        # exit 1, and the reason named
-        target = make_adopt_dir(tmp_path, "no-ignore")  # no .gitignore at all
-        src = tmp_path / "env-template"
-        src.write_text("KEY=secret-fixture\n", encoding="utf-8")
-        src.chmod(0o600)
-        result = sourced(f'TARGET="{target}"; apply_env_source "{src}"')
-        assert result.returncode == 1
-        assert "refusing to seed secrets" in result.stderr
-        assert not (target / ".env").exists()
-
-
-class TestNormalizeBots:
-    """KIT-0056 F1: 'none' alone, or a subset of coderabbit/bugbot —
-    normalized to canonical order, comma- or space-separated input."""
-
-    @pytest.mark.parametrize(
-        "raw,expected",
-        [
-            ("coderabbit bugbot", "coderabbit bugbot"),
-            ("bugbot coderabbit", "coderabbit bugbot"),
-            ("bugbot,coderabbit", "coderabbit bugbot"),
-            ("CodeRabbit,BUGBOT", "coderabbit bugbot"),  # case-insensitive
-            ("coderabbit", "coderabbit"),
-            ("bugbot", "bugbot"),
-            ("coderabbit coderabbit", "coderabbit"),  # duplicates collapse
-            ("bugbot,bugbot coderabbit", "coderabbit bugbot"),
-            ("none", "none"),
-            ("None", "none"),
-        ],
-    )
-    def test_canonical_forms(self, raw, expected):
-        result = sourced(f'normalize_bots "{raw}"')
-        assert result.returncode == 0, result.stderr
-        assert result.stdout.strip() == expected
-
-    def test_unknown_bot_rejected(self):
-        result = sourced('normalize_bots horsebot || echo "rc=$?"')
-        assert "unknown bot 'horsebot'" in result.stderr
-        assert result.stdout.strip() == "rc=1"
-
-    def test_glob_token_not_expanded(self, tmp_path):
-        # CodeRabbit PR #83: a '*' token must be rejected AS '*', not
-        # glob-expanded into whatever filenames the cwd holds
-        (tmp_path / "coderabbit").touch()  # a file a glob could hit
-        result = subprocess.run(
-            ["bash", "-c", f'source "{DOOR}"; normalize_bots "*"'],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            stdin=subprocess.DEVNULL,
-            env=_scrubbed_env(),
-            cwd=tmp_path,
-        )
-        assert result.returncode == 1
-        assert "unknown bot '*'" in result.stderr
-
-    def test_none_combined_rejected(self):
-        result = sourced('normalize_bots "none bugbot" || echo "rc=$?"')
-        assert "'none' cannot be combined" in result.stderr
-        assert result.stdout.strip() == "rc=1"
-
-    def test_empty_input_is_unanswered_not_error(self):
-        # rc 1 with NO error text: empty means "question still open"
-        # (the caller prompts or writes nothing), never a rejection
-        result = sourced('normalize_bots "" || echo "rc=$?"')
-        assert result.stdout.strip() == "rc=1"
-        assert result.stderr == ""
-
-
-class TestExitContract:
-    """F6: 0 install-ok / 1 install-failed / 2 usage-or-illegal."""
-
-    def test_help_exits_zero(self):
-        result = run_door("--help")
-        assert result.returncode == 0
-        assert "the one setup door" in result.stdout
-        assert "--new" in result.stdout and "--adopt" in result.stdout
-        assert "Exit contract" in result.stdout
-
-    def test_unknown_flag_is_usage(self):
-        assert run_door("--frobnicate").returncode == 2
-
-    def test_mode_flag_must_not_swallow_following_flag(self):
-        # BugBot PR #81: '--new --shape planning' must not adopt
-        # '--shape' as the target directory
-        result = run_door("--new", "--shape", "planning", timeout=30)
-        assert result.returncode == 2
-        assert "requires a value" in result.stderr
-        result = run_door("--adopt", "--profile", "none", timeout=30)
-        assert result.returncode == 2
-        assert "requires a value" in result.stderr
-        # short options are flags too, not targets
-        result = run_door("--new", "-h", timeout=30)
-        assert result.returncode == 2
-        assert "requires a value" in result.stderr
-
-    def test_missing_mode_non_tty_fails_fast(self):
-        result = run_door(timeout=30)
-        assert result.returncode == 2
-        assert "mode is required" in result.stderr
-
-    def test_missing_target_non_tty_fails_fast(self, tmp_path):
-        result = run_door("--adopt", timeout=30)
-        assert result.returncode == 2
-        assert "target directory is required" in result.stderr
-
-    def test_illegal_pair_exits_2_naming_pairs(self, tmp_path):
-        result = run_door(
-            "--adopt", str(tmp_path), "--shape", "planning", "--profile", "python"
-        )
-        assert result.returncode == 2
-        for pair in ("single+python", "single+none", "planning+none"):
-            assert pair in result.stderr
-
-    def test_unknown_shape_exits_2(self, tmp_path):
-        assert run_door("--adopt", str(tmp_path), "--shape", "cube").returncode == 2
-
-    def test_unknown_profile_exits_2(self, tmp_path):
-        result = run_door("--adopt", str(tmp_path), "--profile", "elixir")
-        assert result.returncode == 2
-
-    def test_venv_offer_needs_python_profile(self, tmp_path):
-        result = run_door("--adopt", str(tmp_path), "--profile", "none", "--with-venv")
-        assert result.returncode == 2
-        assert "--with-venv requires profile python" in result.stderr
-
-    def test_name_prefix_are_new_only(self, tmp_path):
-        result = run_door("--adopt", str(tmp_path), "--name", "X")
-        assert result.returncode == 2
-
-    def test_target_pointer_is_planning_only(self, tmp_path):
-        result = run_door("--adopt", str(tmp_path), "--target-path", "../x")
-        assert result.returncode == 2
-
-    def test_no_kit_materials_contradiction(self, tmp_path):
-        # BugBot PR #81: the materials engine installs the full kit
-        # workflow — --no-kit cannot be honored there and must be
-        # rejected loudly, never silently dropped
-        result = run_door("--adopt", str(tmp_path), "--design-materials", "--no-kit")
-        assert result.returncode == 2
-        assert "--no-kit contradicts --design-materials" in result.stderr
-
-    def test_no_kit_planning_contradiction(self, tmp_path):
-        result = run_door("--adopt", str(tmp_path), "--shape", "planning", "--no-kit")
-        assert result.returncode == 2
-
-    def test_invalid_bots_flag_exits_2(self, tmp_path):
-        result = run_door("--adopt", str(tmp_path), "--bots", "horsebot")
-        assert result.returncode == 2
-        assert "unknown bot 'horsebot'" in result.stderr
-
-    def test_bots_none_combined_exits_2(self, tmp_path):
-        result = run_door("--adopt", str(tmp_path), "--bots", "none coderabbit")
-        assert result.returncode == 2
-        assert "'none' cannot be combined" in result.stderr
-
-    def test_malformed_preset_exits_2_before_any_work(self, tmp_path):
-        cfg = write_preset(tmp_path, "this is not a preset\n")
-        env = _scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg))
-        result = run_door("--new", str(tmp_path / "proj"), env=env, timeout=30)
-        assert result.returncode == 2
-        assert "malformed preset line 1" in result.stderr
-        assert not (tmp_path / "proj").exists()
-
-    def test_new_target_must_not_exist(self, tmp_path):
-        result = run_door("--new", str(tmp_path))
-        assert result.returncode == 2
-        assert "already exists" in result.stderr
-
-    def test_adopt_target_must_exist(self, tmp_path):
-        result = run_door("--adopt", str(tmp_path / "nope"))
-        assert result.returncode == 2
-        assert "does not exist" in result.stderr
-
-    def test_adopting_the_kit_itself_refused(self):
-        result = run_door("--adopt", str(REPO_ROOT))
-        assert result.returncode == 2
-        assert "kit source repo" in result.stderr
-
-    def test_missing_git_identity_fails_fast_with_guidance(self, tmp_path):
-        # o3 finding: without an identity the export engine would die
-        # mid-run with git's own cryptic error — the door pre-checks
-        for key in ("user.email", "user.name"):
-            system_cfg = subprocess.run(
-                ["git", "config", "--system", "--get", key],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if system_cfg.returncode == 0:
-                pytest.skip(f"system gitconfig carries {key} on this machine")
-        home = tmp_path / "bare-home"
-        home.mkdir()
-        env = _scrubbed_env(HOME=str(home), XDG_CONFIG_HOME=str(home / "xdg"))
-        result = run_door("--new", str(tmp_path / "proj"), env=env)
-        assert result.returncode == 1
-        assert "git identity incomplete" in result.stderr
-        assert not (tmp_path / "proj").exists()  # failed BEFORE any work
-
-        # email alone is not an identity — commits need name AND email
-        # (BugBot PR #81)
-        xdg = home / "xdg"
-        (xdg / "git").mkdir(parents=True)
-        (xdg / "git" / "config").write_text(
-            "[user]\n\temail = only-email@example.invalid\n", encoding="utf-8"
-        )
-        result = run_door("--new", str(tmp_path / "proj"), env=env)
-        assert result.returncode == 1
-        assert "user.name unset" in result.stderr
-
-
-def _kit_install_region(target: Path) -> str:
-    text = (target / "CLAUDE.md").read_text(encoding="utf-8")
-    assert "<!-- BEGIN KIT-LOCAL: kit-install -->" in text
-    return text.split("BEGIN KIT-LOCAL: kit-install")[1].split(
-        "END KIT-LOCAL: kit-install"
-    )[0]
-
-
-def _assert_doctor_tail(stdout: str) -> None:
-    assert "project doctor" in stdout
-    assert "DOCTOR:" in stdout, "doctor checks must have run"
-    assert "Doctor verdict:" in stdout
-    assert "Install complete:" in stdout
-
-
-def _assert_packaged_tail(stdout: str) -> None:
-    """--new (KIT-0093 packaged mode): the two installs are verified or
-    instructed, and doctor runs via the installed CLI when present —
-    green-or-actionably-instructive, never silent."""
-    assert "package verification" in stdout
-    assert (
-        "Doctor verdict:" in stdout
-        or "Install the lifecycle CLI: uv tool install agentive-kit" in stdout
-        or "uv tool upgrade agentive-kit" in stdout
-    )
-    assert "Install complete:" in stdout
-
-
-@pytest.mark.slow
-class TestAdoptE2E:
-    def test_adopt_single_defaults(self, tmp_path):
-        target = make_adopt_dir(tmp_path, "app")
-        result = run_door("--adopt", str(target))
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Setup door: mode=adopt shape=single profile=python" in result.stdout
-        # offers skipped with notice in non-TTY (N4)
-        assert "Offer skipped (non-interactive): evaluators" in result.stdout
-        assert "Offer skipped (non-interactive): venv" in result.stdout
-        _assert_doctor_tail(result.stdout)
-        region = _kit_install_region(target)
-        assert "shape: single" in region
-        assert "profile: python" in region
-        assert (target / "scripts" / "local" / "checks.sh").is_file()
-
-    def test_adopt_single_profile_none(self, tmp_path):
-        """The single:none matrix cell, adopt mode (CodeRabbit PR #81).
-        The profile scopes the check hook + record ONLY — the shipset
-        is the shape's job (ADR-0027 P1 / KIT-0050 contract), so the
-        toolchain still ships for a single-shape install."""
-        target = make_adopt_dir(tmp_path, "docsrepo")
-        result = run_door("--adopt", str(target), "--profile", "none")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Setup door: mode=adopt shape=single profile=none" in result.stdout
-        # no venv offer for a toolchain-free profile
-        assert "Offer skipped (non-interactive): venv" not in result.stdout
-        _assert_doctor_tail(result.stdout)
-        region = _kit_install_region(target)
-        assert "shape: single" in region
-        assert "profile: none" in region
-        none_seed = REPO_ROOT / "scripts" / "local" / "templates" / "checks-none.sh"
-        hook = target / "scripts" / "local" / "checks.sh"
-        assert hook.read_bytes() == none_seed.read_bytes()
-        # shipset unchanged by profile: single shape ships the toolchain
-        assert (target / "pyproject.toml").is_file()
-        # a seeded pyproject carries the placeholder the onboarding
-        # agents rewrite, never the kit's own identity (BugBot PR #90 —
-        # the engine-export reset applied to the adopt copy path too)
-        seeded = (target / "pyproject.toml").read_text(encoding="utf-8")
-        assert (
-            'name = "your-project-name"  # TODO: Change this to your project name'
-            in seeded
-        )
-        assert 'name = "agentive-starter-kit"' not in seeded
-
-    def test_readopt_with_conflicting_profile_rejected(self, tmp_path):
-        """CodeRabbit PR #81: explicit flags that contradict the
-        target's existing kit-install record are an error, never a
-        silent preserve (the PR #78 target-pointer precedent)."""
-        target = make_adopt_dir(tmp_path, "docsrepo")
-        assert run_door("--adopt", str(target), "--profile", "none").returncode == 0
-        result = run_door("--adopt", str(target), "--profile", "python")
-        assert result.returncode == 2
-        assert "conflicts with the target's existing kit-install record" in (
-            result.stderr
-        )
-        # flagless re-adopt keeps working (nothing explicit to conflict)
-        # AND preserves the existing record — the default must not
-        # silently overwrite single:none with single:python
-        readopt = run_door("--adopt", str(target))
-        assert readopt.returncode == 0, readopt.stderr + readopt.stdout
-        assert "profile: none" in _kit_install_region(target)
-
-    def test_adopt_planning_records_pointer(self, tmp_path):
-        target = make_adopt_dir(tmp_path, "coord")
-        result = run_door(
-            "--adopt",
-            str(target),
-            "--shape",
-            "planning",
-            "--target-path",
-            "../product",
-            "--target-github",
-            "acme/product",
-        )
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "planning shape → profile none (forced" in result.stdout
-        # no venv offer for a toolchain-free shape
-        assert "Offer skipped (non-interactive): venv" not in result.stdout
-        _assert_doctor_tail(result.stdout)
-        region = _kit_install_region(target)
-        assert "shape: planning" in region
-        assert "profile: none" in region
-        assert "target_path: ../product" in region
-
-    def test_adopt_gitless_target_hints_materials(self, tmp_path):
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "materials"
-        target.mkdir()
-        (target / "brief.md").write_text("# brief\n", encoding="utf-8")
-        result = run_door("--adopt", str(target), env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "--design-materials" in result.stdout  # the detection hint
-        _assert_doctor_tail(result.stdout)
-
-    def test_adopt_git_target_no_materials_hint(self, tmp_path):
-        target = make_adopt_dir(tmp_path, "app")
-        result = run_door("--adopt", str(target))
-        assert "re-run with --design-materials" not in result.stdout
-
-
-@pytest.mark.slow
-class TestNewE2E:
-    def test_new_single_exports_and_records(self, tmp_path):
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "fresh-app"
-        result = run_door("--new", str(target), env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Content scaffold ready" in result.stdout  # scaffold engine
-        assert "Scaffold committed (branch: main)." in result.stdout
-        _assert_packaged_tail(result.stdout)
-        region = _kit_install_region(target)
-        assert "shape: single" in region
-        assert "profile: python" in region
-        assert (target / "scripts" / "local" / "checks.sh").is_file()
-        # kit_markers.py travels with the agentive-kit package (KIT-0093)
-        assert not (target / "scripts" / "local" / "kit_markers.py").exists()
-        # one scaffold commit, nothing dangling
-        log = subprocess.run(
-            ["git", "-C", str(target), "log", "--oneline"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=env,
-        )
-        assert len(log.stdout.strip().splitlines()) == 1
-        status = subprocess.run(
-            ["git", "-C", str(target), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=env,
-        )
-        assert status.stdout.strip() == ""
-
-    def test_new_export_carries_no_planning_corpus(self, tmp_path):
-        """The export engine's .kit/context/ scrubs are -maxdepth 1, so
-        every SUBDIRECTORY of context/ needs its own removal. KIT-0077
-        added context/archive/ (100 finished-task handoffs) and it
-        escaped the sweep until engine-export.sh gained an explicit
-        rm -rf. Mirrors test_engine_materials.py's corpus guard so the
-        class is closed on both consumer copy paths, not just one."""
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "clean-app"
-        result = run_door("--new", str(target), env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-
-        context = target / ".kit" / "context"
-        assert context.is_dir(), "export should still scaffold .kit/context/"
-        leaked = [
-            str(p.relative_to(target))
-            for p in context.rglob("*")
-            if p.is_file() and re.match(r"^[A-Z]+-\d{4}", p.name)
-        ]
-        assert not leaked, f"kit planning corpus leaked into export: {leaked}"
-        assert not (
-            context / "archive"
-        ).exists(), "the kit's finished-task archive must never ship to a new project"
-
-    def test_new_single_profile_none_reseeds_rules(self, tmp_path):
-        """BugBot PR #81: the export carries the kit's python Project
-        Rules region; a profile-none install must reseed it to the
-        none content, never record none next to python guidance."""
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "docs-app"
-        result = run_door("--new", str(target), "--profile", "none", env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-        region = _kit_install_region(target)
-        assert "profile: none" in region
-        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
-        rules = text.split("BEGIN KIT-LOCAL: project-rules")[1].split(
-            "END KIT-LOCAL: project-rules"
-        )[0]
-        assert "No project toolchain is configured" in rules
-        assert "### Python" not in rules
-        assert text.count("BEGIN KIT-LOCAL: project-rules") == 1
-        # the none check hook seeded alongside (byte-identical to template)
-        none_seed = REPO_ROOT / "scripts" / "local" / "templates" / "checks-none.sh"
-        hook = target / "scripts" / "local" / "checks.sh"
-        assert hook.read_bytes() == none_seed.read_bytes()
-
-    def test_new_planning_scaffolds_and_records(self, tmp_path):
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "fresh-planning"
-        result = run_door(
-            "--new",
-            str(target),
-            "--shape",
-            "planning",
-            "--target-path",
-            "../product",
-            env=env,
-        )
-        assert result.returncode == 0, result.stderr + result.stdout
-        _assert_packaged_tail(result.stdout)
-        # born packaged (KIT-0093): the lifecycle comes from the
-        # installed CLI, never a script copy
-        assert not (target / "scripts" / "core").exists()
-        assert not (target / "pyproject.toml").exists()  # never-ship contract
-        region = _kit_install_region(target)
-        assert "shape: planning" in region
-        assert "profile: none" in region
-
-
 def _env_lines(target: Path) -> list[str]:
     return (target / ".env").read_text(encoding="utf-8").splitlines()
 
@@ -712,928 +126,143 @@ def _assert_env_invariants(target: Path, env: dict) -> None:
     assert check_ignore.returncode == 0, ".env must be gitignored"
 
 
-@pytest.mark.slow
-class TestEnvSeedingE2E:
-    """KIT-0084: every --new target ends with a working, safe .env."""
+class TestShimStatic:
+    """F2's grep proof, pinned as a test: the shim file carries no
+    second copy of the matrix, the legality logic, or the flag table —
+    the package is the single owner."""
 
-    def test_new_single_seeds_env_with_identity(self, tmp_path):
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "fresh-env-app"
-        result = run_door("--new", str(target), "--prefix", "FEA", env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Seeded .env from .env.template" in result.stdout
-        _assert_env_invariants(target, env)
-        lines = _env_lines(target)
-        assert "PROJECT_NAME=fresh-env-app" in lines
-        assert "TASK_PREFIX=FEA" in lines
-        # F3, non-TTY face: the operator gets the exact command (when
-        # the kit clone has a .env to carry over) or the add-keys notice
-        kit_env = REPO_ROOT / ".env"
-        if kit_env.is_file():
-            # install -m 600: the copy is born 0600, no cp+chmod window
-            assert f'install -m 600 "{kit_env}" "{target}/.env"' in result.stdout
-            assert "operator" in result.stdout
-        else:
-            assert "No API keys seeded" in result.stdout
+    def test_no_matrix_copy_survives(self):
+        text = DOOR.read_text(encoding="utf-8")
+        for needle in (
+            "single:python",  # the LEGAL_PAIRS data form
+            "LEGAL_PAIRS",
+            "validate_pair",
+            "validate_combo",
+            "validate_values",
+            "legal_pairs_human",
+            "planning+none",  # the human-readable table form
+            "✔",  # the help-table matrix glyphs
+        ):
+            assert needle not in text, f"matrix copy in shim: {needle!r}"
 
-    def test_new_single_default_prefix_matches_recorded_state(self, tmp_path):
-        """Without --prefix the export engine derives one; the .env line
-        must be the RECORDED value, never re-derived and never TASK."""
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "derived-app"
-        result = run_door("--new", str(target), env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-        _assert_env_invariants(target, env)
-        state = json.loads(
-            (target / ".kit" / "context" / "current-state.json").read_text(
-                encoding="utf-8"
-            )
-        )
-        recorded = state["project"]["task_prefix"]
-        assert recorded  # the export engine always derives something
-        lines = _env_lines(target)
-        assert f"TASK_PREFIX={recorded}" in lines
-        assert "TASK_PREFIX=TASK" not in lines
+    def test_no_resolution_chain_survives(self):
+        """The preset/record/default chain is package code — none of
+        its function surface may reappear in the shim."""
+        text = DOOR.read_text(encoding="utf-8")
+        for needle in (
+            "resolve_setting",
+            "load_preset",
+            "preset_get",
+            "kit_default",
+            "load_record",
+            "check_record_conflict",
+            "normalize_bots",
+        ):
+            assert needle not in text, f"resolver copy in shim: {needle!r}"
 
-    def test_new_planning_seeds_env_with_empty_prefix(self, tmp_path):
-        """Planning shape has no prefix at door time — written EMPTY
-        (doctor warns until intake decides it), never 'TASK'."""
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "fresh-env-planning"
-        result = run_door(
-            "--new",
-            str(target),
-            "--shape",
-            "planning",
-            "--target-path",
-            "../product",
-            env=env,
-        )
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Seeded .env from .env.template" in result.stdout
-        _assert_env_invariants(target, env)
-        lines = _env_lines(target)
-        assert "PROJECT_NAME=fresh-env-planning" in lines
-        assert "TASK_PREFIX=" in lines  # the line exists, empty
-        assert "TASK_PREFIX=TASK" not in lines
+    def test_only_the_materials_engine_is_referenced(self):
+        """The shim's one legacy branch drives engine-materials.sh; the
+        scaffold/consumer engines are reached only through the package."""
+        text = DOOR.read_text(encoding="utf-8")
+        assert "engine-materials.sh" in text
+        assert "engine-consumer.sh" not in text
+        assert "engine-scaffold.sh" not in text
 
-    def test_env_source_seeded_env_gets_identity_filled(self, tmp_path):
-        """The preset env-source path (F6) gains the identity fields
-        too — appended when the operator's template lacks them — and
-        the secret still never surfaces."""
-        _cfg, env = _demo_preset_env(tmp_path)
-        target = tmp_path / "preset-env-app"
-        result = run_door("--new", str(target), env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-        _assert_env_invariants(target, env)
-        lines = _env_lines(target)
-        assert f"OPENAI_API_KEY={SECRET}" in lines  # carried over intact
-        assert "PROJECT_NAME=preset-env-app" in lines
-        # appended: single shape reads the export engine's recorded prefix
-        prefix_lines = [ln for ln in lines if ln.startswith("TASK_PREFIX=")]
-        assert prefix_lines and prefix_lines[0] not in ("TASK_PREFIX=TASK",)
-        assert SECRET not in result.stdout + result.stderr
-        # env-source present → no template seeding, no carry-over offer
-        assert "Seeded .env from .env.template" not in result.stdout
-        assert "API keys not seeded" not in result.stdout
+    def test_shim_names_its_removal_task(self):
+        assert "KIT-0107" in DOOR.read_text(encoding="utf-8")
 
 
-class TestFillEnvIdentityUnits:
-    """KIT-0084 F2, sourced: the .env rewrite in isolation."""
+class TestTranslation:
+    """Historical flags reach the package as verbs."""
 
-    def _target_with_env(
-        self, tmp_path: Path, content: str, name: str = "unit-target"
-    ) -> Path:
-        target = tmp_path / name
-        target.mkdir()
-        # a .git dir so the rewrite's temp file takes its real home
-        # (inside .git/, never stageable)
-        (target / ".git").mkdir()
-        (target / ".env").write_text(content, encoding="utf-8")
-        (target / ".env").chmod(0o600)
-        return target
+    def test_help_deferred_to_package_new(self):
+        result = run_door("--help")
+        assert result.returncode == 0
+        assert "agentive new — the agentive setup door" in result.stdout
+        # the shim's own header must not answer — the package does
+        assert "the one setup door" not in result.stdout
 
-    def test_planning_rewrites_placeholder_to_empty(self, tmp_path):
-        target = self._target_with_env(
-            tmp_path, "PROJECT_NAME=\nTASK_PREFIX=TASK\nOPENAI_API_KEY=x\n"
-        )
-        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
-        assert result.returncode == 0, result.stderr
-        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
-        assert "PROJECT_NAME=unit-target" in lines
-        assert "TASK_PREFIX=" in lines
-        assert "TASK_PREFIX=TASK" not in lines
-        assert "OPENAI_API_KEY=x" in lines  # untouched
-        assert ((target / ".env").stat().st_mode & 0o777) == 0o600
+    def test_help_deferred_to_package_adopt(self, tmp_path):
+        # a bare '-h' after --adopt is a swallowed-flag error (see the
+        # guard test below) — adopt help rides an ordinary invocation
+        result = run_door("--adopt", str(tmp_path), "--help")
+        assert result.returncode == 0
+        assert "agentive adopt — the agentive setup door" in result.stdout
 
-    def test_missing_lines_appended_commented_left_alone(self, tmp_path):
-        target = self._target_with_env(
-            tmp_path, "# PROJECT_NAME=commented\nOPENAI_API_KEY=x\n"
-        )
-        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
-        assert result.returncode == 0, result.stderr
-        text = (target / ".env").read_text(encoding="utf-8")
-        assert "# PROJECT_NAME=commented" in text  # comments never rewritten
-        assert "PROJECT_NAME=unit-target" in text.splitlines()
-        assert "TASK_PREFIX=" in text.splitlines()
+    def test_removal_notice_on_stderr(self):
+        result = run_door("--help")
+        assert "shim over the packaged door" in result.stderr
+        assert "KIT-0107" in result.stderr
+        # notice never pollutes stdout (the derivable-help surface)
+        assert "shim over the packaged door" not in result.stdout
 
-    def test_no_env_file_is_a_quiet_noop(self, tmp_path):
-        target = tmp_path / "no-env"
-        target.mkdir()
-        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
-        assert result.returncode == 0, result.stderr
-        assert not (target / ".env").exists()
-
-    def test_duplicate_identity_lines_deduplicated(self, tmp_path):
-        """fast-v2/o3 review: dotenv parsers are last-assignment-wins,
-        so a surviving duplicate would silently override the identity
-        the door just wrote — later duplicates must be dropped."""
-        target = self._target_with_env(
-            tmp_path,
-            "PROJECT_NAME=old-one\nOPENAI_API_KEY=x\n"
-            "  PROJECT_NAME=old-two\nTASK_PREFIX=AAA\nTASK_PREFIX=BBB\n",
-        )
-        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
-        assert result.returncode == 0, result.stderr
-        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
-        name_lines = [ln for ln in lines if ln.startswith("PROJECT_NAME=")]
-        prefix_lines = [ln for ln in lines if ln.startswith("TASK_PREFIX=")]
-        assert name_lines == ["PROJECT_NAME=unit-target"]
-        assert prefix_lines == ["TASK_PREFIX="]
-        assert "OPENAI_API_KEY=x" in lines
-
-    def test_export_prefixed_duplicates_deduplicated(self, tmp_path):
-        """CodeRabbit: the doctor accepts `export KEY=`, so an exported
-        duplicate surviving the rewrite would override the identity
-        under last-wins parsers — it must be dropped too."""
-        target = self._target_with_env(
-            tmp_path,
-            "PROJECT_NAME=old\nexport PROJECT_NAME=older\n"
-            "export TASK_PREFIX=ZZZ\nOPENAI_API_KEY=x\n",
-        )
-        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
-        assert result.returncode == 0, result.stderr
-        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
-        assert [ln for ln in lines if "PROJECT_NAME" in ln] == [
-            "PROJECT_NAME=unit-target"
-        ]
-        assert [ln for ln in lines if "TASK_PREFIX" in ln] == ["TASK_PREFIX="]
-        assert "OPENAI_API_KEY=x" in lines
-
-    def test_special_char_name_written_quoted(self, tmp_path):
-        """CodeRabbit: a value carrying '#' or spaces is written
-        double-quoted so the doctor (and dotenv parsers) read it back
-        intact; quote characters themselves are stripped."""
-        target = self._target_with_env(
-            tmp_path, "PROJECT_NAME=\nTASK_PREFIX=\n", name="acme #1's"
-        )
-        result = sourced(f'TARGET="{target}"; SHAPE=planning; fill_env_identity')
-        assert result.returncode == 0, result.stderr
-        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
-        assert 'PROJECT_NAME="acme #1s"' in lines  # quoted; "'" stripped
-
-    def test_null_recorded_prefix_writes_empty_never_none(self, tmp_path):
-        """fast-v2 review: a JSON null task_prefix must never become
-        the literal string 'None' in .env."""
-        target = self._target_with_env(tmp_path, "TASK_PREFIX=TASK\n")
-        state_dir = target / ".kit" / "context"
-        state_dir.mkdir(parents=True)
-        (state_dir / "current-state.json").write_text(
-            '{"project": {"name": "x", "task_prefix": null}}', encoding="utf-8"
-        )
-        result = sourced(f'TARGET="{target}"; SHAPE=single; fill_env_identity')
-        assert result.returncode == 0, result.stderr
-        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
-        assert "TASK_PREFIX=" in lines
-        assert "TASK_PREFIX=None" not in lines
-
-
-SECRET = "KIT0056-FIXTURE-SECRET-NEVER-PRINT"
-
-
-def _demo_preset_env(tmp_path: Path) -> tuple[Path, dict[str, str]]:
-    """A FULL preset (every door question answered) in a scratch
-    config home, plus git identity and a 0600 env template carrying a
-    fixture secret. Returns (config_home, env)."""
-    xdg = _git_identity(tmp_path)  # xdg-config/ with git/config
-    env_template = tmp_path / "env-template"
-    env_template.write_text(f"OPENAI_API_KEY={SECRET}\n", encoding="utf-8")
-    env_template.chmod(0o600)
-    cfg = write_preset(
-        tmp_path,
-        "# full operator preset (KIT-0056 N4 fixture)\n"
-        "shape: single\n"
-        "profile: python\n"
-        "bots: coderabbit bugbot\n"
-        "evaluators: no\n"
-        "venv: no\n"
-        f"env-source: {env_template}\n",
-    )
-    env = _scrubbed_env(XDG_CONFIG_HOME=str(xdg), AGENTIVE_KIT_CONFIG_DIR=str(cfg))
-    return cfg, env
-
-
-@pytest.mark.slow
-class TestPresetE2E:
-    """KIT-0056 P7 end to end. Preset fixtures live under scratch XDG
-    dirs — the suite never reads or writes the real ~/.config (N-rule
-    in the task spec)."""
-
-    def test_one_button_demo(self, tmp_path):
-        """N4, the acceptance bar: a full preset answers every question
-        — zero prompts, zero skipped-offer notices — and the resulting
-        record reflects the preset's declarations. Secrets arrive by
-        reference at mode 0600 and never appear in output or git."""
-        cfg, env = _demo_preset_env(tmp_path)
-        preset_file = cfg / "preset"
-        preset_before = preset_file.read_bytes()
-        target = tmp_path / "one-button"
-        result = run_door("--new", str(target), env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Preset:" in result.stdout  # the layer announced itself
-        # zero prompts is structural (stdin closed); zero NOTICES is the
-        # preset's work — nothing was skipped-with-notice
-        assert "Offer skipped" not in result.stdout
-        _assert_packaged_tail(result.stdout)
-        region = _kit_install_region(target)
-        assert "shape: single" in region
-        assert "profile: python" in region
-        assert "bots: coderabbit bugbot" in region
-        # F6: .env seeded 0600, gitignored, contents NEVER surfaced
-        dotenv = target / ".env"
-        assert dotenv.is_file()
-        assert (dotenv.stat().st_mode & 0o777) == 0o600
-        assert SECRET in dotenv.read_text(encoding="utf-8")
-        assert SECRET not in result.stdout + result.stderr
-        check_ignore = subprocess.run(
-            ["git", "-C", str(target), "check-ignore", "-q", ".env"],
-            env=env,
-            timeout=30,
-        )
-        assert check_ignore.returncode == 0, ".env must be gitignored"
-        status = subprocess.run(
-            ["git", "-C", str(target), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=env,
-        )
-        # rc asserted first — a FAILED git call also has empty stdout
-        # (CodeRabbit): empty output only means clean when git ran
-        assert status.returncode == 0, status.stderr
-        assert status.stdout.strip() == ""  # nothing staged, nothing dangling
-        tracked_grep = subprocess.run(
-            ["git", "-C", str(target), "grep", "-l", SECRET, "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=env,
-        )
-        assert tracked_grep.returncode == 1, tracked_grep.stderr  # 1 = no match
-        assert tracked_grep.stdout.strip() == ""  # secret in no tracked file
-        # F7: the run read the preset but never touched it
-        assert preset_file.read_bytes() == preset_before
-
-    @staticmethod
-    def _door_output(stdout: str, target: Path) -> str:
-        # The doctor tail's config-home CHECK reports the environment
-        # (whether a config home exists) — the very thing this test
-        # varies between the two runs (KIT-0058). Mask that one check
-        # line and the verdict-count summary; every other byte of the
-        # two runs still compares exactly.
-        lines = [
-            ln
-            for ln in stdout.replace(str(target), "<T>").splitlines(keepends=True)
-            if not ln.startswith("DOCTOR:config-home:")
-            and not ln.startswith("Doctor: ")
-        ]
-        return "".join(lines)
-
-    def test_no_preset_gives_the_stranger_path(self, tmp_path):
-        """--no-preset with a preset present must be byte-identical to
-        a machine with no preset at all (N1's flip side) — modulo the
-        config-home doctor line, which by design names the environment
-        difference this test constructs."""
-        _cfg, env = _demo_preset_env(tmp_path)
-        # same basename in different parents: engine banners print the
-        # project NAME, so only the parent path may differ
-        target_a = make_adopt_dir(tmp_path / "a", "proj")
-        target_b = make_adopt_dir(tmp_path / "b", "proj")
-        with_flag = run_door(
-            "--adopt",
-            str(target_a),
-            "--no-preset",
-            env=env,
-        )
-        stranger = run_door("--adopt", str(target_b))
-        assert with_flag.returncode == 0, with_flag.stderr + with_flag.stdout
-        assert stranger.returncode == 0, stranger.stderr + stranger.stdout
-        normalized_a = self._door_output(with_flag.stdout, target_a)
-        normalized_b = self._door_output(stranger.stdout, target_b)
-        assert normalized_a == normalized_b
-        # the door's OWN chrome never mentions the preset in either run
-        assert "Preset:" not in with_flag.stdout
-        assert "Seeded" not in with_flag.stdout
-
-    def test_adopt_record_beats_preset(self, tmp_path):
-        """A recorded target keeps its identity: the preset answers
-        none of the recorded questions, and the record round-trips
-        untouched (divergence belongs to doctor --against-preset)."""
-        target = make_adopt_dir(tmp_path, "recorded")
-        first = run_door("--adopt", str(target), "--profile", "none", "--bots", "none")
-        assert first.returncode == 0, first.stderr + first.stdout
-        cfg = write_preset(
-            tmp_path, "shape: planning\nprofile: python\nbots: coderabbit bugbot\n"
-        )
-        readopt = run_door(
-            "--adopt", str(target), env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg))
-        )
-        assert readopt.returncode == 0, readopt.stderr + readopt.stdout
-        assert "Setup door: mode=adopt shape=single" in readopt.stdout
-        region = _kit_install_region(target)
-        assert "shape: single" in region
-        assert "profile: none" in region
-        assert "bots: none" in region
-
-    def test_preset_answers_the_offer_questions(self, tmp_path):
-        """Preset 'evaluators:'/'venv:' answers reach run_offers like
-        flags would — the non-interactive skip notices disappear (the
-        preset-less baseline asserts their presence). 'no' keeps the
-        test network-free; the wiring is identical for 'yes'."""
-        cfg = write_preset(tmp_path, "evaluators: no\nvenv: no\n")
-        target = make_adopt_dir(tmp_path, "offers")
-        result = run_door(
-            "--adopt", str(target), env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg))
-        )
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Offer skipped (non-interactive): evaluators" not in result.stdout
-        assert "Offer skipped (non-interactive): venv" not in result.stdout
-
-    def test_preset_venv_ignored_for_none_recorded_target(self, tmp_path):
-        """BugBot round 2: on adopt, the record's profile wins over the
-        resolved default for the venv answer too — a preset 'venv: yes'
-        must never run setup-dev.sh on a recorded docs-only project,
-        and ignoring the answer is said out loud."""
-        target = make_adopt_dir(tmp_path, "docs-only")
-        assert run_door("--adopt", str(target), "--profile", "none").returncode == 0
-        cfg = write_preset(tmp_path, "venv: yes\nevaluators: no\n")
-        result = run_door(
-            "--adopt", str(target), env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg))
-        )
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Preset venv answer ignored" in result.stdout
-        assert "profile: none" in result.stdout  # the reason is named
-        assert "setup-dev" not in result.stdout  # the venv step never ran
-        # BugBot round 3: the OFFER is closed too — no misleading
-        # non-TTY --with-venv hint (and in TTY, no prompt) on a
-        # docs-only recorded project
-        assert "Offer skipped (non-interactive): venv" not in result.stdout
-        assert "profile: none" in _kit_install_region(target)
-
-    def test_venv_offer_closed_for_none_recorded_target(self, tmp_path):
-        """BugBot round 3, the preset-less face: flagless adopt of a
-        profile:none-recorded target must not surface the venv offer
-        at all — the record has no Python toolchain."""
-        target = make_adopt_dir(tmp_path, "docs-flagless")
-        assert run_door("--adopt", str(target), "--profile", "none").returncode == 0
-        result = run_door("--adopt", str(target))
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "Offer skipped (non-interactive): venv" not in result.stdout
-        # the evaluators offer is profile-independent and stays open
-        assert "Offer skipped (non-interactive): evaluators" in result.stdout
-
-    def test_with_venv_flag_rejected_for_none_recorded_target(self, tmp_path):
-        """The explicit flag keys on the effective profile too —
-        --with-venv on a docs-only recorded project is the same
-        illegal ask as on a resolved-none run."""
-        target = make_adopt_dir(tmp_path, "docs-flagged")
-        assert run_door("--adopt", str(target), "--profile", "none").returncode == 0
-        result = run_door("--adopt", str(target), "--with-venv")
+    def test_missing_mode_non_tty_fails_fast(self):
+        result = run_door(timeout=30)
         assert result.returncode == 2
-        assert "--with-venv requires profile python" in result.stderr
+        assert "mode is required" in result.stderr
 
-    def test_bad_offer_value_fails_loud(self, tmp_path):
-        cfg = write_preset(tmp_path, "evaluators: maybe\n")
-        target = make_adopt_dir(tmp_path, "badval")
-        result = run_door(
-            "--adopt", str(target), env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg))
-        )
+    def test_missing_target_reaches_package_prompt_guard(self):
+        result = run_door("--adopt", timeout=30)
         assert result.returncode == 2
-        assert "preset key 'evaluators' must be yes or no" in result.stderr
+        assert "target directory is required" in result.stderr
 
-    def test_unreadable_preset_fails_loud(self, tmp_path):
-        # a present-but-unreadable preset must diagnose itself, not
-        # die with bash's raw "Permission denied" (fast-v2 finding)
-        if os.geteuid() == 0:
-            pytest.skip("permission checks are meaningless as root")
-        cfg = write_preset(tmp_path, "shape: single\n")
-        (cfg / "preset").chmod(0o000)
-        target = make_adopt_dir(tmp_path, "unreadable")
-        try:
-            result = run_door(
-                "--adopt",
-                str(target),
-                env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg)),
-            )
-            assert result.returncode == 2
-            assert "not readable" in result.stderr
-            assert "--no-preset" in result.stderr  # the escape hatch is named
-        finally:
-            (cfg / "preset").chmod(0o600)
-
-    @pytest.mark.slow
-    def test_loose_env_source_perms_warn_but_proceed(self, tmp_path):
-        """0600 on the SOURCE is expected-not-enforced by design (F6:
-        it is the operator's own file; the target copy is always
-        0600) — but the warning must actually fire."""
-        _cfg, env = _demo_preset_env(tmp_path)
-        env_template = tmp_path / "env-template"
-        env_template.chmod(0o644)
-        target = tmp_path / "loose-perms"
-        result = run_door("--new", str(target), env=env)
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "0600 expected" in result.stderr
-        assert ((target / ".env").stat().st_mode & 0o777) == 0o600
-
-    def test_unreadable_env_source_fails_before_any_work(self, tmp_path):
-        if os.geteuid() == 0:
-            pytest.skip("permission checks are meaningless as root")
-        secret_file = tmp_path / "env-template"
-        secret_file.write_text("KEY=x\n", encoding="utf-8")
-        secret_file.chmod(0o000)
-        cfg = write_preset(tmp_path, f"env-source: {secret_file}\n")
-        env = _scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg))
-        try:
-            result = run_door("--new", str(tmp_path / "proj"), env=env, timeout=30)
-            assert result.returncode == 2
-            assert "not readable" in result.stderr
-            assert not (tmp_path / "proj").exists()  # failed BEFORE any work
-        finally:
-            secret_file.chmod(0o600)
-
-
-@pytest.mark.slow
-class TestBotsDeclarationE2E:
-    """KIT-0056 P5: the --bots flag through door + engine + record."""
-
-    def test_adopt_bots_subset_records_line(self, tmp_path):
-        target = make_adopt_dir(tmp_path, "one-bot")
-        result = run_door("--adopt", str(target), "--bots", "coderabbit")
-        assert result.returncode == 0, result.stderr + result.stdout
-        region = _kit_install_region(target)
-        assert "bots: coderabbit" in region
-        assert "bugbot" not in region
-
-    def test_new_planning_with_bots_records_line(self, tmp_path):
-        # the matrix's other seed path: the planning region body (4
-        # lines incl. the target pointer) gains the bots line too
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        target = tmp_path / "planning-bots"
-        result = run_door(
-            "--new", str(target), "--shape", "planning", "--bots", "none", env=env
-        )
-        assert result.returncode == 0, result.stderr + result.stdout
-        region = _kit_install_region(target)
-        assert "shape: planning" in region
-        assert "target_github:" in region
-        assert "bots: none" in region
-
-    def test_readopt_adds_bots_line_surgically(self, tmp_path):
-        """An existing record without the line gains exactly the bots
-        line — shape/profile preserved byte-for-byte (the one-writer
-        path through kit_markers, never a region rewrite)."""
-        target = make_adopt_dir(tmp_path, "add-later")
-        assert run_door("--adopt", str(target), "--profile", "none").returncode == 0
-        before = _kit_install_region(target)
-        assert "shape: single\nprofile: none\n" in before
-        assert "bots:" not in before
-        result = run_door("--adopt", str(target), "--bots", "none")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "bots line added" in result.stdout
-        after = _kit_install_region(target)
-        # prior lines byte-preserved, bots appended right after them
-        assert "shape: single\nprofile: none\nbots: none\n" in after
-
-    def test_readopt_conflicting_bots_rejected(self, tmp_path):
-        target = make_adopt_dir(tmp_path, "conflict")
-        assert run_door("--adopt", str(target), "--bots", "none").returncode == 0
-        result = run_door("--adopt", str(target), "--bots", "coderabbit bugbot")
+    def test_mode_flag_must_not_swallow_following_flag(self):
+        # BugBot PR #81: '--new --shape planning' must not adopt
+        # '--shape' as the target directory
+        result = run_door("--new", "--shape", "planning", timeout=30)
         assert result.returncode == 2
-        assert "conflicts with the target's existing kit-install record" in (
-            result.stderr
-        )
-        assert "bots: none" in _kit_install_region(target)  # record untouched
+        assert "requires a value" in result.stderr
+        result = run_door("--new", "-h", timeout=30)
+        assert result.returncode == 2
+        assert "requires a value" in result.stderr
 
-    def test_indented_existing_bots_line_not_duplicated(self, tmp_path):
-        """o3 (this PR): an indented hand-edited bots line read as
-        'absent' by the engine would gain a SECOND bots line — the
-        whitespace-tolerant reader must see it and no-op."""
-        target = make_adopt_dir(tmp_path, "indented")
-        assert run_door("--adopt", str(target), "--bots", "none").returncode == 0
-        claude_md = target / "CLAUDE.md"
-        text = claude_md.read_text(encoding="utf-8")
-        claude_md.write_text(
-            text.replace("\nbots: none\n", "\n   bots: none\n"), encoding="utf-8"
-        )
-        result = run_door("--adopt", str(target), "--bots", "none")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "bots line added" not in result.stdout
-        region = _kit_install_region(target)
-        assert region.count("bots:") == 1
+    def test_equals_form_translates(self, tmp_path):
+        # --adopt=<dir> reaches the package as a target: the run gets
+        # past the shim and fails on the PACKAGE's own target check
+        result = run_door(f"--adopt={tmp_path / 'nope'}", timeout=60)
+        assert result.returncode == 2
+        assert "--adopt target does not exist" in result.stderr
 
-    def test_equivalent_bots_record_is_not_a_conflict(self, tmp_path):
-        """BugBot PR #83: conflict checks compare NORMALIZED forms —
-        a hand-edited 'BugBot, CodeRabbit' record is the same
-        declaration as --bots 'bugbot coderabbit', not a conflict,
-        and the engine must not append a second line either."""
-        target = make_adopt_dir(tmp_path, "equiv")
-        first = run_door("--adopt", str(target), "--bots", "coderabbit bugbot")
-        assert first.returncode == 0, first.stderr + first.stdout
-        claude_md = target / "CLAUDE.md"
-        text = claude_md.read_text(encoding="utf-8")
-        claude_md.write_text(
-            text.replace("\nbots: coderabbit bugbot\n", "\nbots: BugBot, CodeRabbit\n"),
-            encoding="utf-8",
-        )
-        result = run_door("--adopt", str(target), "--bots", "bugbot coderabbit")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "conflicts" not in result.stderr
-        assert "bots line added" not in result.stdout
-        region = _kit_install_region(target)
-        assert region.count("bots:") == 1
-        # the operator's spelling is preserved, not rewritten
-        assert "bots: BugBot, CodeRabbit" in region
+    def test_unknown_flag_is_the_packages_usage_error(self, tmp_path):
+        result = run_door("--new", str(tmp_path / "x"), "--frobnicate", timeout=60)
+        assert result.returncode == 2
+        assert "unknown argument: --frobnicate" in result.stderr
+        assert "agentive new --help" in result.stderr  # the package's pointer
 
-    def test_valueless_existing_bots_line_fails_loud(self, tmp_path):
-        """CodeRabbit PR #83: a record whose bots: line has NO value is
-        malformed, not absent — appending a second line after it would
-        leave two declarations; the engine refuses loudly instead."""
-        target = make_adopt_dir(tmp_path, "valueless")
-        assert run_door("--adopt", str(target), "--profile", "none").returncode == 0
-        claude_md = target / "CLAUDE.md"
-        text = claude_md.read_text(encoding="utf-8")
-        claude_md.write_text(
-            text.replace("\nprofile: none\n", "\nprofile: none\nbots:\n"),
-            encoding="utf-8",
-        )
-        result = run_door("--adopt", str(target), "--bots", "none")
-        assert result.returncode == 1
-        assert "bots: line with no value" in result.stdout + result.stderr
-        assert _kit_install_region(target).count("bots:") == 1  # no second line
-
-    def test_new_without_bots_writes_no_line(self, tmp_path):
-        """N1: no flag, no preset — the record is byte-identical to a
-        pre-KIT-0056 install (no bots line, zero migration)."""
-        target = make_adopt_dir(tmp_path, "no-decl")
-        result = run_door("--adopt", str(target))
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert "bots:" not in _kit_install_region(target)
+    def test_new_target_must_not_exist_via_package(self, tmp_path):
+        result = run_door("--new", str(tmp_path), timeout=60)
+        assert result.returncode == 2
+        assert "already exists" in result.stderr
 
 
-@pytest.mark.slow
-class TestMissingDependencyInstructions:
-    """KIT-0093 (CodeRabbit, PR #117): every other assertion accepts
-    verified-OR-instructed, so on a machine that HAS the tools the
-    instruction strings are never exercised. This test forces the
-    missing-CLI and missing-plugin branches hermetically — a restricted
-    PATH carrying only the tools the door itself needs — and pins the
-    exact contract lines plus the degradation guarantee (exit 0)."""
+class TestMaterialsBranch:
+    """The one legacy branch the shim keeps (dies with it, KIT-0107):
+    exactly `--adopt <dir> --design-materials [--no-preset]` — anything
+    else alongside is refused loudly, never silently dropped."""
 
-    _NEEDED_TOOLS = (
-        "bash",
-        "sh",
-        "env",
-        "git",
-        "python3",
-        "sed",
-        "awk",
-        "grep",
-        "tr",
-        "cut",
-        "sort",
-        "uniq",
-        "head",
-        "tail",
-        "basename",
-        "dirname",
-        "cat",
-        "cp",
-        "mv",
-        "rm",
-        "mkdir",
-        "touch",
-        "chmod",
-        "ls",
-        "wc",
-        "mktemp",
-        "install",
-        "stat",
-        "uname",
-    )
+    def test_requires_adopt(self, tmp_path):
+        result = run_door("--new", str(tmp_path / "x"), "--design-materials")
+        assert result.returncode == 2
+        assert "--design-materials applies to --adopt only" in result.stderr
 
-    def _restricted_path(self, tmp_path: Path) -> Path:
-        bindir = tmp_path / "restricted-bin"
-        bindir.mkdir()
-        for tool in self._NEEDED_TOOLS:
-            real = shutil.which(tool)
-            if real:  # builtins/absent tools simply aren't linked
-                (bindir / tool).symlink_to(real)
-        assert not (bindir / "agentive").exists()
-        assert not (bindir / "claude").exists()
-        return bindir
+    def test_requires_existing_target(self, tmp_path):
+        result = run_door("--adopt", str(tmp_path / "nope"), "--design-materials")
+        assert result.returncode == 2
+        assert "does not exist" in result.stderr
 
-    def test_new_without_cli_or_plugin_instructs_and_succeeds(self, tmp_path):
-        bindir = self._restricted_path(tmp_path)
-        env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(tmp_path)))
-        env["PATH"] = str(bindir)
-        target = tmp_path / "no-deps-app"
-        result = run_door("--new", str(target), env=env)
-        out = result.stdout
-        # Degradation, never a hard fail (the KIT-0083 pattern)
-        assert result.returncode == 0, result.stderr + out
-        assert "Install complete:" in out
-        # The exact contract lines (test_scaffold_acceptance docstring)
-        assert "Install the lifecycle CLI: uv tool install agentive-kit" in out
-        # KIT-0101 R3: the missing CLI is the one gap that cascades —
-        # the tail must elevate it to the headline next step
-        assert "NEXT STEP (required): install the lifecycle CLI" in out
-        assert "Install the agent plugin:" in out
-        assert "claude plugin marketplace add movito/agentive-skills" in out
-        assert "claude plugin install agentive-workflow@agentive-skills" in out
-        # Nothing claimed VERIFIED, and doctor honestly not run — the
-        # rejection targets the positive-verification forms only, so a
-        # future honest status line (e.g. 'agentive CLI: missing')
-        # would not trip it (CodeRabbit, PR #117)
-        assert not re.search(r"agentive CLI:.*\(verified\)", out)
-        assert "agent plugin: verified" not in out
-        assert "Doctor verdict:" not in out
+    def test_no_kit_contradiction_keeps_its_message(self, tmp_path):
+        target = make_adopt_dir(tmp_path, "mat")
+        result = run_door("--adopt", str(target), "--design-materials", "--no-kit")
+        assert result.returncode == 2
+        assert "--no-kit contradicts --design-materials" in result.stderr
 
-
-class TestPresetNeverDistributed:
-    """F7: nothing in the config home (<kit-parent>/agentive-config/,
-    KIT-0058) rides any sync tier, rsync, or export path. Structural
-    check: the ONLY scripts allowed to reference the config-home
-    location are the door (reads it), the project script (doctor
-    --against-preset compares against it), and the config-home doctor
-    check — engines, sync, and export code must not know it exists."""
-
-    # KIT-0092 Part B (executed with KIT-0093 PR 2, where the old probe
-    # became blocking): the probe checks the config-home LOCATION
-    # ("agentive-config") only. The old probe also matched the literal
-    # "agentive-kit" — the PACKAGE name — so every package shim tripped
-    # it and ALLOWED grew to 7 entries for the wrong reason. Package
-    # references are legitimate everywhere; the config home has exactly
-    # three readers.
-    ALLOWED = {
-        "scripts/local/bootstrap",
-        "scripts/core/project",
-        "scripts/core/doctor.d/90-config-home.sh",
-    }
-
-    def test_preset_path_referenced_only_by_allowed_readers(self):
-        offenders = []
-        for path in (REPO_ROOT / "scripts").rglob("*"):
-            if not path.is_file():
-                continue
-            try:
-                text = path.read_text(encoding="utf-8")
-            except (UnicodeDecodeError, OSError):
-                continue
-            if "agentive-config" in text:
-                rel = str(path.relative_to(REPO_ROOT))
-                if rel not in self.ALLOWED:
-                    offenders.append(rel)
-        assert (
-            offenders == []
-        ), f"config-home location referenced outside the allowed readers: {offenders}"
-
-
-def _scratch_kit_clone(base: Path) -> tuple[Path, Path]:
-    """A throwaway 'kit checkout' (parent/kit) for resolution tests —
-    config_home derives parent/agentive-config from it."""
-    parent = base / "parent"
-    kit = parent / "kit"
-    kit.mkdir(parents=True)
-    subprocess.run(
-        ["git", "init", "--quiet", "-b", "main", str(kit)],
-        check=True,
-        timeout=30,
-        env=_scrubbed_env(),
-    )
-    return parent, kit
-
-
-class TestConfigHomeResolution:
-    """KIT-0058 F1: the config home is <kit-parent>/agentive-config,
-    resolved worktree-safely via --git-common-dir; the env override is
-    an override, never a search chain."""
-
-    def test_override_wins(self, tmp_path):
-        result = sourced(
-            "config_home",
-            env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(tmp_path / "elsewhere")),
-        )
-        assert result.returncode == 0, result.stderr
-        assert result.stdout.strip() == str(tmp_path / "elsewhere")
-
-    def test_empty_override_falls_through_to_derivation(self, tmp_path):
-        # empty is unset, not "resolve to ''" — matches the Python
-        # mirror's truthiness check so the two can never disagree
-        _parent, kit = _scratch_kit_clone(tmp_path)
-        result = sourced(
-            f'PROJECT_ROOT="{kit}"; config_home',
-            env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=""),
-        )
-        assert result.returncode == 0, result.stderr
-        assert result.stdout.strip() == str(tmp_path / "parent" / "agentive-config")
-
-    def test_derives_sibling_of_primary_clone(self, tmp_path):
-        parent, kit = _scratch_kit_clone(tmp_path)
-        env = _scrubbed_env()
-        del env["AGENTIVE_KIT_CONFIG_DIR"]
-        result = sourced(f'PROJECT_ROOT="{kit}"; config_home', env=env)
-        assert result.returncode == 0, result.stderr
-        assert result.stdout.strip() == str(parent / "agentive-config")
-
-    def test_worktree_resolves_to_primary_sibling(self, tmp_path):
-        # --git-common-dir names the PRIMARY clone's .git from a linked
-        # worktree — both checkouts must agree on ONE config home
-        parent, kit = _scratch_kit_clone(tmp_path)
-        env = _scrubbed_env()
-        del env["AGENTIVE_KIT_CONFIG_DIR"]
-        subprocess.run(
-            [
-                "git",
-                "-C",
-                str(kit),
-                "-c",
-                "user.name=t",
-                "-c",
-                "user.email=t@example.invalid",
-                "commit",
-                "--allow-empty",
-                "-q",
-                "-m",
-                "seed",
-            ],
-            check=True,
-            timeout=30,
-            env=env,
-        )
-        wt = tmp_path / "worktrees" / "kit-wt"
-        subprocess.run(
-            ["git", "-C", str(kit), "worktree", "add", "-q", str(wt)],
-            check=True,
-            timeout=30,
-            env=env,
-        )
-        from_primary = sourced(f'PROJECT_ROOT="{kit}"; config_home', env=env)
-        from_worktree = sourced(f'PROJECT_ROOT="{wt}"; config_home', env=env)
-        assert from_primary.returncode == 0, from_primary.stderr
-        assert from_worktree.returncode == 0, from_worktree.stderr
-        assert from_primary.stdout.strip() == from_worktree.stdout.strip()
-        assert from_primary.stdout.strip() == str(parent / "agentive-config")
-
-    def test_non_git_checkout_resolves_nothing(self, tmp_path):
-        plain = tmp_path / "not-a-clone"
-        plain.mkdir()
-        env = _scrubbed_env()
-        del env["AGENTIVE_KIT_CONFIG_DIR"]
-        result = sourced(
-            f'PROJECT_ROOT="{plain}"; config_home || echo "rc=$?"', env=env
-        )
-        assert "rc=1" in result.stdout
-
-    def test_door_and_doctor_agree_on_the_path(self, tmp_path):
-        """The 'two can never disagree' pin: the door's config_home and
-        the project script's _config_home resolve the SAME path for the
-        same checkout (doctor --against-preset names it in its
-        no-preset INFO line)."""
-        parent, kit = _scratch_kit_clone(tmp_path)
-        env = _scrubbed_env()
-        del env["AGENTIVE_KIT_CONFIG_DIR"]
-        bash_home = sourced(f'PROJECT_ROOT="{kit}"; config_home', env=env)
-        assert bash_home.returncode == 0, bash_home.stderr
-        checks = tmp_path / "checks"
-        checks.mkdir()
-        stub = checks / "10-stub.sh"
-        stub.write_text('#!/bin/bash\necho "DOCTOR:stub:PASS:ok"\n', encoding="utf-8")
-        stub.chmod(0o755)
-        project_script = REPO_ROOT / "scripts" / "core" / "project"
-        doctor = subprocess.run(
-            [
-                "python3",
-                str(project_script),
-                "doctor",
-                f"--root={kit}",
-                f"--dir={checks}",
-                "--against-preset",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            env=env,
-        )
-        info = [ln for ln in doctor.stdout.splitlines() if "no preset found at" in ln]
-        assert info, doctor.stdout
-        expected = f"{bash_home.stdout.strip()}/preset"
-        assert expected in info[0]
-
-
-class TestConfigHomeSeeding:
-    """KIT-0058 F2: first-use guardrail seeding — an orchestrate step
-    (resolve locates, writes nothing). Idempotent, never overwrites,
-    never creates the folder (N3)."""
-
-    def _run(self, tmp_path, cfg, *extra):
-        target = make_adopt_dir(tmp_path / f"t{len(list(tmp_path.iterdir()))}", "app")
-        return run_door(
-            "--adopt",
-            str(target),
-            *extra,
-            env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg)),
-        )
-
-    def test_first_use_seeds_gitignore_and_readme(self, tmp_path):
-        cfg = tmp_path / "agentive-config"
-        cfg.mkdir()
-        result = self._run(tmp_path, cfg)
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert (cfg / ".gitignore").read_text(encoding="utf-8") == (
-            "env.source\n*.env\n"
-        )
-        readme = (cfg / "README.md").read_text(encoding="utf-8")
-        assert "env.source" in readme  # the secrets story is told
-        assert "Seeded" in result.stdout  # announced, never silent
-
-    def test_seeding_is_idempotent(self, tmp_path):
-        cfg = tmp_path / "agentive-config"
-        cfg.mkdir()
-        assert self._run(tmp_path, cfg).returncode == 0
-        before = {p.name: p.read_bytes() for p in cfg.iterdir() if p.is_file()}
-        second = self._run(tmp_path, cfg)
-        assert second.returncode == 0, second.stderr + second.stdout
-        assert "Seeded" not in second.stdout
-        after = {p.name: p.read_bytes() for p in cfg.iterdir() if p.is_file()}
-        assert after == before
-
-    def test_seeding_never_overwrites(self, tmp_path):
-        cfg = tmp_path / "agentive-config"
-        cfg.mkdir()
-        (cfg / ".gitignore").write_text("my-own-rules\n", encoding="utf-8")
-        result = self._run(tmp_path, cfg)
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert (cfg / ".gitignore").read_text(encoding="utf-8") == "my-own-rules\n"
-        # the OTHER file still seeds — per-file independence
-        assert (cfg / "README.md").is_file()
-
-    def test_no_preset_flag_skips_seeding(self, tmp_path):
-        cfg = tmp_path / "agentive-config"
-        cfg.mkdir()
-        result = self._run(tmp_path, cfg, "--no-preset")
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert list(cfg.iterdir()) == []
-        assert "Seeded" not in result.stdout
-
-    def test_never_creates_the_folder(self, tmp_path):
-        # N3: a preset-less run must not drive-by-create the config
-        # home — engaging the preset flow (mkdir) is the user's move
-        cfg = tmp_path / "agentive-config"  # never created
-        result = self._run(tmp_path, cfg)
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert not cfg.exists()
-
-
-class TestPresetPathNamed:
-    """The loudness rule: the loaded preset path is NAMED in door
-    output. (The legacy ~/.config/agentive-kit notice and its tests
-    retired at 0.9.0 with the KIT-0059 removal set.)"""
-
-    def test_new_location_loads_named(self, tmp_path):
-        cfg = write_preset(tmp_path, "profile: none\n")
-        target = make_adopt_dir(tmp_path, "app")
-        result = run_door(
-            "--adopt",
-            str(target),
-            env=_scrubbed_env(AGENTIVE_KIT_CONFIG_DIR=str(cfg)),
-        )
-        assert result.returncode == 0, result.stderr + result.stdout
-        assert f"Preset: {cfg / 'preset'}" in result.stdout
-        assert "profile: none" in _kit_install_region(target)
-
-
-class TestConfigHomeOverrideTilde:
-    """o3 (this PR): an env file can hand the override a literal
-    leading tilde the shell never expanded — all resolvers expand it
-    (the env-source precedent)."""
-
-    def test_tilde_in_override_expands(self, tmp_path):
-        result = sourced(
-            "config_home",
-            env=_scrubbed_env(
-                AGENTIVE_KIT_CONFIG_DIR="~/agentive-config-tilde",
-                HOME=str(tmp_path),
-            ),
-        )
-        assert result.returncode == 0, result.stderr
-        assert result.stdout.strip() == str(tmp_path / "agentive-config-tilde")
+    def test_other_flags_refused_never_dropped(self, tmp_path):
+        target = make_adopt_dir(tmp_path, "mat")
+        for extra in (
+            ["--shape", "planning"],
+            ["--profile", "none"],
+            ["--bots", "none"],
+        ):
+            result = run_door("--adopt", str(target), "--design-materials", *extra)
+            assert result.returncode == 2, extra
+            assert "cannot be combined with --design-materials" in result.stderr, extra


### PR DESCRIPTION
## Summary

PR 2 of 3 for KIT-0104 (KIT-ADR-0030 — the door ships in the package). PR 1 (#129) shipped `agentive new` / `agentive adopt`; this PR retires the old entrance:

- **F3 — `scripts/local/bootstrap` is an exec shim** (1,230 → 165 lines): translates `--new`/`--adopt` to the package verbs and execs the **checkout's own** `packages/agentive-kit/src` (deterministic — never an older installed wheel). `--help` defers to the package. One legacy branch stays: `--adopt --design-materials` still drives `engine-materials.sh` directly until project-intake (KIT-0105) succeeds it — the branch dies with the shim.
- **F4 — `agentive new <dir> --no-kit`** produces a KIT-ADR-0032 rung-0 repo (check hook + git init; no `.kit/`, no record, no doctor), mirroring the adopt rung-0 tail: explicit offers and a preset `env-source` are acknowledged out loud; `--bots` and `--name`/`--prefix` are refused loudly (masking class).
- **F2 riders filed and pinned**: shim removal = `.kit/tasks/1-backlog/KIT-0107-remove-the-bootstrap-shim.md`; engine consolidation = `.kit/tasks/1-backlog/KIT-0108-consolidate-the-door-engines.md` — both pinned to the next minor release (0.10.0).

Two deliberate retirements ride the shim (both operator decisions recorded on PR 1):
- **adopt is packaged-mode** — the legacy copy-adopt (toolchain rsync) is gone; pinned by `TestPackagedAdoptThroughShim`.
- **`--no-kit` is rung 0 from both verbs** — the old seeded-record `--no-kit` is gone; pinned by `TestRungZeroThroughShim`.

## Grep proofs

**Matrix single ownership** (AC 5) — the only implementation is the Python front; also pinned forever as `tests/test_setup_door.py::TestShimStatic`:
```text
$ grep -rn 'LEGAL_PAIRS\|single:python\|legal_pairs' --include='*.sh' --include='*.py' --include=bootstrap scripts/ packages/ .claude/ | grep -v door/__init__.py
(no output)
```

**Behavioral equivalence** (AC \"bootstrap --new proof\") — `TestShimEquivalence` asserts tree-snapshot equality (sha256, per file) between a shim run and a direct `agentive` run for both `new` and `adopt`; the full scaffold-acceptance suite also runs through the shim.

## Deliberate deviations (said out loud)

- The shim does not re-implement the old TTY mode prompt: bare `bootstrap` exits 2 with `mode is required` in all contexts (the flag surface is unchanged).
- `--design-materials` accepts no companion flags (previously-legal redundant ones like `--shape single` are now refused loudly rather than resolved) — the flow is fixed adopt/single/python, and the branch is deprecated.

## Review-surface budget

832 additions / 3,263 deletions. Over the 500-addition target — **operator-approved as one PR** (in-session, 2026-08-13): 64% of additions are test rewrites replacing 3.2k deleted legacy-characterization lines, 17% are the two required backlog filings + CHANGELOG; the shim breaks the legacy tests instantly, so no green split lands under budget.

## Evaluator trio (pre-PR, KIT-0035 ordering)

Record: `.kit/context/reviews/KIT-0104-evaluator-review.md` (PR 2 section). fast = CONCERNS (3 parity notes, declined with evidence); deep = FAIL (both \"blockers\" refuted against `main`'s door — the bash door never accepted dash-leading targets and its identity check/GIT_* scrub are byte-parity, the KIT-0048 defense); claude-code = APPROVED (one remediation taken: the shim probes `agentive_kit/cli.py`, not just the package dir).

## Test plan

- [x] Full suite: 1110 passed, 13 skipped (`ci-check.sh` green, coverage 89.6%)
- [x] `test_door_data_sync.py` untouched and green (no engine/data edits in this PR)
- [x] Shim smoke: `--new` full install, `--new --no-kit` rung 0, `--help` deferral, materials-flag refusals
- [x] New: `TestNewNoKit` (5 E2E), `validate_combo` rung-0 units, shim static/translation/materials suites

Task: `.kit/tasks/3-in-progress/KIT-0104-ship-the-door-in-the-package.md` (stays in-progress; PR 3 = prose sweep + KIT-0094 rider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvXHQsb72XdAs8wqzQYuoQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the primary project-creation entry path and rung-0 semantics for `new`, with large test rewrites; behavior is heavily pinned but mis-shimmed flags or materials-only edge cases could still surprise operators until KIT-0107 lands.
> 
> **Overview**
> **KIT-0104 PR 2** turns `scripts/local/bootstrap` from the full door (~1,230 lines) into a **~165-line exec shim** that maps `--new` / `--adopt` to `python3 -m agentive_kit.cli` using the **checkout’s** `packages/agentive-kit/src` (not an installed wheel). Matrix, presets, help, and exit codes live only in `agentive_kit.door`. The shim keeps **one legacy path**: `--adopt --design-materials` still runs `engine-materials.sh` until KIT-0107; everything else prints a removal notice (KIT-0107, 0.10.0).
> 
> In the package, **`--no-kit` is rung 0 for both verbs** (KIT-0104 F4 / KIT-ADR-0032): check hook + git init, no `.kit/`, record, `.env`, or doctor. New guards refuse **`--no-kit` with `--name`/`--prefix` or `--bots`**, and preset **`env-source` on rung 0** is acknowledged but not applied. Help text matches (`.env` only when a kit install runs).
> 
> **Tests** drop legacy copy-adopt characterization and add **shim vs direct `agentive` tree equivalence**, rung-0 coverage (`TestNewNoKit`, shim rung-zero suites), and **bots conformance** via `pkg_door.load_record` / `normalize_bots`. **Backlog**: KIT-0107 (shim + materials branch removal) and KIT-0108 (engine consolidation), both pinned to **0.10.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7971aef801a65ccb4ba061df98ed8bf68c37ec03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->