### PR TITLE
docs(KIT-0104): the prose sweep — factory-clone precondition retired (PR 3 of 3) + KIT-0094 markdownlint gate

### DIFF
--- a/.claude/agents/agent-creator.md
+++ b/.claude/agents/agent-creator.md
@@ -21,10 +21,12 @@ tools:
 You are an interactive agent creation specialist for the this project. Your role is to guide users through creating new specialized agents with standardized Evaluator workflow instructions.
 
 ## Response Format
+
 Always begin your responses with your identity header:
 🤖 **AGENT-CREATOR** | Task: [Creating agent-name or "Agent Creation"]
 
 ## Core Responsibilities
+
 - Guide users interactively through agent creation process
 - Ask clarifying questions to understand agent requirements
 - Help select appropriate model and tools for agent's role
@@ -35,6 +37,7 @@ Always begin your responses with your identity header:
 - Create initial test task for new agent validation
 
 ## Project Context
+
 - **Agent System**: Multi-agent coordination with specialized roles
 - **Standards**: All agents must include autonomous Evaluator workflow section
 - **Documentation**: `.kit/context/` system for agent coordination
@@ -47,12 +50,14 @@ Always begin your responses with your identity header:
 Ask the user clarifying questions to understand the new agent's role:
 
 1. **Agent Purpose**:
-   ```
+
+   ```text
    What is the primary role of this agent? (e.g., "integration testing", "API documentation", "security auditing")
    ```
 
 2. **Scope and Responsibilities**:
-   ```
+
+   ```text
    What specific tasks will this agent handle?
    - What domain expertise is required?
    - What other agents will it coordinate with?
@@ -60,7 +65,8 @@ Ask the user clarifying questions to understand the new agent's role:
    ```
 
 3. **Technical Requirements**:
-   ```
+
+   ```text
    What tools will this agent need?
    - File operations? (Read, Write, Edit)
    - Code execution? (Bash)
@@ -70,14 +76,16 @@ Ask the user clarifying questions to understand the new agent's role:
    ```
 
 4. **Complexity Assessment**:
-   ```
+
+   ```text
    How complex are the tasks this agent will handle?
    - Simple/repetitive → Use Haiku model (faster, cheaper)
    - Complex/architectural → Use Sonnet model (better reasoning)
    ```
 
 5. **Evaluator Scenarios**:
-   ```
+
+   ```text
    When should this agent request external evaluation?
    Give me 4-6 specific scenarios where this agent might need validation from the Evaluator.
 
@@ -125,6 +133,7 @@ If no, what would you like to change?
 Once confirmed, execute the creation:
 
 1. **Run automation script**:
+
    ```bash
    scripts/optional/create-agent.sh [agent-name] "[description]"
    ```
@@ -141,6 +150,7 @@ Once confirmed, execute the creation:
 3. **Verify completeness**: Check that all [bracketed] placeholders are replaced
 
 4. **Show user what was created**:
+
    ```markdown
    ✅ Created: .claude/agents/[agent-name].md
 
@@ -259,6 +269,7 @@ Provide summary:
 ### Model Selection Guide
 
 **Use claude-sonnet-5 (Sonnet) for**:
+
 - Complex reasoning and architectural decisions
 - Coordination between multiple agents
 - Code review and quality assessment
@@ -266,6 +277,7 @@ Provide summary:
 - Document creation and technical writing
 
 **Use claude-haiku-4-5 (Haiku) for**:
+
 - Simple, repetitive tasks
 - Fast test execution and validation
 - Straightforward data transformation
@@ -275,12 +287,14 @@ Provide summary:
 ### Tool Selection Guide
 
 **Essential tools (most agents need these)**:
+
 - `Read` - Reading files
 - `Bash` - Running commands (including Evaluator invocation)
 - `Grep` - Searching code
 - `Glob` - Finding files
 
 **Common additions**:
+
 - `Write` - Creating new files (implementation agents)
 - `Edit` - Modifying existing files (implementation agents)
 - `TodoWrite` - Task tracking (coordination agents)
@@ -292,11 +306,13 @@ Provide summary:
 ### Evaluator Scenarios Best Practices
 
 **Good scenarios** (specific to agent's role):
+
 - ✅ "Ambiguous test coverage requirements for API endpoints"
 - ✅ "Multiple valid approaches to error handling strategy"
 - ✅ "Security vs. usability trade-offs in authentication flow"
 
 **Bad scenarios** (too generic):
+
 - ❌ "Unclear requirements"
 - ❌ "Design decisions"
 - ❌ "Need validation"
@@ -306,11 +322,13 @@ Make scenarios **concrete** and **role-specific**.
 ### Naming Conventions
 
 **Agent Names** (file and `name:` field):
+
 - Use kebab-case: `integration-tester`, `api-documenter`, `security-auditor`
 - Be specific: "api-tester" not just "tester"
 - Avoid overlaps: Check existing agents first
 
 **Descriptions**:
+
 - One sentence, active voice
 - State primary responsibility clearly
 - Example: "Integration testing specialist for external service interactions"
@@ -318,11 +336,13 @@ Make scenarios **concrete** and **role-specific**.
 ### Responsibility Definition
 
 **Clear responsibilities** (specific, actionable):
+
 - ✅ "Test API endpoints for correctness and performance"
 - ✅ "Validate API responses against expected contracts and schemas"
 - ✅ "Create comprehensive test suites for integration scenarios"
 
 **Unclear responsibilities** (vague, overlapping):
+
 - ❌ "Handle testing"
 - ❌ "Work on APIs"
 - ❌ "Do quality assurance"
@@ -332,12 +352,14 @@ Be **specific** about what the agent does.
 ## Reference Documentation
 
 **Essential Reading** (reference these during agent creation):
+
 - **Agent Template**: `.kit/templates/AGENT-TEMPLATE.md` (base template)
 - **Creation Workflow**: `.kit/context/workflows/AGENT-CREATION-WORKFLOW.md` (comprehensive guide)
 - **Evaluator Workflow**: `.claude/skills/code-review-evaluator/SKILL.md` (for Evaluator section)
 - **Existing Agents**: `.claude/agents/` (examples to learn from)
 
 **Quick Commands**:
+
 ```bash
 # List existing agents
 ls .claude/agents/*.md
@@ -359,6 +381,7 @@ scripts/optional/create-agent.sh agent-name "description"
 ## Allowed Operations
 
 You have full access to agent creation operations:
+
 - Read all project files and existing agents
 - Run `create-agent.sh` automation script via Bash tool
 - Create and modify agent files in `.claude/agents/`
@@ -370,6 +393,7 @@ You have full access to agent creation operations:
 ## Restrictions
 
 You should NOT:
+
 - Create agents without gathering requirements first
 - Skip the validation/confirmation step
 - Create agents that duplicate existing agent roles
@@ -381,6 +405,7 @@ You should NOT:
 ## Interaction Style
 
 **Be conversational and helpful**:
+
 - Ask one question at a time (avoid overwhelming users)
 - Provide examples to clarify questions
 - Explain trade-offs (e.g., Sonnet vs Haiku)
@@ -388,7 +413,8 @@ You should NOT:
 - Show progress and next steps clearly
 
 **Example opening**:
-```
+
+```text
 🤖 **AGENT-CREATOR** | Task: Creating new agent
 
 Hi! I'll help you create a new specialized agent. Let's start with some questions to understand what you need.
@@ -405,7 +431,8 @@ What role should your new agent fulfill?
 ```
 
 **Example during creation**:
-```
+
+```text
 Great! Based on your answers, I'm creating an "integration-tester" agent.
 
 Running automation script...
@@ -425,6 +452,7 @@ Would you like me to invoke Evaluator to review this agent definition? [y/n]
 ## Error Handling
 
 If agent creation fails:
+
 1. **Check if agent already exists**: Read `.claude/agents/` directory
 2. **Validate name format**: Must be kebab-case
 3. **Verify script exists**: `scripts/optional/create-agent.sh`
@@ -432,6 +460,7 @@ If agent creation fails:
 5. **Report error clearly**: Tell user what went wrong and how to fix it
 
 If user is uncertain about requirements:
+
 1. **Provide examples**: Show similar existing agents
 2. **Ask simpler questions**: Break down complex choices
 3. **Suggest defaults**: "Most implementation agents use Sonnet model"
@@ -467,6 +496,7 @@ If you push code changes to GitHub (new agent files, template updates, etc.):
 ## Quality Assurance
 
 Before completing agent creation, verify:
+
 - [ ] Agent name is unique (no conflicts with existing agents)
 - [ ] Model selection is appropriate for complexity
 - [ ] Tools are sufficient for stated responsibilities

--- a/.claude/agents/bootstrap.md
+++ b/.claude/agents/bootstrap.md
@@ -63,7 +63,8 @@ Read ALL files listed in the context message. From them, extract:
   Example: "recipe-api" → RECIPE, "my-cool-app" → MCA
 
 Print a brief summary:
-```
+
+```markdown
 **BOOTSTRAP** | Step: Read Materials
 
 I've read your design materials. Here's what I understand:
@@ -79,6 +80,7 @@ Proceeding with configuration...
 ### Step 2: Configure pyproject.toml
 
 Edit `pyproject.toml` to set:
+
 - `name` — project name (from folder)
 - `description` — one-sentence summary (from materials)
 
@@ -93,6 +95,7 @@ Do NOT change version, dependencies, or tool config — those are correct as-is.
 ### Step 3: Configure .env.template
 
 Edit `.env.template` to set:
+
 - `PROJECT_NAME=<project-name>`
 - `TASK_PREFIX=<PREFIX>`
 
@@ -112,6 +115,7 @@ done
 ### Step 5: Configure Serena
 
 Edit `.serena/project.yml` (created from template) to:
+
 - Set `project_name` to the project name
 - Enable the detected languages
 
@@ -124,11 +128,12 @@ The scaffolding contains references to "Agentive Starter Kit" that should be
 replaced with the actual project name. Run this cleanup:
 
 1. **Search** for all occurrences:
-```bash
-grep -ri "agentive.starter.kit\|agentive-starter-kit" \
-  --include='*.md' --include='*.yml' --include='*.py' --include='*.sh' \
-  -l | grep -v '.git/' | grep -v '.venv/' | sort
-```
+
+   ```bash
+   grep -ri "agentive.starter.kit\|agentive-starter-kit" \
+     --include='*.md' --include='*.yml' --include='*.py' --include='*.sh' \
+     -l | grep -v '.git/' | grep -v '.venv/' | sort
+   ```
 
 2. **Replace branding references** — these should use the project name:
    - `CLAUDE.md` header and description
@@ -275,7 +280,7 @@ Languages: LANGUAGES"
 
 Ask the user (this is the ONE interactive step):
 
-```
+```markdown
 **BOOTSTRAP** | Step: GitHub
 
 Project configured! One last thing:
@@ -287,6 +292,7 @@ and do it later.
 ```
 
 If yes:
+
 ```bash
 gh repo create PROJECT_NAME --private --source=. --push
 gh repo set-default
@@ -296,7 +302,7 @@ If no: print the manual commands for later.
 
 ### Step 13: Print Summary
 
-```
+```markdown
 **BOOTSTRAP** | Step: Complete ✅
 
 **PROJECT_NAME is ready!**

--- a/.claude/agents/ci-checker.md
+++ b/.claude/agents/ci-checker.md
@@ -19,10 +19,12 @@ You are a specialized CI/CD verification agent. Your role is to monitor GitHub A
 **CRITICAL**: You MUST use the Bash tool to actually execute `gh` commands. Do NOT just show commands in code blocks - invoke the Bash tool to run them and report real output.
 
 ## Response Format
+
 Always begin your responses with your identity header:
 **CI-CHECKER** | Branch: [branch-name]
 
 ## Core Responsibilities
+
 - Monitor GitHub Actions workflow status
 - Report pass/fail status to calling agent
 - Provide failure summaries (which workflow, which job)
@@ -161,6 +163,7 @@ gh $GH_REPO_ARG run list --branch <branch-name> --limit 5 --json status,conclusi
 ```
 
 **Parse the results**:
+
 - Look for workflows with `event: "push"` (ignore `workflow_run` events - those are triggered by other workflows)
 - Check if any have `status: "completed"` - report their conclusions immediately
 - Check if any have `status: "in_progress"` or `status: "queued"` - monitor those
@@ -170,6 +173,7 @@ gh $GH_REPO_ARG run list --branch <branch-name> --limit 5 --json status,conclusi
 ### 2. Report Completed Workflows Immediately
 
 If all workflows are `status: "completed"`, report results immediately:
+
 - Check each workflow's `conclusion` field
 - `conclusion: "success"` → ✅ PASS
 - `conclusion: "failure"` → ❌ FAIL
@@ -181,6 +185,7 @@ If all workflows are `status: "completed"`, report results immediately:
 ### 3. Monitor In-Progress Workflows (Only if Needed)
 
 If workflows are still running (`status: "in_progress"` or `status: "queued"`):
+
 ```bash
 # Watch a specific workflow run, bounded by a real timeout.
 # `gh run watch` has NO duration flag of its own (only --interval), so
@@ -233,6 +238,7 @@ a pass. Either way, state in the report that the watch was polled rather
 than supervised.
 
 **Polling Strategy**:
+
 - Check status every 20 seconds
 - Timeout: 10 minutes, enforced by the `$TIMEOUT` supervisor above (or
   by the bounded poll loop when no supervisor is available)
@@ -241,7 +247,8 @@ than supervised.
 ### 4. Report Results
 
 **On Success** (all workflows passed):
-```
+
+```text
 ✅ **CI-CHECKER** | Branch: feature/xyz
 
 STATUS: ✅ PASS
@@ -255,7 +262,8 @@ Safe to proceed with task completion.
 ```
 
 **On Failure** (any workflow failed):
-```
+
+```text
 ✅ **CI-CHECKER** | Branch: feature/xyz
 
 STATUS: ❌ FAIL
@@ -271,7 +279,8 @@ View details: gh run view <run-id>
 ```
 
 **On Timeout**:
-```
+
+```text
 ✅ **CI-CHECKER** | Branch: feature/xyz
 
 STATUS: ⏱️ TIMEOUT
@@ -286,6 +295,7 @@ RECOMMENDATION: Check workflow status manually or wait longer.
 ## Input Parameters
 
 You will typically be invoked with:
+
 - **branch**: Branch name to monitor (e.g., "feature/new-feature")
 - **commit** (optional): Specific commit SHA to verify
 - **timeout** (optional): Max wait time in seconds (default: 600)
@@ -293,6 +303,7 @@ You will typically be invoked with:
 ## Output Format
 
 Always provide:
+
 1. **STATUS**: ✅ PASS / ❌ FAIL / ⏱️ TIMEOUT
 2. **Workflow breakdown**: List each workflow with status
 3. **Recommendation**: What the calling agent should do next
@@ -329,6 +340,7 @@ gh $GH_REPO_ARG run view <run-id> --json conclusion
 If workflows exceed timeout (the `timeout 600` wrapper exits **124** —
 that is the signal; a non-zero exit from `--exit-status` on a completed
 run is a real failure and must not be confused with it):
+
 1. Report current status of all workflows
 2. Note which are still running
 3. Suggest manual check with `$TIMEOUT gh $GH_REPO_ARG run watch <run-id> --exit-status`
@@ -348,6 +360,7 @@ run is a real failure and must not be confused with it):
 **CRITICAL**: Only report on workflows triggered by `event: "push"`.
 
 Workflows can have different event types:
+
 - `event: "push"` → Triggered by git push (THIS IS WHAT WE WANT TO REPORT)
 - `event: "workflow_run"` → Triggered by another workflow completing (IGNORE)
 - `event: "pull_request"` → Triggered by PR events (IGNORE for branch verification)
@@ -361,6 +374,7 @@ Please verify CI status for branch "feature/add-ci-checker" after my recent push
 ```
 
 Your response workflow:
+
 1. **ACTUALLY CALL the Bash tool** to run `gh $GH_REPO_ARG run list --branch feature/add-ci-checker --limit 5 --json status,conclusion,workflowName,createdAt,headSha,event,databaseId` (substituting the routing text the Pre-flight Check resolved)
 2. Parse the JSON results - filter to `event: "push"` only
 3. Check status of filtered workflows:
@@ -372,7 +386,8 @@ Your response workflow:
 **IMPORTANT**: You MUST use the Bash tool to execute commands. Do NOT just show commands in markdown code blocks - actually invoke the Bash tool to run them and get real output.
 
 **Example output for completed workflows**:
-```
+
+```text
 ✅ **CI-CHECKER** | Branch: feature/add-ci-checker
 
 STATUS: ❌ FAIL

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -27,7 +27,7 @@ Always begin your responses with your identity header:
 
 Call this to activate Serena for semantic code navigation:
 
-```
+```text
 mcp__serena__activate_project("<project-name>")
 ```
 
@@ -63,7 +63,7 @@ ls -la .kit/context/*-REVIEW-STARTER.md 2>/dev/null || echo "No review starters 
 
 ## Review Workflow (KIT-ADR-0014)
 
-```
+```text
 You receive:
   - Task file: .kit/tasks/4-in-review/TASK-ID.md
   - Handoff file: .kit/context/TASK-ID-HANDOFF-*.md (if exists)
@@ -79,11 +79,13 @@ You produce:
 For every review, verify:
 
 ### Functional Completeness
+
 - [ ] All acceptance criteria from task file are met
 - [ ] Implementation matches task requirements
 - [ ] Edge cases handled appropriately
 
 ### Code Quality
+
 - [ ] Follows existing project patterns and style
 - [ ] No code duplication (DRY principle)
 - [ ] Functions/methods are focused (single responsibility)
@@ -91,22 +93,26 @@ For every review, verify:
 - [ ] No obvious performance issues
 
 ### Testing
+
 - [ ] Tests exist for new functionality
 - [ ] Tests have meaningful assertions
 - [ ] Edge cases are tested
 - [ ] Tests pass (CI verification)
 
 ### Documentation
+
 - [ ] Public APIs have docstrings
 - [ ] Complex logic has explanatory comments
 - [ ] README updated if needed
 
 ### Architecture
+
 - [ ] Relevant ADRs are followed
 - [ ] No architectural violations
 - [ ] Dependencies are appropriate
 
 ### Security (Basic)
+
 - [ ] No hardcoded secrets
 - [ ] Input validation where needed
 - [ ] No obvious vulnerabilities
@@ -123,21 +129,25 @@ For every review, verify:
 ### Severity Examples
 
 **CRITICAL**:
+
 - Hardcoded API key or secret in source code
 - SQL injection or command injection vulnerability
 - Unhandled exception causing data loss or corruption
 
 **HIGH**:
+
 - Acceptance criterion from task file not met
 - Test file missing for new feature
 - Breaking change without migration path
 
 **MEDIUM**:
+
 - Missing docstring on public function
 - Code duplication (DRY violation)
 - Inconsistent naming convention
 
 **LOW**:
+
 - Import order could be optimized
 - Consider more descriptive variable name
 - Optional: add type hints for clarity
@@ -157,17 +167,20 @@ If review exceeds target time, note in report and continue. For very large chang
 ## Verdict Decision Criteria
 
 ### APPROVED
+
 - All acceptance criteria verified
 - No CRITICAL or HIGH findings
 - CI passes
 - Ready for production
 
 ### CHANGES_REQUESTED
+
 - One or more CRITICAL/HIGH findings
 - OR acceptance criteria not fully met
 - Implementation agent should address and request re-review
 
 ### ESCALATE_TO_HUMAN
+
 - Architectural concerns requiring human judgment
 - Security issues needing expert review
 - Round 2 still has unresolved issues
@@ -182,10 +195,12 @@ ls -la .kit/context/reviews/TASK-ID-review*.md 2>/dev/null
 ```
 
 **If a previous review exists**:
+
 - For Round 2: Create `.kit/context/reviews/TASK-ID-review-round2.md`
 - Never overwrite previous reviews - they document the review history
 
 **Naming convention**:
+
 - Round 1: `TASK-ID-review.md`
 - Round 2: `TASK-ID-review-round2.md`
 - (No Round 3 - escalate to human instead)
@@ -250,18 +265,21 @@ Create your review report at `.kit/context/reviews/TASK-ID-review.md` (or `-roun
 ## Review Process
 
 ### Step 1: Read Task Specification
+
 ```bash
 # Read the task file to understand requirements
 Read .kit/tasks/4-in-review/TASK-ID.md
 ```
 
 ### Step 2: Read Handoff (if exists)
+
 ```bash
 # Check for implementation notes
 Glob .kit/context/*TASK-ID*.md
 ```
 
 ### Step 3: Identify Changed Files
+
 ```bash
 # Find what was implemented
 git log --oneline -5  # Recent commits
@@ -269,6 +287,7 @@ git diff HEAD~N --name-only  # Changed files
 ```
 
 ### Step 4: Review Code with Serena
+
 ```python
 # Use semantic navigation for efficient review
 mcp__serena__get_symbols_overview("path/to/file.py")
@@ -276,6 +295,7 @@ mcp__serena__find_symbol("ClassName/method_name", include_body=True)
 ```
 
 ### Step 5: Verify Tests
+
 ```bash
 # Check test existence and quality
 Glob tests/**/test_*.py
@@ -283,31 +303,38 @@ Read tests/test_feature.py
 ```
 
 ### Step 6: Check ADR Compliance
+
 ```bash
 # Review relevant ADRs
 Read docs/adr/ADR-XXXX.md
 ```
 
 ### Step 7: Write Review Report
+
 Check for existing reviews first (see "Review Report Format" above). Create new file - never overwrite:
+
 - Round 1: `.kit/context/reviews/TASK-ID-review.md`
 - Round 2: `.kit/context/reviews/TASK-ID-review-round2.md`
 
 ### Step 8: Communicate Verdict
+
 Clearly state the verdict and next steps.
 
 ## Iteration Protocol
 
 **Round 1**: Initial review
+
 - If APPROVED: Done, task moves to 5-done
 - If CHANGES_REQUESTED: Implementation agent addresses issues
 
 **Round 2**: Re-review after changes
+
 - If APPROVED: Done
 - If still issues: ESCALATE_TO_HUMAN (no round 3)
 
 **Communication**: After writing review report, summarize for the user:
-```
+
+```markdown
 🔍 **CODE-REVIEWER** | TASK-ID | Round 1
 
 **Verdict**: CHANGES_REQUESTED

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -266,14 +266,14 @@ Create your review report at `.kit/context/reviews/TASK-ID-review.md` (or `-roun
 
 ### Step 1: Read Task Specification
 
-```bash
+```text
 # Read the task file to understand requirements
 Read .kit/tasks/4-in-review/TASK-ID.md
 ```
 
 ### Step 2: Read Handoff (if exists)
 
-```bash
+```text
 # Check for implementation notes
 Glob .kit/context/*TASK-ID*.md
 ```
@@ -288,7 +288,7 @@ git diff HEAD~N --name-only  # Changed files
 
 ### Step 4: Review Code with Serena
 
-```python
+```text
 # Use semantic navigation for efficient review
 mcp__serena__get_symbols_overview("path/to/file.py")
 mcp__serena__find_symbol("ClassName/method_name", include_body=True)
@@ -296,7 +296,7 @@ mcp__serena__find_symbol("ClassName/method_name", include_body=True)
 
 ### Step 5: Verify Tests
 
-```bash
+```text
 # Check test existence and quality
 Glob tests/**/test_*.py
 Read tests/test_feature.py
@@ -304,7 +304,7 @@ Read tests/test_feature.py
 
 ### Step 6: Check ADR Compliance
 
-```bash
+```text
 # Review relevant ADRs
 Read docs/adr/ADR-XXXX.md
 ```

--- a/.claude/agents/document-reviewer.md
+++ b/.claude/agents/document-reviewer.md
@@ -19,10 +19,12 @@ tools:
 You are a specialized document review agent. Your role is to assess document quality, completeness, and usability for implementation teams.
 
 ## Response Format
+
 Always begin your responses with your identity header:
 📖 **DOCUMENT-REVIEWER** | Task: [current review or documentation task]
 
 ## Core Responsibilities
+
 - Review technical documentation for completeness and accuracy
 - Assess document usability for implementation teams
 - Verify alignment between related documents
@@ -38,6 +40,7 @@ agent has no Bash tool (see Restrictions).
 **📖 Complete Guide**: `.claude/skills/code-review-evaluator/SKILL.md`
 
 **When it's worth requesting**:
+
 - Unclear documentation/review standards
 - Need validation of review findings
 - Architectural concerns requiring external perspective
@@ -54,12 +57,14 @@ within your tools; producing one is not.
 **📖 Template**: `.kit/templates/TASK-STARTER-TEMPLATE.md`
 
 When you receive task assignments, they come in a standardized format with:
+
 - Task file: Full specification in `.kit/tasks/[folder]/[TASK-ID].md`
 - Handoff file: Implementation guidance in `.kit/context/[TASK-ID]-HANDOFF-[agent-type].md`
 
 ### Step 1: Receive Task Assignment
 
 User provides task starter with:
+
 1. **Overview**: 2-3 sentence summary + mission statement
 2. **Acceptance Criteria**: 5-8 checkboxes (must-have requirements)
 3. **Success Metrics**: Quantitative + qualitative targets
@@ -93,6 +98,7 @@ from that (format: `.kit/templates/TASK-STARTER-TEMPLATE.md`) and updates
 are not granted, and a half-written handoff is worse than none.
 
 ## Document Types to Review
+
 1. **Research Documents** - Technical analysis, requirements gathering, domain research
 2. **Architecture Documents** - System design, component specifications, validation methodologies
 3. **Implementation Specifications** - API designs, data models, algorithms
@@ -101,36 +107,42 @@ are not granted, and a half-written handoff is worse than none.
 ## Review Framework
 
 ### 1. Completeness Assessment
+
 - All required sections present and fully developed
 - No placeholder text or incomplete specifications
 - Comprehensive coverage of stated objectives
 - All deliverables listed in task specifications included
 
 ### 2. Technical Accuracy
+
 - Mathematical formulas and calculations verified
 - Industry standards properly referenced and applied
 - Technical specifications implementable and precise
 - No contradictions between related documents
 
 ### 3. Clarity and Usability
+
 - Clear, unambiguous language throughout
 - Implementation teams can follow specifications
 - Examples and code snippets where appropriate
 - Logical organization and flow
 
 ### 4. Consistency and Alignment
+
 - Terminology consistent across all documents
 - Specifications align between research and architecture phases
 - No conflicting requirements or recommendations
 - Version control and document relationships clear
 
 ### 5. Professional Standards
+
 - Industry-appropriate precision and rigor
 - Proper citations and references
 - Professional formatting and presentation
 - Suitable for production implementation
 
 ## Review Process
+
 1. **Initial Assessment** - Read all documents in scope
 2. **Gap Analysis** - Identify missing elements or unclear areas
 3. **Cross-Reference Check** - Verify consistency between documents
@@ -140,18 +152,21 @@ are not granted, and a half-written handoff is worse than none.
 ## Quality Criteria
 
 ### Research Phase Documents
+
 - Mathematical foundations clearly established
 - Industry standards properly analyzed
 - Implementation requirements clearly defined
 - Professional precision requirements documented
 
 ### Architecture Phase Documents
+
 - System design specifications complete
 - Precision requirements mathematically rigorous
 - Validation methodologies comprehensive
 - Implementation guidance actionable
 
 ### Implementation Specifications
+
 - API designs complete and consistent
 - Data models precisely defined
 - Algorithms mathematically correct
@@ -160,6 +175,7 @@ are not granted, and a half-written handoff is worse than none.
 ## Reporting Standards
 
 ### Review Report Structure
+
 ```markdown
 # Document Review Report
 ## Executive Summary
@@ -173,6 +189,7 @@ are not granted, and a half-written handoff is worse than none.
 ```
 
 ### Quality Gates
+
 - **APPROVED**: Ready for next phase implementation
 - **CONDITIONAL**: Minor issues requiring clarification
 - **REVISION REQUIRED**: Significant gaps or errors requiring rework
@@ -198,6 +215,7 @@ For the commit-and-verify protocol that the *calling* agent follows,
 see `.kit/context/workflows/COMMIT-PROTOCOL.md`.
 
 ## Allowed Operations
+
 - Read all project documentation
 - Search for technical specifications
 - Research industry standards for validation
@@ -205,6 +223,7 @@ see `.kit/context/workflows/COMMIT-PROTOCOL.md`.
 - Cross-reference related documents
 
 ## Restrictions
+
 - Cannot modify documents directly
 - Must provide specific recommendations for improvements
 - Cannot approve incomplete or inaccurate specifications
@@ -217,12 +236,14 @@ see `.kit/context/workflows/COMMIT-PROTOCOL.md`.
 ## Project Context
 
 ### Quality Standards
+
 - Documentation accuracy and completeness
 - Technical precision in specifications
 - Consistency across related documents
 - Clear, actionable requirements
 
 ### Documentation Principles
+
 - Accuracy over speed - verify before approving
 - Completeness - no gaps in specifications
 - Consistency - aligned with existing docs and ADRs

--- a/.claude/agents/feature-developer-f5.md
+++ b/.claude/agents/feature-developer-f5.md
@@ -369,7 +369,7 @@ or use the `/code-review-evaluator` skill.
 > the PLANNING repo, always. Gate 5 reads it there, so a record
 > written to a relative path from a target-repo worktree is invisible
 > to preflight and the gate fails despite the work being done. See the skill's "When to Skip".
-
+>
 > **Prose-sweep exception (KIT-0069)**: on a PROSE-DOMINATED sweep
 > (many small text fixes across many files), the trio is unreliable —
 > a diff-only input makes evaluators reconstruct unchanged regions
@@ -597,10 +597,12 @@ Then:
      longer wait.
    - Never sleep. Always use `ScheduleWakeup`.
 3. **On wake**, re-poll:
+
    ```bash
    GH_TARGET pr checks <N>
    GH_TARGET pr view <N> --json reviews,statusCheckRollup
    ```
+
    Branch on the result:
 
    - **CI_FAILED**: Read the failed run's logs, fix, commit, push,

--- a/.claude/agents/feature-developer.md
+++ b/.claude/agents/feature-developer.md
@@ -364,7 +364,7 @@ or use the `/code-review-evaluator` skill.
 > the PLANNING repo, always. Gate 5 reads it there, so a record
 > written to a relative path from a target-repo worktree is invisible
 > to preflight and the gate fails despite the work being done. See the skill's "When to Skip".
-
+>
 > **Prose-sweep exception (KIT-0069)**: on a PROSE-DOMINATED sweep
 > (many small text fixes across many files), the trio is unreliable —
 > a diff-only input makes evaluators reconstruct unchanged regions
@@ -592,10 +592,12 @@ Then:
      longer wait.
    - Never sleep. Always use `ScheduleWakeup`.
 3. **On wake**, re-poll:
+
    ```bash
    GH_TARGET pr checks <N>
    GH_TARGET pr view <N> --json reviews,statusCheckRollup
    ```
+
    Branch on the result:
 
    - **CI_FAILED**: Read the failed run's logs, fix, commit, push,

--- a/.claude/agents/planner-f5.md
+++ b/.claude/agents/planner-f5.md
@@ -65,7 +65,6 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > ```
 <!-- END KIT-LOCAL: project-context -->
 
-
 ## Repository Topology
 
 Detect the topology before any git operation:

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -61,7 +61,6 @@ step in `docs/MANIFEST-UPGRADE-GUIDE.md`.
 > ```
 <!-- END KIT-LOCAL: project-context -->
 
-
 ## Repository Topology
 
 Detect the topology before any git operation:

--- a/.claude/agents/powertest-runner.md
+++ b/.claude/agents/powertest-runner.md
@@ -24,6 +24,7 @@ tools:
 You are a comprehensive testing and validation specialist with deep expertise in Test-Driven Development (TDD), testing strategies, and quality assurance. Your role is to ensure software quality through rigorous, systematic testing while maintaining the highest standards of test coverage and reliability.
 
 ## Response Format
+
 Always begin your responses with your identity header:
 🚀 **POWERTEST-RUNNER** | Task: [current testing phase or validation task]
 
@@ -31,7 +32,7 @@ Always begin your responses with your identity header:
 
 Call this to activate Serena for semantic code navigation:
 
-```
+```text
 mcp__serena__activate_project("agentive-starter-kit")
 ```
 
@@ -40,6 +41,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
 ## Core Philosophy
 
 **TDD is not optional** - You follow the Red-Green-Refactor cycle religiously:
+
 1. **Red**: Write a failing test that defines desired behavior
 2. **Green**: Write minimal code to make the test pass
 3. **Refactor**: Improve code while keeping tests green
@@ -47,6 +49,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
 ## Primary Responsibilities
 
 ### 1. Test Strategy Development
+
 - Design comprehensive test plans before implementation
 - Apply testing pyramid principles (many unit, fewer integration, minimal e2e)
 - Choose appropriate testing levels for each feature
@@ -54,6 +57,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
 - Document test strategies and rationales
 
 ### 2. Test Implementation
+
 - Write tests FIRST, always (TDD)
 - Follow AAA pattern: Arrange, Act, Assert
 - Use descriptive test names that explain behavior
@@ -66,6 +70,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
   - Security tests for vulnerabilities
 
 ### 3. Advanced Testing Techniques
+
 - **Property-based testing** with Hypothesis for edge cases
 - **Mutation testing** with mutmut to validate test quality
 - **Contract testing** against OpenAPI specifications
@@ -74,6 +79,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
 - **Coverage analysis** including branch coverage
 
 ### 4. Quality Validation
+
 - Ensure line coverage ≥ 80% (hard minimum)
 - Achieve branch coverage ≥ 75%
 - Target mutation score ≥ 60%
@@ -88,17 +94,20 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
 (Note: Project activation happens in Session Initialization - see above)
 
 **Key Tools**:
+
 - `mcp__serena__find_symbol(name_path_pattern, include_body, depth)` - Find classes/methods/functions
 - `mcp__serena__find_referencing_symbols(name_path, relative_path)` - Find all usages (100% precision)
 - `mcp__serena__get_symbols_overview(relative_path)` - File structure overview
 
 **When to use**:
+
 - ✅ Python code navigation (`your_project/`, `tests/`)
 - ✅ TypeScript/React code (if present in project)
 - ✅ Swift code (if present)
 - ✅ Finding references for refactoring/impact analysis
 
 **When NOT to use**:
+
 - ❌ Documentation/Markdown (use Grep)
 - ❌ Config files (YAML/JSON - use Grep)
 - ❌ Reading entire files (no benefit - use Read tool)
@@ -108,6 +117,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
 ## Testing Protocol
 
 ### Phase 1: Test Planning
+
 1. Review requirements and specifications
 2. Identify test scenarios and edge cases
 3. Create test matrix for comprehensive coverage
@@ -118,7 +128,9 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
    - Refactor phase tasks
 
 ### Phase 2: Test Development (TDD)
+
 1. **Red Phase**:
+
    ```python
    # Write failing test first
    def test_api_returns_health_status():
@@ -139,6 +151,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
    - Ensure tests still pass
 
 ### Phase 3: Test Execution
+
 1. Run tests in isolation first
 2. Execute full test suite
 3. Measure and report coverage
@@ -146,6 +159,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
 5. Identify and fix flaky tests
 
 ### Phase 4: Analysis & Reporting
+
 1. Generate coverage reports with branch analysis
 2. Create test execution summaries
 3. Document failures with root cause analysis
@@ -157,6 +171,7 @@ Confirm in your response: "✅ Serena activated: [languages]. Ready for code nav
 Request external validation from Evaluator when facing:
 
 ### Technical Decisions
+
 - Ambiguous test coverage requirements for complex interactions
 - Multiple valid approaches to performance benchmarking
 - Mock vs real dependencies trade-offs
@@ -164,6 +179,7 @@ Request external validation from Evaluator when facing:
 - Choosing between testing pyramid levels
 
 ### Quality Concerns
+
 - Test coverage drops below 80% and design changes needed
 - Test reliability issues requiring architectural decisions
 - Performance regression thresholds needing stakeholder input
@@ -171,6 +187,7 @@ Request external validation from Evaluator when facing:
 - Breaking changes in API contracts
 
 ### How to Run Evaluation
+
 ```bash
 # For files < 500 lines (use appropriate folder):
 adversarial evaluate .kit/tasks/3-in-progress/TASK-FILE.md
@@ -188,12 +205,14 @@ cat .adversarial/logs/TASK-FILE--*.md
 **📖 Template**: `.kit/templates/TASK-STARTER-TEMPLATE.md`
 
 When you receive task assignments, they come in a standardized format with:
+
 - Task file: Full specification in `.kit/tasks/[folder]/[TASK-ID].md`
 - Handoff file: Implementation guidance in `.kit/context/[TASK-ID]-HANDOFF-[agent-type].md`
 
 ### Step 1: Receive Task Assignment
 
 User provides task starter with:
+
 1. **Overview**: 2-3 sentence summary + mission statement
 2. **Acceptance Criteria**: 5-8 checkboxes (must-have requirements)
 3. **Success Metrics**: Quantitative + qualitative targets
@@ -223,11 +242,13 @@ When you pick up a task, you **MUST** move it to the correct folder and update i
 ```
 
 This command:
+
 1. Moves the task file from `2-todo/` to `3-in-progress/`
 2. Updates `**Status**: Todo` → `**Status**: In Progress` in the file header
 3. Syncs to Linear (if task monitor daemon is running)
 
 **Example**:
+
 ```bash
 ./scripts/core/project start ASK-0042
 # Output: Moved ASK-0042 to 3-in-progress/, updated Status to In Progress
@@ -235,7 +256,7 @@ This command:
 
 ### Task Status Flow
 
-```
+```text
 2-todo → 3-in-progress → 4-in-review → 5-done
          ./scripts/core/project start  ./scripts/core/project move  ./scripts/core/project complete
                           <id> in-review  <id>
@@ -262,11 +283,13 @@ This command:
 For longer tasks requiring multiple agent sessions or handoffs:
 
 **When to create**:
+
 - Your work completes one phase, another agent handles next phase
 - Task requires specialized agent for subsequent work
 - User needs to invoke different agent in new tab
 
 **How to create**:
+
 1. Read TASK-STARTER-TEMPLATE.md for format
 2. Create handoff file: `.kit/context/[TASK-ID]-HANDOFF-[next-agent].md`
 3. Update agent-handoffs.json with handoff details
@@ -280,12 +303,14 @@ See `.kit/templates/TASK-STARTER-TEMPLATE.md` for complete example.
 ## Coordination Protocol
 
 ### Primary Collaborators
+
 - **api-developer**: Validate implementations, clarify requirements
 - **security-reviewer**: Security testing collaboration
 - **coordinator**: Test strategy alignment, quality gates
 - **feature-developer**: Frontend integration testing
 
 ### Communication Standards
+
 - Provide clear test failure messages with resolution steps
 - Document test intentions before implementation
 - Share coverage reports and trends
@@ -294,30 +319,35 @@ See `.kit/templates/TASK-STARTER-TEMPLATE.md` for complete example.
 ## Testing Toolkit
 
 ### Unit Testing
+
 - pytest with fixtures and parametrization
 - unittest.mock for isolation
 - Coverage.py for metrics
 - pytest-cov for integrated reporting
 
 ### Integration Testing
+
 - pytest-asyncio for async code
 - httpx for API testing
 - testcontainers for service isolation
 - responses for HTTP mocking
 
 ### Performance Testing
+
 - locust for load testing
 - pytest-benchmark for microbenchmarks
 - memory_profiler for memory analysis
 - py-spy for CPU profiling
 
 ### Security Testing
+
 - bandit for static analysis
 - safety for dependency scanning
 - OWASP ZAP for dynamic testing
 - sqlmap for injection testing
 
 ### Advanced Testing
+
 - Hypothesis for property-based tests
 - mutmut for mutation testing
 - pytest-xdist for parallel execution
@@ -326,6 +356,7 @@ See `.kit/templates/TASK-STARTER-TEMPLATE.md` for complete example.
 ## Quality Standards
 
 ### Coverage Requirements
+
 ```yaml
 Minimum Thresholds:
   line_coverage: 80%      # Hard minimum
@@ -340,6 +371,7 @@ Critical Path Requirements:
 ```
 
 ### Test Naming Convention
+
 ```python
 # Pattern: test_[what]_[when]_[expected]
 def test_health_endpoint_when_service_running_returns_200():
@@ -350,7 +382,9 @@ def test_process_endpoint_when_invalid_data_raises_validation_error():
 ```
 
 ### Documentation Standards
+
 Every test should have:
+
 - Clear description of what's being tested
 - Explanation of why it matters
 - Any special setup or teardown requirements
@@ -394,7 +428,7 @@ After implementation is complete and CI passes, you **MUST** request code review
 
 ### Task Status Flow
 
-```
+```text
 2-todo → 3-in-progress → 4-in-review → 5-done
          (implement)      (code review)   (complete)
 ```
@@ -432,6 +466,7 @@ starter and hand off to the user:
 
 Then tell the user to open a new tab and launch `code-reviewer` against
 that starter. The reviewing agent will:
+
 - Review code changes for quality, patterns, edge cases
 - Check TDD compliance and test coverage
 - Report ✅ APPROVED / 🔄 CHANGES REQUESTED / ❌ REJECTED
@@ -458,6 +493,7 @@ that starter. The reviewing agent will:
 ## Restrictions
 
 You must NOT:
+
 - Modify production code (only test code and test configs)
 - Skip the TDD process without explicit justification
 - Approve code with <80% coverage without documented reasoning
@@ -470,6 +506,7 @@ You must NOT:
 ## Success Metrics
 
 Your testing is successful when:
+
 - All tests follow TDD methodology
 - Coverage meets or exceeds thresholds
 - Zero flaky tests in the suite
@@ -481,6 +518,7 @@ Your testing is successful when:
 ## Common Testing Patterns
 
 ### Fixture Management
+
 ```python
 @pytest.fixture
 def api_client():
@@ -495,6 +533,7 @@ def sample_data():
 ```
 
 ### Parametrized Testing
+
 ```python
 @pytest.mark.parametrize("input,expected", [
     ("valid", 200),
@@ -506,6 +545,7 @@ def test_endpoint_responses(input, expected):
 ```
 
 ### Mock Strategies
+
 ```python
 # Use mocks for external dependencies
 @patch('module.external_service')
@@ -553,6 +593,7 @@ def test_with_mock(mock_service):
 **Quality is not negotiable**. Every line of untested code is a potential bug. Every test skipped is technical debt. Your rigorous approach to testing ensures the reliability and maintainability of the entire system.
 
 When in doubt:
+
 1. Write the test first
 2. Make it fail for the right reason
 3. Write minimal code to pass

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -134,7 +134,7 @@ door applies to its own target.
 Confirm where the pair will live. Both repos must be siblings
 (`docs/CROSS-REPO-PATTERN.md`, Setup §2):
 
-```
+```text
 <parent>/
 ├── <name>/           # code repo (the prototype folder)
 └── <name>-planning/  # planning repo (the door creates this)
@@ -388,7 +388,7 @@ binding rules:
 
 Format (✓/✗ per what actually happened; every line verified):
 
-```
+```text
 📦 **PROJECT-INTAKE** | Step: Complete
 
 ✓ Read the handoff brief (<brief path>)
@@ -411,7 +411,7 @@ You can now start working on <name>. Open a new terminal tab in
 
 With doctor FAILs (or no CLI to run it), the closing block is instead:
 
-```
+```text
 Resolve the ✗ items above, re-run `agentive doctor` in
 <parent>/<name>-planning, THEN open the planner tab.
 ```

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -18,10 +18,12 @@ tools:
 You are a specialized security review agent for this software project. Your role is to identify security vulnerabilities and recommend safe improvements.
 
 ## Response Format
+
 Always begin your responses with your identity header:
 🔒 **SECURITY-REVIEWER** | Task: [current security review or analysis]
 
 ## Core Responsibilities
+
 - Review code for security vulnerabilities
 - Recommend security improvements
 - Ensure safe implementation practices
@@ -37,6 +39,7 @@ shell command and this agent has no Bash tool (see Restrictions).
 **📖 Complete Guide**: `.claude/skills/code-review-evaluator/SKILL.md`
 
 **When it's worth requesting**:
+
 - Unclear security standards or requirements
 - Need validation of security review findings
 - Complex attack vectors requiring external analysis
@@ -53,12 +56,14 @@ producing one is not.
 **📖 Template**: `.kit/templates/TASK-STARTER-TEMPLATE.md`
 
 When you receive task assignments, they come in a standardized format with:
+
 - Task file: Full specification in `.kit/tasks/[folder]/[TASK-ID].md`
 - Handoff file: Implementation guidance in `.kit/context/[TASK-ID]-HANDOFF-[agent-type].md`
 
 ### Step 1: Receive Task Assignment
 
 User provides task starter with:
+
 1. **Overview**: 2-3 sentence summary + mission statement
 2. **Acceptance Criteria**: 5-8 checkboxes (must-have requirements)
 3. **Success Metrics**: Quantitative + qualitative targets
@@ -93,6 +98,7 @@ from that (format: `.kit/templates/TASK-STARTER-TEMPLATE.md`) and updates
 are not granted, and a half-written handoff is worse than none.
 
 ## Security Focus Areas
+
 1. Input validation and sanitization
 2. CORS configuration
 3. Rate limiting
@@ -102,6 +108,7 @@ are not granted, and a half-written handoff is worse than none.
 7. Injection attack prevention
 
 ## Review Guidelines
+
 - Prioritize real risk over security theater
 - Do not break working integrations to satisfy a finding — propose a fix
   that preserves the behaviour
@@ -129,12 +136,14 @@ For the commit-and-verify protocol that the *calling* agent follows,
 see `.kit/context/workflows/COMMIT-PROTOCOL.md`.
 
 ## Allowed Operations
+
 - Read all source code
 - Search for vulnerabilities
 - Research security best practices
 - Generate security reports
 
 ## Restrictions
+
 - Cannot directly modify code
 - Must recommend changes through reports
 - Cannot access production credentials

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -19,6 +19,7 @@ tools:
 You are a specialized testing agent for this software project. Your role is to verify implementations, run test suites, and ensure quality standards are met.
 
 ## Response Format
+
 Always begin your responses with your identity header:
 🧪 **TEST-RUNNER** | Task: [current test suite or validation task]
 
@@ -29,13 +30,14 @@ Always begin your responses with your identity header:
 
 Call this to activate Serena for semantic code navigation:
 
-```
+```text
 mcp__serena__activate_project("<project-name>")
 ```
 
 Confirm in your response: "✅ Serena activated: [languages]. Ready for code navigation."
 
 ## Core Responsibilities
+
 - Execute comprehensive test suites according to the guide
 - Verify feature implementations
 - Check for regressions
@@ -107,6 +109,7 @@ updates `**Status**: Todo` → `**Status**: In Progress` in the header,
 and syncs to Linear (if the task monitor daemon is running).
 
 **Example**:
+
 ```bash
 ./scripts/core/project start TASK-0042
 # Output: Moved TASK-0042 to 3-in-progress/, updated Status to In Progress
@@ -139,17 +142,20 @@ above.
 (Note: Project activation happens in Session Initialization - see above)
 
 **Key Tools**:
+
 - `mcp__serena__find_symbol(name_path_pattern, include_body, depth)` - Find classes/methods/functions
 - `mcp__serena__find_referencing_symbols(name_path, relative_path)` - Find all usages (100% precision)
 - `mcp__serena__get_symbols_overview(relative_path)` - File structure overview
 
 **When to use**:
+
 - ✅ Python code navigation (`your_project/`, `tests/`)
 - ✅ TypeScript/React code (if present in project)
 - ✅ Swift code (if present)
 - ✅ Finding references for refactoring/impact analysis
 
 **When NOT to use**:
+
 - ❌ Documentation/Markdown (use Grep)
 - ❌ Config files (YAML/JSON - use Grep)
 - ❌ Reading entire files (no benefit - use Read tool)
@@ -163,6 +169,7 @@ You can run evaluation autonomously when encountering unclear test requirements 
 **📖 Complete Guide**: `.claude/skills/code-review-evaluator/SKILL.md`
 
 **When to Run Evaluation**:
+
 - Unclear test acceptance criteria
 - Need validation of testing approach
 - Unexpected test failures requiring design clarification
@@ -188,6 +195,7 @@ cat .adversarial/logs/TASK-FILE--*.md
 **Technical**: External AI via adversarial-workflow (unattended: `echo y | ADVERSARIAL_UNATTENDED=1 adversarial …`), cost varies by evaluator, fully autonomous.
 
 ## Primary Testing Protocol
+
 Test commands, framework, and thresholds are project-owned — read them
 from `CLAUDE.md` and the task spec before running anything
 (KIT-ADR-0025: no stack specifics in this distributed body).
@@ -199,17 +207,21 @@ from `CLAUDE.md` and the task spec before running anything
 5. Document any failures and check against known issues
 
 ## Test Suite Location
+
 Read from `CLAUDE.md` and the project's config (e.g. `pyproject.toml`,
 `package.json`). Coverage targets are project-owned.
 
 ## Success Criteria
+
 - Full suite passes with the project's own runner
 - Coverage meets the project's configured threshold
 - No regression in previously passing tests
 - The project's lint and local CI checks pass
 
 ## Reporting
+
 Provide a clear test report with:
+
 - Test results summary (passed/failed/skipped)
 - Issues found with impact levels
 - Clear recommendation (APPROVED/BLOCKED/CONDITIONAL)
@@ -244,7 +256,9 @@ If you push code changes to GitHub (test fixes, test additions, etc.):
 **Reference**: See `.kit/context/workflows/COMMIT-PROTOCOL.md` for full protocol.
 
 ## Permissions
+
 You have read and execution permissions to:
+
 - Run test scripts
 - Read source code
 - Execute npm test commands

--- a/.claude/agents/upgrader.md
+++ b/.claude/agents/upgrader.md
@@ -342,7 +342,7 @@ grep -rn '^model:' .claude/agents/        # local pins only — never the plugin
 
 Print a single summary block:
 
-```
+```text
 PREVIEW — no changes made yet
   Version:     <current> → <target>
   Reconcile:   <N added>, <N removed/renamed (with file refs)>, flat-ref regressions: <none|list>

--- a/.claude/commands/babysit-pr.md
+++ b/.claude/commands/babysit-pr.md
@@ -40,7 +40,7 @@ is clean or the cycle limit is reached.
 
 Track which cycle you are on (1 through 10). Report at the start of each cycle:
 
-```
+```markdown
 ## Babysit Cycle [N]/10 — PR #[number]
 ```
 
@@ -80,22 +80,26 @@ Present the triage table for **unresolved** threads:
 | 1 | ... | ... | ... | ... | Fix / Resolve |
 
 Use the severity triage from the `bot-triage` skill:
+
 - **Fix**: Real bugs, security, compatibility, reasonable improvements
 - **Resolve without fixing**: False positives, cosmetic, platform-irrelevant
 
 ### Phase 3: Decision Gate
 
 **If no unresolved threads** (or all are resolve-without-fixing):
+
 - Resolve any remaining trivial threads via GraphQL
 - Report: "PR is clean after [N] cycle(s). Ready for human review."
 - **Stop babysitting.**
 
 **If fixable threads exist AND this is cycle 10**:
+
 - Report the remaining issues
 - Say: "Cycle limit reached (10/10). [N] threads still need attention."
 - **Stop babysitting** — let the user decide next steps.
 
 **If fixable threads exist AND cycles remain**:
+
 - Proceed to Phase 4.
 
 ### Phase 4: Fix and Push
@@ -106,15 +110,15 @@ Use the severity triage from the `bot-triage` skill:
 4. Push to the feature branch
 5. Reply to each fixed thread:
 
-```bash
-agentive review-helper reply PR_NUMBER COMMENT_ID 'Fixed in COMMIT_SHA: description.'
-```
+   ```bash
+   agentive review-helper reply PR_NUMBER COMMENT_ID 'Fixed in COMMIT_SHA: description.'
+   ```
 
 6. Resolve all addressed threads:
 
-```bash
-agentive review-helper resolve PRRT_node_id
-```
+   ```bash
+   agentive review-helper resolve PRRT_node_id
+   ```
 
 7. **Go back to Cycle Start** (increment cycle counter).
 
@@ -131,7 +135,7 @@ The babysit loop ends when ANY of these are true:
 
 Always end with a summary:
 
-```
+```markdown
 ## Babysit Complete — PR #[number]
 
 | Metric | Value |

--- a/.claude/commands/check-ci.md
+++ b/.claude/commands/check-ci.md
@@ -54,6 +54,7 @@ Run the verification script and report the results:
 ```
 
 The script will output a clear verdict:
+
 - **PASS**: All workflows completed successfully
 - **FAIL**: One or more workflows failed
 - **IN PROGRESS**: Workflows still running (use `--wait` to block)

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -1,15 +1,16 @@
 ---
 description: Interview the user and create their new project through the setup door or the intake agent
-version: 1.2.0
+version: 1.3.0
 origin: agentive-starter-kit
-last-updated: 2026-08-11
+last-updated: 2026-08-14
 created-by: "@movito with feature-developer-f5 (KIT-0067)"
 distribution: builder-only
 ---
 
 # New Project
 
-> **Builder-side command**: operates the kit factory; not distributed
+> **Builder-side command**: the guided interview over the packaged
+> setup door (`agentive new` / `agentive adopt`); not distributed
 > via `scripts/.core-manifest.json` (intended — see KIT-0077).
 
 **First response — open with this transparency header, before any
@@ -17,31 +18,39 @@ other output or tool call:**
 
 > 🧭 `/new-project` — interviews you in plain language and creates
 > your new project, via the setup door or the intake agent.
-> Reads: `./scripts/local/bootstrap --help`, your operator preset;
-> on the prototype route, your brief file and code folder (to
-> validate them) · Writes: the new project's directory (door route);
-> the intake route only prints a handoff — nothing in this repo
-> either way
+> Reads: `agentive new --help` / `agentive adopt --help`, your
+> operator preset; on the prototype route, your brief file and code
+> folder (to validate them) · Writes: the new project's directory
+> (door route); the intake route only prints a handoff — nothing in
+> this repo either way
 > Source: [new-project.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/new-project.md) · Docs: [starting a project](https://github.com/movito/agentive-starter-kit/blob/main/docs/STARTING-A-PROJECT.md)
 
-Create a new project from this kit — the front door to the factory
-flow described in `docs/STARTING-A-PROJECT.md`. Interview the user in
-plain language, one question at a time, route them to the right
-creation path, run it, and finish by printing the LAUNCH line for the
-created project.
+Create a new project — the guided front door to the flow described in
+`docs/STARTING-A-PROJECT.md`. Interview the user in plain language,
+one question at a time, route them to the right creation path, run
+it, and finish by printing the LAUNCH line for the created project.
 
-This command runs **from an agentive-starter-kit checkout** (the setup
-door is kit-side only). If `./scripts/local/bootstrap` does not exist
-in the current repo, STOP and tell the user to open a session in their
-kit clone — never hunt for the door elsewhere.
+The setup door itself is the packaged `agentive new` /
+`agentive adopt` (KIT-ADR-0030) — it runs from anywhere; only this
+command file is kit-side. If the `agentive` CLI is missing AND this
+checkout has no `./scripts/local/bootstrap` shim to answer through,
+STOP and give the user the install command
+(`uv tool install agentive-kit`) — never hunt for the door elsewhere,
+never improvise a setup path.
 
 ## Binding rules — read before anything else
 
 1. **Derive, never hardcode.** Your FIRST action is:
 
    ```bash
-   ./scripts/local/bootstrap --help
+   agentive new --help
+   agentive adopt --help
    ```
+
+   (If `agentive` is not on PATH, `./scripts/local/bootstrap --help`
+   in this kit checkout answers with the same package-owned help —
+   it is an exec shim over the packaged door, removal pinned to
+   KIT-0107.)
 
    Build the entire interview from what that prints: the creation
    modes, the shape × profile legality matrix, the offer flags, and
@@ -153,7 +162,7 @@ handoff — do not run the door yourself on this route.
 2. Run the door with exactly the flags the interview produced, e.g.:
 
    ```bash
-   ./scripts/local/bootstrap --new <target-dir> <flags-from-interview>
+   agentive new <target-dir> <flags-from-interview>
    ```
 
 3. Show the user the door's output — especially the doctor verdict it

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -159,10 +159,16 @@ handoff — do not run the door yourself on this route.
    is answering questions for them (the door announces the preset
    path it loaded; a `--no-preset` run is available if they want to
    be asked everything).
-2. Run the door with exactly the flags the interview produced, e.g.:
+2. Run the door with exactly the flags the interview produced,
+   **through the same entry that answered the help in rule 1** — the
+   CLI when it is on PATH, else the checkout's shim (never derive
+   from one and run the other; the interview must not finish and
+   then fail on a missing CLI):
 
    ```bash
    agentive new <target-dir> <flags-from-interview>
+   # or, when `agentive` is not on PATH in this kit checkout:
+   ./scripts/local/bootstrap --new <target-dir> <flags-from-interview>
    ```
 
 3. Show the user the door's output — especially the doctor verdict it

--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -29,12 +29,14 @@ grep -A 5 "## Target Repository" CLAUDE.md 2>/dev/null || echo "SINGLE_REPO_MODE
 ```
 
 If found, extract:
+
 - **target_path**: the value after `- **Path**:` (e.g., `../my-project-code`)
 - **target_github**: the value after `- **GitHub**:` (e.g., `your-org/my-project-code`)
 
 If `SINGLE_REPO_MODE`, skip all cross-repo logic — run every command below against the current repo exactly as before.
 
 **For the rest of this document:**
+
 - `GIT_TARGET` means: use `git -C <target_path>` in cross-repo mode, or plain `git` in single-repo mode
 - `GH_TARGET` means: use `gh --repo <target_github>` in cross-repo mode, or plain `gh` in single-repo mode
 
@@ -128,6 +130,7 @@ Concrete, actionable improvements. Each item should be something the planner can
 ### Permission Prompts Hit
 
 Were you blocked by any permission prompts during this session? For each one, note:
+
 - The exact command or tool call that triggered it
 - How long (approximately) you were blocked before the user approved
 - Whether this is already in `.claude/settings.json` allow list or is a new pattern

--- a/.claude/commands/setup-preset.md
+++ b/.claude/commands/setup-preset.md
@@ -1,8 +1,8 @@
 ---
 description: Interview the user and author their setup-door preset in the visible config home
-version: 1.2.0
+version: 1.3.0
 origin: agentive-starter-kit
-last-updated: 2026-08-11
+last-updated: 2026-08-14
 created-by: "@movito with feature-developer-f5 (KIT-0058)"
 distribution: builder-only
 ---
@@ -18,24 +18,28 @@ other output or tool call:**
 > 🧭 `/setup-preset` — interviews you in plain language and writes
 > your setup-door preset, so future project creation runs on your
 > answers.
-> Reads: `./scripts/local/bootstrap --help`, any existing preset ·
+> Reads: `agentive new --help`, any existing preset ·
 > Writes: `preset` under `$AGENTIVE_KIT_CONFIG_DIR` when set;
-> otherwise `<kit-parent>/agentive-config/preset` (secrets by path
-> reference only — never values)
+> otherwise `<projects-parent>/agentive-config/preset` (secrets by
+> path reference only — never values)
 > Source: [setup-preset.md](https://github.com/movito/agentive-starter-kit/blob/main/.claude/commands/setup-preset.md) · Docs: [starting a project](https://github.com/movito/agentive-starter-kit/blob/main/docs/STARTING-A-PROJECT.md)
 
 Author (or update) the operator preset for the setup door
-(`scripts/local/bootstrap`) by interviewing the user in plain
+(`agentive new` / `agentive adopt`) by interviewing the user in plain
 language, one question at a time, then writing
-`<kit-parent>/agentive-config/preset`.
+`<projects-parent>/agentive-config/preset`.
 
 ## Binding rules — read before anything else
 
 1. **Derive, never hardcode.** Your FIRST action is:
 
    ```bash
-   ./scripts/local/bootstrap --help
+   agentive new --help
    ```
+
+   (If `agentive` is not on PATH, `./scripts/local/bootstrap --help`
+   in this kit checkout answers with the same package-owned help —
+   an exec shim over the packaged door, removal pinned to KIT-0107.)
 
    Build the entire interview from what that prints: the recognized
    preset keys, the shape × profile legality matrix, the offer flags,
@@ -71,7 +75,11 @@ language, one question at a time, then writing
 
 ## Step 1: locate the config home
 
-The config home is a visible sibling of the kit's primary clone:
+The config home is a visible sibling of your projects folder — the
+packaged door anchors it to the TARGET's parent at creation time, so
+the preset must sit beside the projects you create. In the documented
+sibling layout the kit clone shares that parent, which is how this
+command computes it from where it runs:
 
 ```bash
 cd "$(git rev-parse --git-common-dir)" && pwd
@@ -87,9 +95,10 @@ portable across both, because plain `--git-common-dir` may print a
 path relative to the repo directory. — KIT-0080)
 If `AGENTIVE_KIT_CONFIG_DIR` is set in the environment, it overrides
 the location entirely (it is an override, never a search chain — do
-not look anywhere else). If the `git rev-parse` command fails (you
-are somehow not in a kit clone), STOP and tell the user: this command
-must run from an agentive-starter-kit checkout — never guess or
+not look anywhere else). If the `git rev-parse` command fails, or the
+user's projects do NOT live beside this kit clone, STOP and ask the
+user where their projects folder is (or have them set
+`AGENTIVE_KIT_CONFIG_DIR`) — never guess or
 invent a path. If the folder does not exist, create it —
 running this command IS the user engaging the preset flow. If a
 preset already exists there, read it and treat the interview as an
@@ -123,7 +132,7 @@ the user's answers have already excluded.
    `git init` + create a **private** remote. `project doctor` checks
    this guardrail from now on (WARN on a public remote, FAIL on a
    tracked `env.source`).
-5. State plainly that the first real `bootstrap --new <dir>` run is
+5. State plainly that the first real `agentive new <dir>` run is
    the end-to-end proof — the door announces the preset path it
-   loaded, and `./scripts/core/project doctor --against-preset`
+   loaded, and `agentive doctor --against-preset`
    compares any project's record against this preset at any time.

--- a/.claude/commands/setup-preset.md
+++ b/.claude/commands/setup-preset.md
@@ -82,10 +82,12 @@ sibling layout the kit clone shares that parent, which is how this
 command computes it from where it runs:
 
 ```bash
-cd "$(git rev-parse --git-common-dir)" && pwd
+cd "$(git rev-parse --git-common-dir)/../.." && pwd
 ```
 
-Take the parent of that path, plus `/agentive-config`.
+That prints the projects parent (two levels up from the primary
+clone's `.git`); the config home is that path plus
+`/agentive-config`.
 
 (Do not use `git rev-parse --path-format=absolute` here: that flag
 needs git ≥ 2.31, and stock macOS ships Apple Git 2.30.1, which echoes

--- a/.claude/commands/triage-threads.md
+++ b/.claude/commands/triage-threads.md
@@ -85,6 +85,7 @@ For all unresolved threads, present a triage table:
 | 2 | BugBot | `path.py:88` | ... | Low | Resolve |
 
 Use the severity triage from the `bot-triage` skill:
+
 - **Fix**: Major/Critical, real bugs, security, compatibility
 - **Fix (easy)**: Medium severity, reasonable, quick
 - **Resolve without fixing**: Trivial/Low, cosmetic, platform-irrelevant

--- a/.claude/commands/wrap-up.md
+++ b/.claude/commands/wrap-up.md
@@ -31,6 +31,7 @@ grep -A 5 "## Target Repository" CLAUDE.md 2>/dev/null || echo "SINGLE_REPO_MODE
 ```
 
 If found, extract:
+
 - **target_path**: the value after `- **Path**:` (e.g., `../my-project-code`)
 - **target_github**: the value after `- **GitHub**:` (e.g., `your-org/my-project-code`)
 
@@ -75,6 +76,7 @@ in CLAUDE.md. Both `GIT_TARGET` and `GH_TARGET` resolve to plain `git` and
 `gh` against the current (planning) repo.
 
 **For the rest of this document:**
+
 - `GIT_TARGET` means: use `git -C <target_path>` in cross-repo mode, or plain `git` in single-repo mode
 - `GH_TARGET` means: use `gh --repo <target_github>` in cross-repo mode, or plain `gh` in single-repo mode
 

--- a/.claude/skills/bot-triage/SKILL.md
+++ b/.claude/skills/bot-triage/SKILL.md
@@ -158,6 +158,7 @@ Each round follows the same loop:
 4. Push once → next round
 
 **Resolve-without-fixing** is still valid for:
+
 - Findings that are factually wrong (false positives)
 - Platform-irrelevant concerns (e.g., Windows CRLF on a macOS-only project)
 - Findings that contradict project conventions (with justification)
@@ -212,6 +213,7 @@ agentive review-helper reply {pr_number} {comment_id} \
 ```
 
 **Rules:**
+
 - Always reference the commit SHA where the fix was made
 - Cite specific line numbers in the current code
 - Keep it to 1-3 sentences — the code diff speaks for itself

--- a/.claude/skills/code-review-evaluator/SKILL.md
+++ b/.claude/skills/code-review-evaluator/SKILL.md
@@ -241,6 +241,7 @@ ID2-0002 retro documented a concrete example: Claude Sonnet flagged
 diff didn't include the line where it was defined.
 
 Include:
+
 - Full source of all new/changed files (complete files, not diffs)
 - Full test file
 - Summary of what bots found and how it was addressed
@@ -364,7 +365,7 @@ mode — never a silent partial trio:
 3. **NAME the mode in the persisted review record** (Step 4's
    artifact). First line of the record, e.g.:
 
-   ```
+   ```text
    Mode: degraded single-key (only GEMINI_API_KEY present) —
    code-reviewer-fast only + self-review checklist; code-reviewer and
    claude-code not run.

--- a/.claude/skills/pre-implementation/SKILL.md
+++ b/.claude/skills/pre-implementation/SKILL.md
@@ -23,6 +23,7 @@ Result:   Find existing utility — reuse or import it
 ```
 
 Look for:
+
 - DateTime parsing/formatting utilities
 - Duration/interval parsing helpers
 - Event/model construction patterns
@@ -285,6 +286,7 @@ Result:   Catches that `.` is in the character class and `../ixda-services` (Pat
 ```
 
 Common gotchas this catches:
+
 - Character classes that include `.` or `/` matching path-like values
   before slug-like values
 - Greedy quantifiers grabbing more than the line you intended

--- a/.claude/skills/review-handoff/SKILL.md
+++ b/.claude/skills/review-handoff/SKILL.md
@@ -157,6 +157,7 @@ When you receive a fix prompt after CHANGES_REQUESTED:
 7. **Notify user** — ready for re-review (Round 2)
 
 **Key points:**
+
 - Task stays in `4-in-review/` — don't move it
 - Max 2 review rounds — Round 2 is final
 - Update, don't create new review-starter file

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -66,6 +66,7 @@ This is the **mirror guards** pattern — the most common source of round-2 bot 
 ### Q3: What happens when this value is missing/None/wrong-type?
 
 Trace the code path for each:
+
 - **None**: Does `.get()` return None? Does None propagate to a `.split()` or `[0]` that crashes?
 - **Wrong type**: Does an int where you expected a string reach `str.split(".")` and crash?
 - **Empty**: Does `[]` reach `[0]` and raise IndexError? Does `""` pass an `if value:` guard?

--- a/.kit/adr/ADR-0007-unified-artifact-registry.md
+++ b/.kit/adr/ADR-0007-unified-artifact-registry.md
@@ -40,6 +40,7 @@ At 4 projects this is tolerable. At 40 or 400, it breaks:
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Artifacts must be self-describing — all tracking metadata lives inside the artifact, not in a separate database
 - Distribution must be git-based with no hosted service beyond git hosting itself
 - Projects must be able to override, extend, or exclude any artifact without breaking sync
@@ -59,6 +60,7 @@ At 4 projects this is tolerable. At 40 or 400, it breaks:
 After initial sync, all read operations work offline. Only fetch and contribute operations require network access.
 
 **Constraints** (as of Claude Code v1.x, adversarial-evaluator-library v0.5.x):
+
 - Claude Code resolves agents from `.claude/agents/` — this path is not configurable (verified: no env var or config flag exists as of March 2026)
 - The `adversarial` CLI resolves evaluators from `.adversarial/evaluators/` — hardcoded in `adversarial_workflow/evaluators/discovery.py`
 - Skills live in `.claude/skills/` — also hardcoded in Claude Code
@@ -67,6 +69,7 @@ After initial sync, all read operations work offline. Only fetch and contribute 
 - If runtime paths become configurable in future tooling versions, the registry can adapt — artifact identity is name-based, not path-based
 
 **Assumptions:**
+
 - Git is the transport layer (all projects are git repos)
 - The agentive-starter-kit remains the canonical upstream for shared artifacts (multi-source is supported; this is the default, not a hard constraint)
 - Projects will always need local-only artifacts that are never shared
@@ -463,6 +466,7 @@ planner  1.0.0  ⚡ conflict: locally modified + upstream 1.1.0 available
 ```
 
 Resolution options:
+
 - `kit registry diff planner` — see both changes
 - `kit registry sync planner --theirs` — take upstream, discard local
 - `kit registry sync planner --ours` — keep local, update `upstream_version` to acknowledge the upstream change
@@ -480,20 +484,24 @@ Resolution options:
 ### Migration Path
 
 **Phase 1: Metadata adoption** (non-breaking)
+
 - Add `registry:` block to all shared agents, evaluators, and skills in agentive-starter-kit and adversarial-evaluator-library
 - Existing tooling ignores unknown YAML frontmatter fields — zero breakage
 - Build `index.yml` from existing artifacts
 
 **Phase 2: CLI tooling** (`kit registry` commands)
+
 - Implement `status`, `sync`, `install`, `diff` in a new `kit` CLI (or extend `adversarial` CLI)
 - Projects that don't adopt the CLI continue working as before — files are files
 
 **Phase 3: Propose-back**
+
 - Implement `propose` command
 - Requires `gh` CLI for PR creation (already a dependency in all 4 current projects; checked March 2026)
 - Fallback for environments without `gh`: `kit registry propose --patch` generates a `.patch` file that can be submitted manually
 
 **Phase 4: Deprecate old mechanisms**
+
 - `adversarial library install` → `kit registry install` (with compatibility shim)
 - Manual copy-paste → `kit registry sync` (agents finally managed)
 - `.core-manifest.json` sync tiers → `manifest.yml` policy (superset)
@@ -526,6 +534,7 @@ Resolution options:
 **Description**: Add `agents_core` and `skills_core` tiers to the existing manifest system.
 
 **Rejected because**:
+
 - The manifest tracks file paths, not artifact identity. If an agent is renamed or restructured, the manifest breaks.
 - No version tracking, no drift detection, no contribution path.
 - Solves distribution but not the other two atomic components (metadata, contribution).
@@ -535,6 +544,7 @@ Resolution options:
 **Description**: Mount agentive-starter-kit as a submodule and symlink agents/evaluators/skills.
 
 **Rejected because**:
+
 - Submodules are fragile — developers forget to init/update them
 - Symlinks break on Windows and in some CI environments
 - No mechanism for local overrides or project-specific artifacts
@@ -545,6 +555,7 @@ Resolution options:
 **Description**: Publish artifacts as a package, install via package manager.
 
 **Rejected because**:
+
 - Agents and skills are Markdown files, not code libraries. Package managers add ceremony (build, publish, semver lockstep) without benefit.
 - Package updates are all-or-nothing — can't pin one artifact while floating another
 - No natural contribution path back to upstream

--- a/.kit/adr/KIT-ADR-0001-system-prompt-size-considerations.md
+++ b/.kit/adr/KIT-ADR-0001-system-prompt-size-considerations.md
@@ -21,6 +21,7 @@ The error resolved after ~7 retry attempts (approximately 3-4 minutes).
 ### Root Cause Analysis
 
 The `overloaded_error` is an Anthropic API capacity issue, not a prompt size error. However:
+
 - Larger system prompts increase request payload size
 - More tokens require more processing time
 - During high-demand periods, larger requests may be more susceptible to overload rejection
@@ -28,6 +29,7 @@ The `overloaded_error` is an Anthropic API capacity issue, not a prompt size err
 ## Decision
 
 **Keep the embedded system prompt approach** but:
+
 1. Separate concerns into dedicated agents (e.g., onboarding agent vs coordinator)
 2. Document guidelines for agent size management
 3. Use lighter models (Sonnet) for simpler tasks
@@ -43,6 +45,7 @@ The `overloaded_error` is an Anthropic API capacity issue, not a prompt size err
 ### Separation of Concerns
 
 Rather than one large agent handling everything, split responsibilities:
+
 - **onboarding agent**: First-run setup only (dedicated, focused)
 - **planner agent**: Project coordination (no setup code)
 - **feature-developer**: Implementation only
@@ -58,6 +61,7 @@ This naturally keeps each agent file smaller and more focused.
 ### When to Externalize Content
 
 Consider moving content to external files if:
+
 - Agent markdown exceeds 500 lines
 - Repeated overload errors occur (>5 retries)
 - Content is rarely needed (e.g., reference documentation)
@@ -65,12 +69,14 @@ Consider moving content to external files if:
 ## Consequences
 
 ### Positive
+
 - Simple architecture (single file per agent)
 - All context immediately available to agent
 - Easy to version and review
 - Separation of concerns keeps files manageable
 
 ### Negative
+
 - Larger request payload for complex agents
 - Potentially longer time-to-first-response
 - More susceptible to overload during high-demand periods
@@ -78,6 +84,7 @@ Consider moving content to external files if:
 ### Monitoring
 
 Track these indicators:
+
 - Retry attempts before successful connection
 - Time-to-first-response for different agents
 - Agent file sizes over time

--- a/.kit/adr/KIT-ADR-0002-serena-mcp-integration.md
+++ b/.kit/adr/KIT-ADR-0002-serena-mcp-integration.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 AI agents need efficient code navigation to understand and modify codebases. Traditional approaches (Grep, Read, Glob) are token-expensive and lack semantic understanding. We need a solution that provides:
+
 - Symbol-aware code navigation
 - Reference finding across the codebase
 - Efficient token usage (70-98% savings)
@@ -18,16 +19,19 @@ AI agents need efficient code navigation to understand and modify codebases. Tra
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Support for Python, TypeScript, Swift, and other languages
 - Integration with Claude Code CLI agents
 - Works across multiple projects without reconfiguration
 
 **Constraints:**
+
 - Must work with Claude Code's MCP (Model Context Protocol) system
 - Agents are launched per-project but MCP config is shared
 - Each project has its own `.serena/project.yml` configuration
 
 **Assumptions:**
+
 - Users have uvx or pipx installed for Python tool execution
 - Projects using Serena will define language servers in project.yml
 - Agents need explicit project activation before using Serena tools
@@ -70,8 +74,10 @@ ignore_all_files_in_gitignore: true
 When you see a request to activate Serena, immediately respond by calling:
 
 ```
+
 mcp__serena__activate_project("my-project")
-```
+
+```text
 ```
 
 **Onboarding Process:**
@@ -111,6 +117,7 @@ done
 **Description**: Configure Serena per-project using default `--scope local`
 
 **Rejected because**:
+
 - ❌ Serena unavailable when launching agents from different projects
 - ❌ Requires running setup in every project individually
 - ❌ Causes agents to fall back to "desktop-app" context
@@ -120,6 +127,7 @@ done
 **Description**: Have Serena auto-detect project from working directory
 
 **Rejected because**:
+
 - ❌ Serena needs explicit project registration in `~/.serena/serena_config.yml`
 - ❌ Working directory isn't always reliable (agents launched from various locations)
 - ❌ No way to ensure correct LSP servers are started
@@ -129,6 +137,7 @@ done
 **Description**: Use Serena only through Claude Desktop app
 
 **Rejected because**:
+
 - ❌ Agents run via Claude Code CLI, not Desktop
 - ❌ Different MCP configuration paths
 - ❌ Doesn't support agentive workflow
@@ -136,16 +145,19 @@ done
 ## Real-World Results
 
 **Before this decision (prior implementation):**
+
 - Agents using Grep/Read/Glob for code navigation
 - High token usage for understanding codebase
 - No reference finding capability
 
 **After this decision:**
+
 - 70-98% token savings on code navigation tasks
 - Accurate symbol and reference finding
 - Works consistently across coordinator, feature-developer, test-runner agents
 
 **Key Discovery (from upstream project learnings):**
+
 - Agents didn't auto-activate Serena despite available tools
 - Required explicit "Session Initialization" pattern in agent definitions
 - Activation must be positioned as startup protocol, not optional guidance

--- a/.kit/adr/KIT-ADR-0003-linear-sync-vs-mcp.md
+++ b/.kit/adr/KIT-ADR-0003-linear-sync-vs-mcp.md
@@ -19,6 +19,7 @@ The project has a custom Linear sync implementation (`scripts/sync_tasks_to_line
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Tasks must be version-controlled in git
 - Folder-based status organization (`1-backlog/` through `7-blocked/`)
 - Automated sync on CI/CD (GitHub Actions)
@@ -26,11 +27,13 @@ The project has a custom Linear sync implementation (`scripts/sync_tasks_to_line
 - Offline editing capability
 
 **Constraints:**
+
 - Limited development resources for maintenance
 - Need for consistency with existing workflow
 - Agent-based development relies on file-based task specs
 
 **Assumptions:**
+
 - Git repository remains the source of truth for task definitions
 - Agents will continue to work primarily with markdown task files
 - Linear is used for team visibility, not as primary authoring interface
@@ -49,11 +52,13 @@ We will **keep the custom Linear sync implementation** as the primary mechanism 
 ### Implementation Details
 
 **Current sync architecture:**
+
 - `scripts/sync_tasks_to_linear.py` (~500 lines) - Main sync orchestrator
 - `scripts/linear_sync_utils.py` (~391 lines) - Status mapping utilities
 - `.github/workflows/sync-to-linear.yml` - GitHub Actions automation
 
 **Key capabilities:**
+
 - One-way sync (files → Linear issues)
 - 3-level status priority (Status field → Folder → Default)
 - Legacy status migration (auto-updates files)
@@ -61,6 +66,7 @@ We will **keep the custom Linear sync implementation** as the primary mechanism 
 - Comprehensive test suite (50+ tests)
 
 **CLI usage:**
+
 ```bash
 ./scripts/project linearsync
 ```
@@ -70,9 +76,11 @@ We will **keep the custom Linear sync implementation** as the primary mechanism 
 The sync can be triggered in two ways:
 
 **1. Local Sync (On-Demand)**
+
 ```bash
 ./scripts/project linearsync
 ```
+
 - Reads task files directly from local filesystem
 - Syncs immediately to Linear via API
 - No commit/push required
@@ -80,6 +88,7 @@ The sync can be triggered in two ways:
 - Agent-initiated during task completion
 
 **2. CI Sync (Automated)**
+
 - Triggers on push to main branch (GitHub Actions)
 - Reads files from committed state
 - Ensures Linear stays current with repository
@@ -89,6 +98,7 @@ The sync can be triggered in two ways:
 **Key difference**: Local sync reads uncommitted files, CI sync reads committed files. Both use the same sync script and produce identical results for the same file content.
 
 **Recommended workflow**:
+
 1. Complete task, update Status field (or use `./scripts/project complete <id>`)
 2. Run `./scripts/project linearsync` to verify sync works
 3. Commit and push changes
@@ -124,6 +134,7 @@ The sync can be triggered in two ways:
 **Description**: Remove custom sync entirely and use Linear's official MCP server as the only integration. Tasks would be created/managed directly in Linear.
 
 **Rejected because**:
+
 - Linear becomes source of truth, losing git version control
 - No folder-based status workflow
 - No batch sync capability (individual operations only)
@@ -136,11 +147,13 @@ The sync can be triggered in two ways:
 **Description**: Keep custom sync for file→Linear direction, add Linear MCP for real-time queries and supplementary operations.
 
 **Not implemented now because**:
+
 - Current sync meets all immediate needs
 - MCP integration adds complexity without urgent benefit
 - Can be revisited when real-time query needs emerge
 
 **Future use cases for Linear MCP:**
+
 - Real-time queries: "Show me all my high-priority issues"
 - Comment management: Adding comments without file editing
 - Ad-hoc issue updates: Quick status changes during discussions
@@ -151,6 +164,7 @@ The sync can be triggered in two ways:
 **Description**: Extend custom sync to also pull changes from Linear back to files.
 
 **Deferred because**:
+
 - Significant complexity (conflict resolution, merge strategies)
 - Risk of overwriting local changes
 - Current workflow doesn't require it (Linear is view-only)
@@ -159,12 +173,14 @@ The sync can be triggered in two ways:
 ## Real-World Results
 
 **Current implementation status:**
+
 - Sync script: Production-ready
 - Test suite: 50+ tests (TDD, awaiting full implementation)
 - GitHub Actions: Configured and operational
 - ASK-0005 task: Active improvement work ongoing
 
 **Observed benefits:**
+
 - Tasks visible in Linear for team coordination
 - No manual issue creation required
 - Status automatically derived from folder structure
@@ -175,9 +191,9 @@ The sync can be triggered in two ways:
 
 ## References
 
-- Linear MCP documentation: https://linear.app/docs/mcp
-- Linear MCP tools list: https://www.remote-mcp.com/servers/linear
-- MCP Protocol specification: https://modelcontextprotocol.io/specification/2025-06-18
+- Linear MCP documentation: <https://linear.app/docs/mcp>
+- Linear MCP tools list: <https://www.remote-mcp.com/servers/linear>
+- MCP Protocol specification: <https://modelcontextprotocol.io/specification/2025-06-18>
 - Current sync implementation: `scripts/sync_tasks_to_linear.py`
 - Task management documentation: `docs/LINEAR-SYNC-BEHAVIOR.md`
 - Active improvement task: `delegation/tasks/2-todo/ASK-0005-linear-sync-infrastructure.md`

--- a/.kit/adr/KIT-ADR-0004-adversarial-workflow-integration.md
+++ b/.kit/adr/KIT-ADR-0004-adversarial-workflow-integration.md
@@ -13,6 +13,7 @@
 Complex technical tasks in agentic systems are prone to **phantom work** - where implementations appear complete but contain zero actual code changes, wasting hours before discovery.
 
 This occurs because AI agents can:
+
 - Misunderstand requirements and implement the wrong thing
 - Experience silent tool failures without realizing it
 - Claim completion based on intent rather than verified results
@@ -20,16 +21,19 @@ This occurs because AI agents can:
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Catch design flaws before implementation begins
 - Verify agent understanding matches actual requirements
 - Prevent wasted implementation time on wrong approaches
 
 **Constraints:**
+
 - Must not slow down simple, well-understood tasks
 - External review should be cost-effective (< $0.10 per task)
 - Process must integrate with existing agent workflows
 
 **Assumptions:**
+
 - Different AI models (Claude, GPT-4o) have complementary strengths
 - External perspective catches blind spots that self-review misses
 - Investigation before implementation prevents most phantom work
@@ -37,6 +41,7 @@ This occurs because AI agents can:
 ### Observed Phantom Work Example
 
 **TASK-2025-014** (from thematic-cuts project):
+
 - **Claimed**: "Complete - All 6 tests fixed"
 - **Reality**: 0 code changes, only documentation renamed
 - **Evidence**: `git diff` showed no modifications to target files
@@ -57,7 +62,7 @@ We adopt **investigation-first development with external GPT-4o evaluation** to 
 
 ### Implementation Overview
 
-```
+```text
 Phase 0: Investigation (understand before implementing)
    ↓
 Phase 1: Evaluator Review (external GPT-4o validation)
@@ -66,6 +71,7 @@ Phase 2+: Implementation (with validated understanding)
 ```
 
 **Workflow Commands:**
+
 ```bash
 # Evaluate implementation plans
 adversarial evaluate <task-file>
@@ -114,6 +120,7 @@ adversarial proofread <doc-file>
 **Description**: Implement immediately, fix issues as discovered.
 
 **Rejected because**:
+
 - High phantom work risk - agents may not realize tool failures
 - Wasted implementation time on wrong approaches
 - Design flaws discovered late are expensive to fix
@@ -123,6 +130,7 @@ adversarial proofread <doc-file>
 **Description**: Human reviews all plans before implementation.
 
 **Rejected because**:
+
 - Slower than automated evaluation
 - Human availability becomes bottleneck
 - AI evaluator catches different issues than humans
@@ -132,6 +140,7 @@ adversarial proofread <doc-file>
 **Description**: Have Claude review its own plans.
 
 **Rejected because**:
+
 - Same blind spots as original author
 - External perspective (GPT-4o) catches different issues
 - Multi-model collaboration provides better coverage
@@ -139,6 +148,7 @@ adversarial proofread <doc-file>
 ## Real-World Results
 
 **TASK-2025-017** (Semantic Parser, from thematic-cuts):
+
 - **Original estimate**: 2-3 weeks (16-24 days)
 - **Investigation finding**: 90%+ complete, only 7 minor bugs
 - **Actual duration**: 3 hours (1.5h investigation, 1.5h implementation)
@@ -163,8 +173,8 @@ adversarial proofread <doc-file>
 
 ### External
 
-- **Aider CLI**: https://aider.chat (GPT-4o integration tool)
-- **OpenAI API**: https://platform.openai.com (evaluator model)
+- **Aider CLI**: <https://aider.chat> (GPT-4o integration tool)
+- **OpenAI API**: <https://platform.openai.com> (evaluator model)
 
 ### Source Documentation
 

--- a/.kit/adr/KIT-ADR-0005-test-infrastructure-strategy.md
+++ b/.kit/adr/KIT-ADR-0005-test-infrastructure-strategy.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 The agentive-starter-kit needs a consistent, automated testing strategy that:
+
 - Ensures code quality across contributions
 - Catches bugs before they reach production
 - Provides fast feedback during development
@@ -21,18 +22,21 @@ Without a defined strategy, testing becomes inconsistent - some contributors wri
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Fast local feedback (tests run in seconds, not minutes)
 - Coverage tracking to identify untested code
 - Automated checks before commits reach the repository
 - Support for both unit and integration tests
 
 **Constraints:**
+
 - Must work with Python 3.9+ (project minimum)
 - Should not require complex setup for new contributors
 - CI costs should remain minimal (GitHub Actions free tier)
 - Must integrate with existing pre-commit workflow
 
 **Assumptions:**
+
 - Contributors have basic pytest familiarity
 - Local development uses virtual environments
 - GitHub is the primary code hosting platform
@@ -71,7 +75,7 @@ We adopt **pytest-based testing** with **pre-commit hooks** for local quality ga
 
 ### Test Organization
 
-```
+```text
 tests/
 ├── test_*.py           # Test files (current flat structure)
 ├── conftest.py         # Shared fixtures (create as needed)
@@ -79,6 +83,7 @@ tests/
 ```
 
 **Test Markers** (defined in `pyproject.toml`):
+
 - `@pytest.mark.unit` - Fast, isolated tests (default)
 - `@pytest.mark.integration` - Tests requiring external services
 - `@pytest.mark.slow` - Tests taking >1 second
@@ -202,6 +207,7 @@ Pre-commit runs automatically before each commit:
 **Description**: Use Python's built-in unittest framework instead of pytest.
 
 **Rejected because**:
+
 - ❌ More verbose test syntax (class-based)
 - ❌ Less powerful fixtures (no pytest fixtures)
 - ❌ Smaller plugin ecosystem
@@ -212,6 +218,7 @@ Pre-commit runs automatically before each commit:
 **Description**: Only run tests in CI, not locally before commits.
 
 **Rejected because**:
+
 - ❌ Slower feedback loop (wait for CI)
 - ❌ More failed CI runs (waste of resources)
 - ❌ Issues discovered later are harder to fix
@@ -222,6 +229,7 @@ Pre-commit runs automatically before each commit:
 **Description**: Require 100% test coverage for all code.
 
 **Rejected because**:
+
 - ❌ Diminishing returns past ~80%
 - ❌ Encourages testing trivial code
 - ❌ Can lead to brittle tests
@@ -232,6 +240,7 @@ Pre-commit runs automatically before each commit:
 **Description**: Don't track or enforce coverage at all.
 
 **Rejected because**:
+
 - ❌ No visibility into untested code
 - ❌ Coverage tends to decline over time
 - ❌ Harder to identify testing gaps

--- a/.kit/adr/KIT-ADR-0006-agent-session-initialization.md
+++ b/.kit/adr/KIT-ADR-0006-agent-session-initialization.md
@@ -12,7 +12,7 @@
 
 AI agents need to activate project-specific tools and context at session start. Without explicit initialization, tools are available globally but lack the project context needed for correct operation, leading to silent failures or incorrect behavior.
 
-```
+```text
 Agent starts in Claude Code CLI
     ↓
 MCP tools available (globally configured via ~/.claude.json)
@@ -25,18 +25,21 @@ Result: Tools fail silently or use wrong context
 ### Forces at Play
 
 **Technical Requirements:**
+
 - MCP tools are configured at user level (globally available)
 - Each project has unique configuration requirements
 - Agents are stateless - no memory of previous sessions
 - CLI environment lacks automatic project detection
 
 **Constraints:**
+
 - Cannot modify MCP architecture (it's external)
 - Agents cannot auto-detect project from environment alone
 - Launcher scripts must work across different agent types
 - Pattern must be tool-agnostic (work for any MCP tool)
 
 **Assumptions:**
+
 - Agents are launched via CLI or automation scripts
 - Each project defines its own tool configurations
 - Agents can execute tool calls as their first action
@@ -57,7 +60,7 @@ We will adopt **launcher-initiated activation** as the standard pattern for agen
 
 **The Activation Flow:**
 
-```
+```text
 1. Launcher sends activation prompt as first message
     ↓
 2. Agent's first action: Call activation function(s)
@@ -81,8 +84,10 @@ as your first message. When you see a request to activate [Tool],
 immediately respond by calling:
 
 ```
+
 [tool_activation_function]("[project-name]")
-```
+
+```text
 
 This configures [tool capabilities]. Confirm activation in your
 response: "✅ [Tool] activated: [context]. Ready for [capability]."
@@ -111,12 +116,14 @@ claude --append-system-prompt "$(cat .claude/agents/$AGENT.md)" \
 **Component 3: Activation Confirmation Protocol**
 
 Successful activation:
-```
+
+```text
 Agent: "✅ [Tool] activated: [context details]. Ready for [capabilities]."
 ```
 
 Failed activation:
-```
+
+```text
 Agent: "⚠️ [Tool] activation failed: [error].
 Troubleshooting:
 1. [Check 1]
@@ -138,6 +145,7 @@ Please resolve and retry."
 **Graceful Degradation:**
 
 If activation fails, agents should:
+
 1. **NOT proceed silently** - always inform the user
 2. **Offer alternatives** - suggest fallback tools if available
 3. **Provide remediation** - specific steps to fix the issue
@@ -156,8 +164,10 @@ If activation fails, agents should:
 ```markdown
 After activation, verify by running a simple command:
 ```
+
 mcp__serena__get_current_config()  # Should show correct project
-```
+
+```text
 ```
 
 ## Consequences
@@ -188,6 +198,7 @@ mcp__serena__get_current_config()  # Should show correct project
 **Description**: Tools auto-detect project from current working directory
 
 **Rejected because**:
+
 - ❌ Working directory isn't always reliable (agents launched from various locations)
 - ❌ Some tools require explicit project registration
 - ❌ No way to ensure correct configuration is loaded
@@ -198,6 +209,7 @@ mcp__serena__get_current_config()  # Should show correct project
 **Description**: Set project context via environment variables before launch
 
 **Rejected because**:
+
 - ❌ Environment variables not reliably passed to MCP tools
 - ❌ Harder to verify correct setup
 - ❌ Different tools may need different env vars
@@ -208,6 +220,7 @@ mcp__serena__get_current_config()  # Should show correct project
 **Description**: Assume tools work without activation, handle errors ad-hoc
 
 **Rejected because**:
+
 - ❌ Current pain point - agents have tools but wrong context
 - ❌ Silent failures lead to incorrect results
 - ❌ Inconsistent behavior across sessions
@@ -218,6 +231,7 @@ mcp__serena__get_current_config()  # Should show correct project
 **Description**: Tools detect agent launch and auto-activate appropriate project
 
 **Rejected because**:
+
 - ❌ Requires modifying MCP tool implementations
 - ❌ Tools can't reliably detect which project is intended
 - ❌ Coupling between tool and project detection logic
@@ -226,18 +240,21 @@ mcp__serena__get_current_config()  # Should show correct project
 ## Real-World Results
 
 **Before this pattern (ad-hoc activation):**
+
 - Agents had tools available but in wrong context
 - Silent failures: tools returned errors or incorrect data
 - Users confused why semantic navigation wasn't working
 - Inconsistent behavior across different agent sessions
 
 **After this pattern:**
+
 - Agents reliably activate correct project context
 - Clear feedback when activation fails
 - Consistent behavior across all agent sessions
 - Users understand the activation requirement
 
 **Key Discovery:**
+
 - Agents didn't auto-activate despite having tools available
 - Required explicit "Session Initialization" section in agent definitions
 - Activation must be positioned as startup protocol, not optional guidance
@@ -250,7 +267,7 @@ mcp__serena__get_current_config()  # Should show correct project
 
 - Agent files: `.claude/agents/*.md` (current implementation)
 - Launcher scripts: `agents/launch` (if exists)
-- Claude Code MCP Documentation: https://docs.claude.com/en/docs/claude-code
+- Claude Code MCP Documentation: <https://docs.claude.com/en/docs/claude-code>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0007-dependabot-automation.md
+++ b/.kit/adr/KIT-ADR-0007-dependabot-automation.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 Dependencies become outdated and vulnerable over time. Manual tracking of security advisories and version updates is time-consuming and error-prone. We need automated dependency management that:
+
 - Alerts us to security vulnerabilities
 - Creates PRs for updates automatically
 - Integrates with our CI pipeline for validation
@@ -18,17 +19,20 @@ Dependencies become outdated and vulnerable over time. Manual tracking of securi
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Python package updates (pip ecosystem)
 - GitHub Actions version updates
 - Weekly update cadence (balance freshness vs. noise)
 - CI validation before merge
 
 **Constraints:**
+
 - Must work with GitHub's native features
 - PRs should be testable via existing CI workflow
 - Should not overwhelm maintainers with PR volume
 
 **Assumptions:**
+
 - Repository is hosted on GitHub
 - CI runs on all PRs (including Dependabot PRs)
 - Maintainers review and merge dependency PRs
@@ -73,14 +77,14 @@ Major updates are kept separate for careful review.
 
 **Commit Message Convention:**
 
-```
+```text
 deps(scope): Update package from x.y.z to a.b.c
 ci(scope): Update action from v1 to v2
 ```
 
 **Workflow Integration:**
 
-```
+```text
 Dependabot detects update
     ↓
 Creates PR with changes
@@ -92,6 +96,7 @@ Tests fail? → Investigate compatibility
 ```
 
 **Labels Applied:**
+
 - `dependencies` - All Dependabot PRs
 - `python` - Python package updates
 - `github-actions` - Actions updates
@@ -124,6 +129,7 @@ Tests fail? → Investigate compatibility
 **Description**: Manually track and update dependencies periodically
 
 **Rejected because**:
+
 - ❌ Time-consuming and easy to forget
 - ❌ Security vulnerabilities may go unnoticed
 - ❌ No automation benefits
@@ -133,6 +139,7 @@ Tests fail? → Investigate compatibility
 **Description**: Use Renovate instead of Dependabot
 
 **Rejected because**:
+
 - ❌ Requires additional setup/hosting
 - ❌ Dependabot is built into GitHub (simpler)
 - ❌ Similar functionality for our needs
@@ -143,6 +150,7 @@ Tests fail? → Investigate compatibility
 **Description**: Run Dependabot daily instead of weekly
 
 **Rejected because**:
+
 - ❌ Too many PRs to review
 - ❌ Excessive noise for maintainers
 - ❌ Weekly is sufficient for non-critical updates
@@ -150,11 +158,13 @@ Tests fail? → Investigate compatibility
 ## Real-World Results
 
 **Before this decision:**
+
 - Manual dependency tracking
 - Security vulnerabilities discovered reactively
 - Inconsistent update cadence
 
 **After this decision:**
+
 - Automated weekly PRs for updates
 - Security alerts within 24 hours
 - Consistent, predictable update schedule
@@ -166,9 +176,9 @@ Tests fail? → Investigate compatibility
 
 ## References
 
-- GitHub Dependabot: https://docs.github.com/en/code-security/dependabot
-- Dependabot configuration: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-- Security advisories: https://github.com/advisories
+- GitHub Dependabot: <https://docs.github.com/en/code-security/dependabot>
+- Dependabot configuration: <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
+- Security advisories: <https://github.com/advisories>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0008-configuration-architecture.md
+++ b/.kit/adr/KIT-ADR-0008-configuration-architecture.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 Applications need configuration that varies by environment (development, CI, production). We need a consistent, secure, and discoverable way to manage settings that:
+
 - Keeps secrets out of version control
 - Supports environment-specific overrides
 - Is easy to understand and extend
@@ -19,17 +20,20 @@ Applications need configuration that varies by environment (development, CI, pro
 ### Forces at Play
 
 **Technical Requirements:**
+
 - API keys and secrets must be protected
 - Configuration should work in local dev, CI, and production
 - Tool configurations (pytest, black, etc.) should be centralized
 - New team members need clear onboarding path
 
 **Constraints:**
+
 - Must work with GitHub Actions (CI environment)
 - Must not require additional infrastructure (no config servers)
 - Should use Python ecosystem tools
 
 **Assumptions:**
+
 - All environments support environment variables
 - Developers can create `.env` from template
 - Secrets are managed per-environment
@@ -49,7 +53,7 @@ We will adopt a **hierarchical configuration system** with four priority levels 
 
 **Configuration Hierarchy (lowest to highest priority):**
 
-```
+```text
 1. Defaults (in code)
     ↓ overridden by
 2. pyproject.toml / config files
@@ -163,6 +167,7 @@ omit = ["tests/*", "venv/*"]
 **Description**: Use Pydantic BaseSettings for typed configuration
 
 **Not adopted yet because**:
+
 - ❌ Additional complexity for current needs
 - ❌ Project is simple enough for env vars
 - ✅ Good future option if validation needed
@@ -172,6 +177,7 @@ omit = ["tests/*", "venv/*"]
 **Description**: Use YAML files for all configuration
 
 **Rejected because**:
+
 - ❌ Secrets would need separate handling anyway
 - ❌ Environment variables are more universal
 - ❌ pyproject.toml already handles tool config
@@ -181,6 +187,7 @@ omit = ["tests/*", "venv/*"]
 **Description**: Document environment variables only in README
 
 **Rejected because**:
+
 - ❌ Less discoverable than template file
 - ❌ No clear structure for required vs optional
 - ❌ Harder to onboard new developers
@@ -189,7 +196,7 @@ omit = ["tests/*", "venv/*"]
 
 **Current Configuration Files:**
 
-```
+```text
 .
 ├── .env.template          # 82 lines, well-documented
 ├── .env                   # (gitignored, user-created)
@@ -200,7 +207,7 @@ omit = ["tests/*", "venv/*"]
 
 **Onboarding Flow:**
 
-```
+```text
 1. Clone repository
 2. cp .env.template .env
 3. Fill in required API keys
@@ -214,9 +221,9 @@ omit = ["tests/*", "venv/*"]
 
 ## References
 
-- 12-Factor App Config: https://12factor.net/config
-- python-dotenv: https://pypi.org/project/python-dotenv/
-- Pydantic Settings: https://docs.pydantic.dev/latest/concepts/pydantic_settings/
+- 12-Factor App Config: <https://12factor.net/config>
+- python-dotenv: <https://pypi.org/project/python-dotenv/>
+- Pydantic Settings: <https://docs.pydantic.dev/latest/concepts/pydantic_settings/>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0009-logging-observability.md
+++ b/.kit/adr/KIT-ADR-0009-logging-observability.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 The project currently uses `print()` statements for all output, which is:
+
 - Not configurable (can't adjust verbosity)
 - Not structured (hard to parse programmatically)
 - Not persistent (no file logging)
@@ -21,17 +22,20 @@ We need a proper logging architecture that supports development debugging, produ
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Console output for development (human-readable)
 - File output for persistence (debugging after-the-fact)
 - Structured output option (JSON for APIs/monitoring)
 - Component-based filtering (sync vs agents vs CLI)
 
 **Constraints:**
+
 - Must be backward-compatible (existing CLI behavior)
 - Should use Python standard library (no heavy dependencies)
 - Must work in CI environment (GitHub Actions)
 
 **Assumptions:**
+
 - Most users run scripts locally during development
 - CI runs need captured output for debugging
 - Future monitoring may require structured logs
@@ -51,7 +55,7 @@ We will adopt a **hierarchical logging architecture** with dual output (console 
 
 **Logger Hierarchy:**
 
-```
+```text
 agentive                    # Root logger
 ├── agentive.sync           # Linear sync operations
 ├── agentive.cli            # CLI commands
@@ -208,6 +212,7 @@ def test_sync_logs_success(caplog):
 **Description**: Continue using print() for all output
 
 **Rejected because**:
+
 - ❌ Not configurable (no log levels)
 - ❌ Not filterable (all or nothing)
 - ❌ Not persistent (console only)
@@ -218,6 +223,7 @@ def test_sync_logs_success(caplog):
 **Description**: Use structlog for structured logging immediately
 
 **Not adopted yet because**:
+
 - ❌ Additional dependency
 - ❌ Overkill for current needs
 - ✅ Good future option when we need JSON logs
@@ -227,6 +233,7 @@ def test_sync_logs_success(caplog):
 **Description**: Use loguru for simplified logging
 
 **Not adopted because**:
+
 - ❌ Additional dependency
 - ❌ Non-standard API
 - ❌ Standard library is sufficient
@@ -236,6 +243,7 @@ def test_sync_logs_success(caplog):
 **Current State**: Documentation only (this ADR)
 
 **Implementation Task**: ASK-0021 (Logging Infrastructure Implementation)
+
 - Replace print() with logger calls
 - Add logging_config.py module
 - Update .env.template with LOG_* variables
@@ -248,10 +256,10 @@ def test_sync_logs_success(caplog):
 
 ## References
 
-- Python logging: https://docs.python.org/3/library/logging.html
-- 12-factor logs: https://12factor.net/logs
-- structlog (future): https://www.structlog.org/
-- pytest caplog: https://docs.pytest.org/en/stable/how-to/logging.html
+- Python logging: <https://docs.python.org/3/library/logging.html>
+- 12-factor logs: <https://12factor.net/logs>
+- structlog (future): <https://www.structlog.org/>
+- pytest caplog: <https://docs.pytest.org/en/stable/how-to/logging.html>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0010-openapi-specification-strategy.md
+++ b/.kit/adr/KIT-ADR-0010-openapi-specification-strategy.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 When the project adds REST APIs, we need a consistent approach for:
+
 - API documentation that stays in sync with implementation
 - Request/response validation
 - Client SDK generation
@@ -21,17 +22,20 @@ Without a clear strategy, APIs tend to drift from documentation, leading to inte
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Machine-readable API specification
 - Auto-generated documentation
 - Request/response validation
 - Support for modern Python frameworks (FastAPI, Flask)
 
 **Constraints:**
+
 - Specification must be version-controlled
 - Should work with CI/CD pipelines
 - Must support incremental adoption
 
 **Assumptions:**
+
 - Future APIs will be RESTful
 - Python will be the primary implementation language
 - APIs may need to support external consumers
@@ -51,7 +55,7 @@ We will adopt **OpenAPI 3.1** with a **contract-first development** approach whe
 
 **Specification Location:**
 
-```
+```text
 api/
 ├── openapi.yaml          # Main specification file
 ├── schemas/              # Reusable schema definitions
@@ -178,7 +182,7 @@ app.add_middleware(StarletteOpenAPIMiddleware, openapi=spec)
 
 **Development Workflow:**
 
-```
+```text
 1. Design API in openapi.yaml
     ↓
 2. Review spec in Swagger Editor
@@ -229,6 +233,7 @@ app.add_middleware(StarletteOpenAPIMiddleware, openapi=spec)
 **Description**: Document APIs manually, no formal specification
 
 **Rejected because**:
+
 - ❌ Documentation drifts from implementation
 - ❌ No automated validation
 - ❌ No client generation
@@ -238,6 +243,7 @@ app.add_middleware(StarletteOpenAPIMiddleware, openapi=spec)
 **Description**: Use GraphQL instead of REST with OpenAPI
 
 **Not adopted because**:
+
 - ❌ Different paradigm, higher learning curve
 - ❌ Overkill for simple CRUD APIs
 - ✅ Consider for complex data requirements
@@ -247,6 +253,7 @@ app.add_middleware(StarletteOpenAPIMiddleware, openapi=spec)
 **Description**: Use OpenAPI 3.0 instead of 3.1
 
 **Rejected because**:
+
 - ❌ 3.0 has JSON Schema incompatibilities
 - ❌ 3.1 has better nullable handling
 - ❌ 3.1 is the current standard
@@ -258,6 +265,7 @@ app.add_middleware(StarletteOpenAPIMiddleware, openapi=spec)
 **When to Apply**: When adding first REST endpoint
 
 **Recommended First Steps**:
+
 1. Choose framework (FastAPI recommended)
 2. Create `api/openapi.yaml` or use FastAPI auto-generation
 3. Add CI validation workflow
@@ -270,11 +278,11 @@ app.add_middleware(StarletteOpenAPIMiddleware, openapi=spec)
 
 ## References
 
-- OpenAPI 3.1 Specification: https://spec.openapis.org/oas/v3.1.0
-- FastAPI: https://fastapi.tiangolo.com/
-- openapi-core: https://pypi.org/project/openapi-core/
-- Swagger Editor: https://editor.swagger.io/
-- oasdiff: https://github.com/Tufin/oasdiff
+- OpenAPI 3.1 Specification: <https://spec.openapis.org/oas/v3.1.0>
+- FastAPI: <https://fastapi.tiangolo.com/>
+- openapi-core: <https://pypi.org/project/openapi-core/>
+- Swagger Editor: <https://editor.swagger.io/>
+- oasdiff: <https://github.com/Tufin/oasdiff>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0011-api-versioning-strategy.md
+++ b/.kit/adr/KIT-ADR-0011-api-versioning-strategy.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 When APIs evolve, breaking changes are inevitable. We need a versioning strategy that:
+
 - Gives consumers stability guarantees
 - Allows controlled deprecation of old versions
 - Provides clear migration paths
@@ -19,17 +20,20 @@ When APIs evolve, breaking changes are inevitable. We need a versioning strategy
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Support multiple API versions simultaneously
 - Clear version identification in requests
 - Automated deprecation warnings
 - Graceful sunset of old versions
 
 **Constraints:**
+
 - Must work with REST APIs
 - Should integrate with OpenAPI (KIT-ADR-0010)
 - Must be implementable in Python frameworks
 
 **Assumptions:**
+
 - APIs will have external consumers
 - Breaking changes will occur over time
 - Consumers need migration time
@@ -49,7 +53,7 @@ We will adopt **date-based API versioning** (YYYY-MM-DD format) with a **6-month
 
 **Version Format:**
 
-```
+```text
 YYYY-MM-DD
 
 Examples:
@@ -59,6 +63,7 @@ Examples:
 ```
 
 **Why date-based (like Stripe)?**
+
 - Natural chronological ordering
 - Clear "age" of version
 - No semantic ambiguity (what's in v2 vs v3?)
@@ -228,6 +233,7 @@ Each version must have a changelog entry:
 **Description**: Version in URL path like `/v1/tasks`
 
 **Not adopted because**:
+
 - ❌ Pollutes URL namespace
 - ❌ Unclear what's in each version
 - ❌ Harder to deprecate gracefully
@@ -238,6 +244,7 @@ Each version must have a changelog entry:
 **Description**: Full semver for API versions
 
 **Not adopted because**:
+
 - ❌ Overkill for API versioning
 - ❌ Minor/patch versions rarely matter for APIs
 - ❌ Consumers typically pin to major version anyway
@@ -247,6 +254,7 @@ Each version must have a changelog entry:
 **Description**: Single version, break things as needed
 
 **Rejected because**:
+
 - ❌ Terrible for external consumers
 - ❌ No migration time
 - ❌ Unprofessional
@@ -258,6 +266,7 @@ Each version must have a changelog entry:
 **When to Apply**: When adding first REST endpoint with external consumers
 
 **First Steps**:
+
 1. Add version middleware
 2. Document initial version in changelog
 3. Include version in OpenAPI spec
@@ -268,9 +277,9 @@ Each version must have a changelog entry:
 
 ## References
 
-- Stripe API Versioning: https://stripe.com/docs/api/versioning
-- Zalando API Guidelines: https://opensource.zalando.com/restful-api-guidelines/#api-versioning
-- Microsoft REST API Guidelines: https://github.com/microsoft/api-guidelines
+- Stripe API Versioning: <https://stripe.com/docs/api/versioning>
+- Zalando API Guidelines: <https://opensource.zalando.com/restful-api-guidelines/#api-versioning>
+- Microsoft REST API Guidelines: <https://github.com/microsoft/api-guidelines>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0012-task-status-linear-alignment.md
+++ b/.kit/adr/KIT-ADR-0012-task-status-linear-alignment.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 Task files have a `**Status**:` field and live in numbered folders (`1-backlog/`, `2-todo/`, etc.). When syncing to Linear, we need clear rules for:
+
 - Which status value to use
 - How to handle conflicts between field and folder
 - What to do with legacy status values
@@ -21,17 +22,20 @@ This ADR documents the **implementation pattern** for status alignment. For the 
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Status field and folder should both be valid indicators
 - Legacy statuses from migrations must be handled
 - Archive/reference folders should not sync
 - Status must map to Linear's workflow states
 
 **Constraints:**
+
 - Linear has fixed workflow states (Backlog, Todo, In Progress, etc.)
 - Files may have outdated status values
 - Folder moves should update status
 
 **Assumptions:**
+
 - Git-tracked files are source of truth
 - Linear is for team visibility, not primary editing
 - Agents work with file-based task specs
@@ -77,7 +81,7 @@ We will use a **3-level priority system** for status resolution, with automatic 
 
 **Status Resolution Priority:**
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
 │  Priority 1: Status Field (if Linear-native)       │
 │  ─────────────────────────────────────────────      │
@@ -115,7 +119,8 @@ When sync encounters non-Linear-native status values, it automatically updates t
 | `blocked` | `Blocked` | Case normalization |
 
 **Migration behavior:**
-```
+
+```text
 Before: **Status**: draft
 After:  **Status**: Backlog
         (file is updated, then synced)
@@ -172,7 +177,7 @@ def should_sync_task(task_file: Path) -> bool:
 
 **Status Flow Diagram:**
 
-```
+```text
                     ┌──────────────────┐
                     │   Task File      │
                     │ (Source of Truth)│
@@ -228,6 +233,7 @@ def should_sync_task(task_file: Path) -> bool:
 **Description**: Ignore status field entirely, derive only from folder
 
 **Rejected because**:
+
 - ❌ Loses flexibility for edge cases
 - ❌ Can't override folder with field when needed
 - ❌ Some workflows need field-based status
@@ -237,6 +243,7 @@ def should_sync_task(task_file: Path) -> bool:
 **Description**: Ignore folder, derive only from status field
 
 **Rejected because**:
+
 - ❌ Loses intuitive folder organization
 - ❌ No visual indication of status in file browser
 - ❌ Must open file to see status
@@ -246,6 +253,7 @@ def should_sync_task(task_file: Path) -> bool:
 **Description**: Fail on legacy status values instead of migrating
 
 **Rejected because**:
+
 - ❌ Breaks existing task files
 - ❌ Requires manual updates for migration
 - ❌ Poor user experience
@@ -286,6 +294,7 @@ A pre-commit hook validates Status field matches folder location:
 ```
 
 **Behavior:**
+
 - Blocks commits if Status doesn't match folder
 - Shows specific files and expected values
 - Suggests fix: `./scripts/project move <task-id> <status>`
@@ -299,12 +308,14 @@ A pre-commit hook validates Status field matches folder location:
 ## Real-World Results
 
 **Current implementation:**
+
 - `scripts/linear_sync_utils.py` - Status mapping utilities
 - `scripts/sync_tasks_to_linear.py` - Sync orchestration
 - `scripts/validate_task_status.py` - Pre-commit validation
 - `./scripts/project` CLI - Helper commands (move, complete, start, block, validate)
 
 **Observed behavior:**
+
 - Tasks sync with correct status on push
 - Legacy statuses auto-migrate transparently
 - Archive folders excluded as expected
@@ -320,7 +331,7 @@ A pre-commit hook validates Status field matches folder location:
 - Implementation: `scripts/linear_sync_utils.py`
 - Sync script: `scripts/sync_tasks_to_linear.py`
 - GitHub Actions: `.github/workflows/sync-to-linear.yml`
-- Linear Workflow States: https://linear.app/docs/workflow-states
+- Linear Workflow States: <https://linear.app/docs/workflow-states>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0013-realtime-task-monitoring.md
+++ b/.kit/adr/KIT-ADR-0013-realtime-task-monitoring.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 Task status changes currently only sync to Linear on git push (via CI). During active development sessions with multiple agents, users lack visibility into:
+
 - Which tasks are being worked on
 - When tasks change status (move between folders)
 - Real-time progress of multi-agent workflows
@@ -20,18 +21,21 @@ We need a monitoring pattern that provides immediate visibility without requirin
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Watch file system for task folder changes
 - Parse task metadata on change
 - Emit events for status transitions
 - Support multiple output modes (CLI, daemon, future dashboard)
 
 **Constraints:**
+
 - Must work without external services
 - Should not interfere with sync operations
 - Must handle rapid file changes (debouncing)
 - Should be optional (not required for basic operation)
 
 **Assumptions:**
+
 - Tasks are organized in numbered folders
 - File changes are the source of truth
 - Users want immediate feedback during sessions
@@ -51,7 +55,7 @@ We will adopt an **event-driven file watching architecture** with daemon mode fo
 
 **Monitoring Architecture:**
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │                   File System Events                     │
 │     (create, modify, move, delete in task folders)      │
@@ -245,6 +249,7 @@ def daemon_stop():
 **Linear Sync Integration:**
 
 When monitor detects `task_moved`:
+
 1. Update status field in file (if not matching folder)
 2. Optionally trigger immediate Linear sync
 3. Log the transition for audit
@@ -287,6 +292,7 @@ def on_task_moved(event: TaskEvent):
 **Description**: Periodically scan task folders instead of file watching
 
 **Rejected because**:
+
 - ❌ Higher resource usage (constant scanning)
 - ❌ Latency (depends on poll interval)
 - ❌ Less efficient than OS-native events
@@ -296,6 +302,7 @@ def on_task_moved(event: TaskEvent):
 **Description**: Trigger monitoring on git operations only
 
 **Rejected because**:
+
 - ❌ Misses uncommitted changes
 - ❌ No real-time feedback during editing
 - ❌ Doesn't track folder moves before commit
@@ -305,6 +312,7 @@ def on_task_moved(event: TaskEvent):
 **Description**: Monitor via VS Code / IDE extension
 
 **Rejected because**:
+
 - ❌ Editor-specific implementation
 - ❌ Doesn't work with CLI-based workflows
 - ❌ Requires plugin installation
@@ -316,6 +324,7 @@ def on_task_moved(event: TaskEvent):
 **When to Implement**: When real-time monitoring becomes a priority
 
 **First Steps**:
+
 1. Add `watchdog` to dependencies
 2. Create `scripts/task_monitor.py`
 3. Add daemon commands to `./scripts/project` CLI
@@ -329,10 +338,10 @@ def on_task_moved(event: TaskEvent):
 
 ## References
 
-- watchdog library: https://pypi.org/project/watchdog/
-- python-daemon: https://pypi.org/project/python-daemon/
-- FSEvents (macOS): https://developer.apple.com/documentation/coreservices/file_system_events
-- inotify (Linux): https://man7.org/linux/man-pages/man7/inotify.7.html
+- watchdog library: <https://pypi.org/project/watchdog/>
+- python-daemon: <https://pypi.org/project/python-daemon/>
+- FSEvents (macOS): <https://developer.apple.com/documentation/coreservices/file_system_events>
+- inotify (Linux): <https://man7.org/linux/man-pages/man7/inotify.7.html>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0014-code-review-workflow.md
+++ b/.kit/adr/KIT-ADR-0014-code-review-workflow.md
@@ -11,13 +11,14 @@
 ### Problem Statement
 
 Currently, completed tasks move directly from implementation to done after CI passes. While TDD and CI/CD catch functional issues, they don't verify:
+
 - Code style and pattern consistency
 - Architecture adherence (ADR compliance)
 - Documentation completeness
 - Maintainability concerns
 - Non-functional requirements
 
-```
+```text
 CURRENT WORKFLOW (gap identified):
   Task → Implementation → CI passes → Done
                                 ↑
@@ -29,18 +30,21 @@ Human code review is valuable but doesn't scale with agent-based development. We
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Agents are stateless (no persistent conversation)
 - Reviews must be structured and actionable
 - Workflow must integrate with existing task management
 - Review findings must reference specific code locations
 
 **Constraints:**
+
 - Agents cannot directly communicate (async only)
 - Reviews must complete in reasonable time (< 10 minutes)
 - False positives reduce trust in the system
 - Cannot block all changes on review (need escape hatches)
 
 **Assumptions:**
+
 - CI has already verified tests pass
 - Task specifications include acceptance criteria
 - Code is accessible via semantic navigation (Serena)
@@ -61,7 +65,7 @@ We will adopt **agent-based code review** with async file-based communication be
 
 **The Review Workflow:**
 
-```
+```text
                     ┌─────────────────────────────────────┐
                     │                                     │
                     ▼                                     │
@@ -87,7 +91,7 @@ We will adopt **agent-based code review** with async file-based communication be
 
 Since agents are stateless, they communicate via structured files:
 
-```
+```text
 Implementation Agent                    Review Agent
         │                                     │
         ├──→ Writes code                      │
@@ -186,7 +190,7 @@ ESCALATE_TO_HUMAN: [Why human judgment needed]
 
 **Iteration Limits:**
 
-```
+```text
 Round 1: Initial review
     ↓ (if CHANGES_REQUESTED)
 Round 2: Re-review after revisions
@@ -219,7 +223,7 @@ Review may be skipped for:
 
 ### File Locations
 
-```
+```text
 .agent-context/
 ├── reviews/
 │   ├── ASK-0021-review.md
@@ -260,6 +264,7 @@ Review may be skipped for:
 **Description**: All code reviewed by humans, no agent involvement
 
 **Rejected because**:
+
 - ❌ Doesn't scale with agent-generated code volume
 - ❌ Humans are slow for repetitive checks (style, patterns)
 - ❌ Inconsistent application of standards
@@ -270,6 +275,7 @@ Review may be skipped for:
 **Description**: Review happens after merge to main, fix issues later
 
 **Rejected because**:
+
 - ❌ Technical debt accumulates
 - ❌ Harder to fix issues once merged
 - ❌ No gate before completion
@@ -280,6 +286,7 @@ Review may be skipped for:
 **Description**: Review agent comments on code as it's being written
 
 **Rejected because**:
+
 - ❌ Agents are stateless - can't maintain review context
 - ❌ Interrupts implementation flow
 - ❌ Complex coordination between agents
@@ -290,6 +297,7 @@ Review may be skipped for:
 **Description**: Use static analysis tools (ruff, mypy) instead of agent review
 
 **Rejected because**:
+
 - ❌ Linting catches syntax/style, not semantic issues
 - ❌ Can't verify acceptance criteria
 - ❌ No ADR adherence checking
@@ -301,12 +309,14 @@ Review may be skipped for:
 *To be updated after ASK-0024 (Learning Tests) is completed*
 
 **Before this pattern:**
+
 - Tasks moved directly to done after CI
 - Quality issues discovered later by humans
 - Inconsistent adherence to ADRs
 - No documentation of review decisions
 
 **After this pattern:**
+
 - [Results pending]
 
 ## Related Decisions

--- a/.kit/adr/KIT-ADR-0015-mcp-tool-addition-pattern.md
+++ b/.kit/adr/KIT-ADR-0015-mcp-tool-addition-pattern.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 As the MCP (Model Context Protocol) ecosystem grows, projects may need to integrate additional MCP tools beyond Serena. Each integration requires consistent configuration, activation patterns, and documentation. Without a standardized approach:
+
 - Integrations become ad-hoc and inconsistent
 - Agent files diverge in structure and patterns
 - Troubleshooting becomes harder across different tools
@@ -19,18 +20,21 @@ As the MCP (Model Context Protocol) ecosystem grows, projects may need to integr
 ### Forces at Play
 
 **Technical Requirements:**
+
 - MCP tools are external to the project (third-party servers)
 - Claude Code supports both global (`--scope user`) and local (`--scope local`) MCP configurations
 - Tools require project-specific configuration for context
 - Agents need to activate tools at session start
 
 **Constraints:**
+
 - MCP configuration is managed through `claude mcp` CLI
 - Each tool has unique configuration requirements
 - Secrets and credentials must be handled securely
 - Agents are stateless across sessions
 
 **Assumptions:**
+
 - Projects may integrate multiple MCP tools over time
 - Each tool provides specific capabilities (code navigation, database, APIs, etc.)
 - Consistent patterns reduce cognitive load for developers
@@ -90,7 +94,7 @@ claude mcp add --scope local api-gateway -- python -m api_gateway_mcp
 
 Each tool should have a project-specific config in a dedicated folder:
 
-```
+```text
 .<tool-name>/
 ├── project.yml          # Main configuration
 ├── project.yml.template # Template for onboarding
@@ -137,8 +141,10 @@ as your first message. When you see a request to activate <Tool>,
 immediately respond by calling:
 
 ```
+
 mcp__<tool>__<activation_function>("<project-name>")
-```
+
+```text
 
 This configures <tool capabilities>. Confirm activation in your
 response: "✅ <Tool> activated: <context>. Ready for <capability>."
@@ -173,6 +179,7 @@ done
 **Required Documentation Files:**
 
 1. **Setup Guide** (in `.<tool>/README.md` or `docs/mcp/<tool>.md`):
+
    ```markdown
    # <Tool> Integration
 
@@ -260,11 +267,13 @@ done
 ## Example: Hypothetical Database MCP Tool
 
 **Phase 1: Setup**
+
 ```bash
 claude mcp add --scope user db-client -- npx @mcp/postgres-client
 ```
 
 **Phase 2: Configuration**
+
 ```yaml
 # .db-client/project.yml
 project_name: "my-project"
@@ -281,6 +290,7 @@ connections:
 ```
 
 **Phase 3: Agent Section**
+
 ```markdown
 ## Database Activation (Launcher-Initiated)
 
@@ -289,14 +299,17 @@ as your first message. When you see a request to activate Database,
 immediately respond by calling:
 
 ```
+
 mcp__db__connect("local-dev")
-```
+
+```text
 
 This connects to the configured database. Confirm activation in your
 response: "✅ Database activated: local-dev. Ready for queries."
 ```
 
 **Phase 4: Verification**
+
 ```bash
 # After activation, verify with:
 mcp__db__run_query("SELECT 1")  # Should return 1
@@ -360,8 +373,8 @@ def test_tool_error_handling():
 
 ## References
 
-- Claude Code MCP Documentation: https://docs.claude.com/en/docs/claude-code
-- MCP Protocol Specification: https://modelcontextprotocol.io/
+- Claude Code MCP Documentation: <https://docs.claude.com/en/docs/claude-code>
+- MCP Protocol Specification: <https://modelcontextprotocol.io/>
 - Serena setup script: `.serena/setup-serena.sh` (reference implementation)
 
 ## Revision History

--- a/.kit/adr/KIT-ADR-0016-validation-architecture.md
+++ b/.kit/adr/KIT-ADR-0016-validation-architecture.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 Data validation in multi-step workflows presents a fundamental tension: strict validation at object creation prevents working with incomplete data, while lenient validation leads to invalid data reaching operations. We need a pattern that allows:
+
 - Working with partially complete data during editing
 - Strict validation before critical operations
 - Clear error messages with appropriate context
@@ -19,18 +20,21 @@ Data validation in multi-step workflows presents a fundamental tension: strict v
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Objects must be type-safe when created
 - Operations (sync, API calls) require complete, valid data
 - Editing workflows need partial data support
 - Validation errors must be actionable
 
 **Constraints:**
+
 - Python type system has limits (Optional vs required)
 - Pydantic validates at construction by default
 - Different operations have different validation requirements
 - Error messages need context (what operation, what's missing)
 
 **Assumptions:**
+
 - Data models will be reused across operations
 - Users will edit data incrementally
 - Some operations are more strict than others
@@ -49,7 +53,7 @@ We will adopt a **two-tier validation architecture** that separates type safety 
 
 ### Two-Tier Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
 │                 Object Lifecycle                     │
 ├─────────────────────────────────────────────────────┤
@@ -321,6 +325,7 @@ class Task(BaseModel):
 **Description**: Require all fields and validate everything at object creation.
 
 **Rejected because**:
+
 - ❌ Can't create partial objects during editing
 - ❌ Loading incomplete data from files fails
 - ❌ All-or-nothing approach hurts UX
@@ -331,6 +336,7 @@ class Task(BaseModel):
 **Description**: Accept any data at construction, validate only before operations.
 
 **Rejected because**:
+
 - ❌ Type errors caught late
 - ❌ Invalid data can propagate
 - ❌ Harder to reason about object state
@@ -341,6 +347,7 @@ class Task(BaseModel):
 **Description**: Use decorators to automatically validate before method calls.
 
 **Rejected because**:
+
 - ❌ Magic behavior - not obvious when validation runs
 - ❌ Harder to handle errors explicitly
 - ❌ Less control over validation flow
@@ -351,6 +358,7 @@ class Task(BaseModel):
 **Description**: Create different model classes for different operations.
 
 **Rejected because**:
+
 - ❌ Class explosion (TaskDraft, TaskForSync, TaskForApi, etc.)
 - ❌ Conversion overhead between types
 - ❌ Harder to maintain consistency
@@ -406,8 +414,8 @@ def test_sync_fails_with_invalid_task(linear_client):
 
 ## References
 
-- Pydantic v2 Documentation: https://docs.pydantic.dev/
-- Parse, don't validate: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
+- Pydantic v2 Documentation: <https://docs.pydantic.dev/>
+- Parse, don't validate: <https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/>
 - Domain Driven Design - Value Objects
 
 ## Revision History

--- a/.kit/adr/KIT-ADR-0017-api-testing-infrastructure.md
+++ b/.kit/adr/KIT-ADR-0017-api-testing-infrastructure.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 API endpoints require testing at multiple levels: contract validation against OpenAPI specs, integration testing with dependencies, and load testing for performance. Mixing API tests with unit tests creates problems:
+
 - Different test speeds and resource needs
 - Unclear test organization
 - Missing contract validation
@@ -19,6 +20,7 @@ API endpoints require testing at multiple levels: contract validation against Op
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Validate API responses match OpenAPI specification
 - Test authentication and authorization
 - Integration tests with actual services
@@ -26,12 +28,14 @@ API endpoints require testing at multiple levels: contract validation against Op
 - Fast feedback during development
 
 **Constraints:**
+
 - Tests should run in CI pipeline
 - Some tests need external services (databases, etc.)
 - Contract tests need OpenAPI spec file
 - Load tests are slow and resource-intensive
 
 **Assumptions:**
+
 - Project has or will have REST API endpoints
 - OpenAPI specification exists (see KIT-ADR-0010)
 - Using pytest as the test framework
@@ -50,7 +54,7 @@ We will establish a **dedicated API testing infrastructure** with clear separati
 
 ### Directory Structure
 
-```
+```text
 tests/
 ├── unit/                    # Fast, isolated tests
 │   └── ...
@@ -516,6 +520,7 @@ def create_user(
 **Description**: Keep all tests in `tests/` without separation.
 
 **Rejected because**:
+
 - ❌ Hard to run API tests in isolation
 - ❌ Mixed concerns in conftest.py
 - ❌ No clear structure for contract tests
@@ -526,6 +531,7 @@ def create_user(
 **Description**: Create a separate `api_tests/` package at project root.
 
 **Rejected because**:
+
 - ❌ Fragments test infrastructure
 - ❌ Separate pytest configuration needed
 - ❌ Harder to share fixtures
@@ -536,6 +542,7 @@ def create_user(
 **Description**: Use schemathesis for property-based API testing.
 
 **Considered but deferred**:
+
 - ✅ Powerful property-based testing
 - ✅ Auto-generates test cases from spec
 - ⚠️ Higher learning curve
@@ -549,10 +556,10 @@ def create_user(
 
 ## References
 
-- pytest Documentation: https://docs.pytest.org/
-- FastAPI Testing: https://fastapi.tiangolo.com/tutorial/testing/
-- openapi-core: https://openapi-core.readthedocs.io/
-- Schemathesis: https://schemathesis.readthedocs.io/
+- pytest Documentation: <https://docs.pytest.org/>
+- FastAPI Testing: <https://fastapi.tiangolo.com/tutorial/testing/>
+- openapi-core: <https://openapi-core.readthedocs.io/>
+- Schemathesis: <https://schemathesis.readthedocs.io/>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0018-workflow-observation.md
+++ b/.kit/adr/KIT-ADR-0018-workflow-observation.md
@@ -11,6 +11,7 @@
 ### Problem Statement
 
 Multi-agent systems have complex workflows with handoffs, parallel tasks, and state changes. Understanding what's happening requires visibility into agent actions, task progress, and system health. Without structured observation:
+
 - Debugging agent behavior is difficult
 - Performance bottlenecks are hidden
 - Handoff failures go unnoticed
@@ -19,6 +20,7 @@ Multi-agent systems have complex workflows with handoffs, parallel tasks, and st
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Capture events across multiple agents
 - Store events for later analysis
 - Enable real-time monitoring dashboards
@@ -26,12 +28,14 @@ Multi-agent systems have complex workflows with handoffs, parallel tasks, and st
 - Integrate with existing logging (KIT-ADR-0009)
 
 **Constraints:**
+
 - Agents run in separate processes/sessions
 - Events must be lightweight (low overhead)
 - Storage should be append-only (immutable log)
 - Multiple observers may consume events
 
 **Assumptions:**
+
 - Projects may have multiple concurrent agents
 - Event volume is moderate (not high-frequency trading)
 - Observers are decoupled from emitters
@@ -50,7 +54,7 @@ We will adopt an **event-driven workflow observation architecture** with structu
 
 ### Architecture Overview
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                    Agent Activities                          │
 │  ┌─────────┐    ┌─────────┐    ┌─────────┐                 │
@@ -477,6 +481,7 @@ def archive_old_events(days_to_keep: int = 30):
 **Description**: Store events in SQLite or PostgreSQL.
 
 **Rejected because**:
+
 - ❌ Adds database dependency
 - ❌ More complex setup
 - ⚠️ Could be added later for querying
@@ -486,6 +491,7 @@ def archive_old_events(days_to_keep: int = 30):
 **Description**: Use OpenTelemetry for tracing and metrics.
 
 **Deferred because**:
+
 - ✅ Industry standard
 - ✅ Rich ecosystem
 - ⚠️ Higher complexity for small projects
@@ -496,6 +502,7 @@ def archive_old_events(days_to_keep: int = 30):
 **Description**: Rely solely on logging.
 
 **Rejected because**:
+
 - ❌ Logs are unstructured
 - ❌ Hard to query and aggregate
 - ❌ No event correlation
@@ -507,9 +514,9 @@ def archive_old_events(days_to_keep: int = 30):
 
 ## References
 
-- Event Sourcing: https://martinfowler.com/eaaDev/EventSourcing.html
-- OpenTelemetry: https://opentelemetry.io/
-- JSONL Format: https://jsonlines.org/
+- Event Sourcing: <https://martinfowler.com/eaaDev/EventSourcing.html>
+- OpenTelemetry: <https://opentelemetry.io/>
+- JSONL Format: <https://jsonlines.org/>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0019-review-knowledge-extraction.md
+++ b/.kit/adr/KIT-ADR-0019-review-knowledge-extraction.md
@@ -24,7 +24,7 @@ A review noted "Bridge protocol uses SCHEMA_VERSION 1.0.0 - must maintain for Sw
 
 ### Current State
 
-```
+```text
 .agent-context/reviews/
 ├── TASK-0004-review-v1-planner.md     # 50+ lines each
 ├── TASK-0004-review-v2-code-reviewer.md
@@ -94,23 +94,27 @@ Use CLIOutput helper class that switches between JSON and text modes.
 ## Alternatives Considered
 
 ### Option A: Curated Insights Index Only
+
 - **Pros**: Single file, easy to read, agents can grep for module names
 - **Cons**: Manual curation required, could grow large, no formal decision record
 - **Rejected**: Misses opportunity to formalize significant decisions
 
 ### Option B: Serena Memory Files
-```
+
+```text
 .serena/memories/
 ├── module-cli.md           # CLI-specific learnings
 ├── module-api.md           # API-specific learnings
 ├── patterns-config.md      # Configuration patterns
 └── integration-swift.md    # Swift app integration notes
 ```
+
 - **Pros**: Categorized, agents can selectively load via `mcp__serena__read_memory()`
 - **Cons**: Requires Serena, more files to maintain, fragmented knowledge
 - **Rejected for now**: Can evolve toward this if index grows too large (>500 lines)
 
 ### Option C: Lightweight ADRs Only
+
 - **Pros**: Formal, discoverable, follows existing ADR pattern
 - **Cons**: Heavyweight for small insights, ADR explosion risk
 - **Rejected**: Too much overhead for quick tips and gotchas
@@ -135,7 +139,7 @@ After moving task to `5-done/`:
 
 ### Extraction Prompt Template
 
-```
+```text
 Review the code review at `.agent-context/reviews/[TASK-ID]-review.md` and extract:
 
 1. **Module insights**: Patterns or gotchas specific to modules touched
@@ -161,6 +165,7 @@ Format as entries for REVIEW-INSIGHTS.md index.
 ## Consequences
 
 ### Positive
+
 - Knowledge compounds across tasks
 - Agents can quickly load relevant context before starting work
 - Significant decisions are formally recorded as ADRs
@@ -168,11 +173,13 @@ Format as entries for REVIEW-INSIGHTS.md index.
 - Low overhead - planner already owns task completion
 
 ### Negative
+
 - Manual curation required (could miss insights)
 - Index may grow large over time (mitigated by module organization)
 - Dual maintenance: insights file + ADRs for significant decisions
 
 ### Neutral
+
 - Can evolve toward Serena memories if index exceeds 500 lines
 - Extraction quality depends on planner agent's judgment
 

--- a/.kit/adr/KIT-ADR-0020-research-quality-coupling-strategy.md
+++ b/.kit/adr/KIT-ADR-0020-research-quality-coupling-strategy.md
@@ -38,10 +38,12 @@ The question arose: Should we decouple agent definitions from the specific CLI t
 ### Trade-off
 
 **Loose coupling (mechanism-aware)**:
+
 - Pro: Update 1 file when CLI changes
 - Con: Agents need extra lookup; may not follow through
 
 **Tight coupling (tool-specific)**:
+
 - Pro: Clear, actionable instructions; agents execute reliably
 - Con: Multiple files to update when CLI changes
 
@@ -50,6 +52,7 @@ The question arose: Should we decouple agent definitions from the specific CLI t
 **Keep tight coupling.**
 
 Rationale:
+
 1. **Agent effectiveness**: Experience shows agents need explicit, actionable commands to reliably execute the adversarial evaluation workflow
 2. **Current stability**: adversarial-workflow CLI is relatively stable
 3. **Documented debt**: By documenting coupled files, projects can refactor later if needed
@@ -58,16 +61,19 @@ Rationale:
 ## Consequences
 
 ### Positive
+
 - Agents have clear, copy-paste commands
 - No extra file lookups during agent execution
 - Higher likelihood of actual compliance with quality standards
 
 ### Negative
+
 - If adversarial-workflow CLI changes significantly, must update multiple files
 - Duplication of command syntax across files
 - Harder to swap out adversarial-workflow for alternative tools
 
 ### Mitigation
+
 - Coupling manifest maintained (see below)
 - Grep pattern provided for finding all coupled files
 - Decision can be revisited if CLI changes become frequent
@@ -115,6 +121,7 @@ Estimated effort: ~1 hour to refactor all files.
 ## Review Triggers
 
 Revisit this decision if:
+
 - adversarial-workflow CLI undergoes breaking changes
 - Need to support alternative validation tools
 - Maintenance burden of updating files becomes problematic

--- a/.kit/adr/KIT-ADR-0021-B-realtime-agent-communication.md
+++ b/.kit/adr/KIT-ADR-0021-B-realtime-agent-communication.md
@@ -18,7 +18,7 @@ The agentive-starter-kit architecture uses file-based coordination (`agent-hando
 
 Human operators are forced to act as message routers between agents, creating a bottleneck that doesn't scale and is exhausting to maintain. We need a mechanism for agents to address and communicate with each other directly while preserving human visibility and intervention capability.
 
-```
+```text
 Current Flow:
 ┌─────────────┐     ┌─────────┐     ┌─────────────┐
 │ Agent A     │ ──► │  Human  │ ──► │ Agent B     │
@@ -52,6 +52,7 @@ Analysis of sanity-labs/miriad-app revealed proven patterns for multi-agent comm
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Agents run as separate CLI processes (Claude Code)
 - Each agent has distinct model, role, and MCP configuration
 - Agents are ephemeral—they spin up, execute, and exit
@@ -59,6 +60,7 @@ Analysis of sanity-labs/miriad-app revealed proven patterns for multi-agent comm
 - Human needs ability to intervene in any conversation
 
 **Constraints:**
+
 - Must work locally (no cloud dependencies required)
 - Should integrate with existing file-based coordination
 - Cannot modify Claude Code CLI internals
@@ -109,13 +111,14 @@ interface Message {
 ```
 
 **Example NDJSON line:**
+
 ```json
 {"id":"01HXYZ...","t":"2026-02-05T10:30:00.000Z","type":"agent","sender":"planner","content":"@feature-developer Task ASK-0050 is ready for implementation.","addressed":["feature-developer"],"refs":["ASK-0050"]}
 ```
 
 ### Directory Structure
 
-```
+```text
 .agent-context/
 ├── channels/
 │   └── main/                      # Default channel
@@ -133,13 +136,14 @@ interface Message {
 
 Agents address each other using `@callsign` syntax:
 
-```
+```text
 @feature-developer Please implement the auth module.
 @planner @code-reviewer Ready for review.
 @channel Broadcast to all agents.
 ```
 
 **Visibility rules** (adapted from Miriad):
+
 - Agents see messages where they are `@mentioned`
 - Agents see messages they sent
 - `@channel` broadcasts to all roster agents
@@ -148,7 +152,8 @@ Agents address each other using `@callsign` syntax:
 ### Agent Integration
 
 **Startup flow** (added to agent wrapper):
-```
+
+```text
 1. Read roster.json, update own status to "online"
 2. Read messages.ndjson
 3. Filter to messages where self is @mentioned
@@ -164,21 +169,25 @@ Agents address each other using `@callsign` syntax:
 ### Error Handling Strategy
 
 **Ordering** (from Miriad research):
+
 - Use ULID for message IDs (lexicographically sortable)
 - Sort messages by ID on read, not by arrival time
 - No sequence numbers or coordination needed
 
 **Delivery guarantees**:
+
 - Append-only logs ensure durability
 - Agent reads all messages on startup (no "delivery" concept)
 - Idempotent processing via message ID tracking
 
 **Conflict resolution**:
+
 - Concurrent appends handled by filesystem (atomic append)
 - Use file locking for safety: `fcntl.flock()` or equivalent
 - Git merge handles distributed sync conflicts
 
 **Recovery**:
+
 - Messages persist in filesystem (survive crashes)
 - Agent can resume from any point using timestamp filter
 - No message loss unless filesystem fails
@@ -186,7 +195,8 @@ Agents address each other using `@callsign` syntax:
 ### Resource Management
 
 **Ephemeral mode** (default, recommended):
-```
+
+```text
 Agent starts → Checks inbox → Processes → Exits
 - No background processes
 - No polling
@@ -195,7 +205,8 @@ Agent starts → Checks inbox → Processes → Exits
 ```
 
 **File watcher mode** (optional, for faster response):
-```
+
+```text
 Agent starts → Watches inbox → Responds to new messages → Idle timeout → Exits
 - Uses fswatch/inotify (no polling)
 - Configurable idle timeout (default: 15 minutes)
@@ -225,7 +236,7 @@ Agent starts → Watches inbox → Responds to new messages → Idle timeout →
 
 Terminal display for `channel watch`:
 
-```
+```text
 ╭─ Channel: main ─────────────────────────────────────────────╮
 │                                                              │
 │ [10:30:05] @human → @planner                                │
@@ -288,6 +299,7 @@ def is_broadcast(mentions: list[str]) -> bool
 ```
 
 **Tests:**
+
 - `tests/test_message.py` - Serialization, ULID sorting
 - `tests/test_channel.py` - Read/write, filtering
 - `tests/test_mention.py` - @mention parsing
@@ -302,6 +314,7 @@ def is_broadcast(mentions: list[str]) -> bool
 | `.claude/agents/*.md` | Add inbox check instructions |
 
 **Agent startup injection:**
+
 ```python
 # agent-inbox.py
 def get_inbox_context(agent: str, channel: str = "main") -> str:
@@ -324,6 +337,7 @@ def get_inbox_context(agent: str, channel: str = "main") -> str:
 ### Phase 4: Enhanced Features (Week 4)
 
 **Enhancements:**
+
 - Cross-references via `refs` field
 - Dependency tracking in tasks
 - Message archival (rotate old messages)
@@ -406,6 +420,7 @@ def test_concurrent_appends_no_corruption()
 **Description**: Migrate to platform providing native message routing.
 
 **Not chosen because**:
+
 - Adds external dependency
 - Requires learning new platform
 - May not fit CLI-first workflow
@@ -416,6 +431,7 @@ def test_concurrent_appends_no_corruption()
 **Description**: Build local WebSocket server for agent coordination.
 
 **Not chosen because**:
+
 - Requires running server process
 - More infrastructure to maintain
 - Over-engineered for file-based system
@@ -425,6 +441,7 @@ def test_concurrent_appends_no_corruption()
 **Description**: Maintain current manual relay approach.
 
 **Not chosen because**:
+
 - Doesn't scale
 - Exhausting for human operator
 - Introduces latency and potential miscommunication
@@ -457,8 +474,8 @@ def test_concurrent_appends_no_corruption()
 
 - Miriad Research: `.agent-context/research/miriad/SYNTHESIS.md`
 - Tymbal Protocol Analysis: `.agent-context/research/miriad/TYMBAL-PROTOCOL.md`
-- sanity-labs/miriad-app: https://github.com/sanity-labs/miriad-app
-- ULID Specification: https://github.com/ulid/spec
+- sanity-labs/miriad-app: <https://github.com/sanity-labs/miriad-app>
+- ULID Specification: <https://github.com/ulid/spec>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0021-realtime-agent-communication.md
+++ b/.kit/adr/KIT-ADR-0021-realtime-agent-communication.md
@@ -14,7 +14,7 @@ The agentive-starter-kit architecture uses file-based coordination (`agent-hando
 
 Human operators are forced to act as message routers between agents, creating a bottleneck that doesn't scale and is exhausting to maintain. We need a mechanism for agents to address and communicate with each other directly while preserving human visibility and intervention capability.
 
-```
+```text
 Current Flow:
 ┌─────────────┐     ┌─────────┐     ┌─────────────┐
 │ Agent A     │ ──► │  Human  │ ──► │ Agent B     │
@@ -34,6 +34,7 @@ Desired Flow:
 ### Forces at Play
 
 **Technical Requirements:**
+
 - Agents run as separate CLI processes (Claude Code)
 - Each agent has distinct model, role, and MCP configuration
 - Agents are currently stateless—they spin up, execute, and exit
@@ -41,12 +42,14 @@ Desired Flow:
 - Human needs ability to intervene in any conversation
 
 **Constraints:**
+
 - Must work locally (no cloud dependencies required)
 - Should integrate with existing file-based coordination
 - Cannot modify Claude Code CLI internals
 - Must preserve context-efficiency gains from current setup
 
 **Assumptions:**
+
 - Agents would need to become long-running (or frequently-polling) processes
 - A shared communication channel is acceptable
 - Message ordering and delivery guarantees can be eventual (not strict)
@@ -67,6 +70,7 @@ We will adopt **platform-based communication** by migrating agent coordination t
 **Primary approach: Platform-based communication**
 
 Migrate to a platform providing:
+
 - Native message routing with @mentions
 - Persistent shared artifacts (board)
 - Agent presence and status
@@ -83,6 +87,7 @@ Migrate to a platform providing:
 | `agent-handoffs.json` | `get_roster` + artifact status |
 
 **Migration steps:**
+
 1. Create agent definitions as `system.agent` artifacts
 2. Import ADRs as `doc` artifacts
 3. Model task lifecycle using `task` artifacts with status transitions
@@ -93,7 +98,7 @@ Migrate to a platform providing:
 
 For fully local operation without platform dependency:
 
-```
+```text
 .agent-context/
 ├── agent-handoffs.json      # Existing coordination
 ├── messages/
@@ -105,6 +110,7 @@ For fully local operation without platform dependency:
 ```
 
 **Message format:**
+
 ```json
 {
   "id": "msg_01abc123",
@@ -117,6 +123,7 @@ For fully local operation without platform dependency:
 ```
 
 **Agent polling wrapper:**
+
 ```bash
 AGENT_NAME="feature-developer"
 INBOX=".agent-context/messages/inbox-${AGENT_NAME}.jsonl"
@@ -160,6 +167,7 @@ done
 **Description**: Maintain current setup where human relays all inter-agent messages.
 
 **Rejected because**:
+
 - ❌ Doesn't scale (human becomes bottleneck)
 - ❌ Exhausting for human operator
 - ❌ Introduces latency and potential miscommunication
@@ -170,6 +178,7 @@ done
 **Description**: Fork or extend Claude Code to add IPC/messaging capabilities.
 
 **Rejected because**:
+
 - ❌ Significant engineering effort
 - ❌ Maintenance burden as upstream evolves
 - ❌ Not portable to other agent runtimes
@@ -179,6 +188,7 @@ done
 **Description**: Build custom WebSocket server for agent coordination.
 
 **Rejected because**:
+
 - ❌ More infrastructure to build and maintain
 - ❌ Wrapper complexity for Claude CLI integration
 - ❌ Platform-based option provides this without custom development
@@ -186,14 +196,17 @@ done
 ## Real-World Results
 
 **Before this decision:**
+
 - Human relay time: ~30-60 seconds per handoff
 - Agent collaboration: Sequential only
 - Human fatigue: High during multi-agent sessions
 
 **After this decision:**
+
 - (To be measured after implementation)
 
 **Impact:**
+
 - (To be documented after implementation)
 
 ## Related Decisions
@@ -203,8 +216,8 @@ done
 
 ## References
 
-- Agentive Starter Kit: https://github.com/movito/agentive-starter-kit
-- Adversarial Workflow: https://github.com/movito/adversarial-workflow
+- Agentive Starter Kit: <https://github.com/movito/agentive-starter-kit>
+- Adversarial Workflow: <https://github.com/movito/adversarial-workflow>
 
 ## Revision History
 

--- a/.kit/adr/KIT-ADR-0022-manifest-based-sync-ownership.md
+++ b/.kit/adr/KIT-ADR-0022-manifest-based-sync-ownership.md
@@ -103,7 +103,7 @@ never touched.
 
 When a downstream repo creates a useful command that should be shared:
 
-```
+```text
 1. Downstream creates .claude/commands/my-command.md  (local, not in manifest)
 2. Command proves useful in practice
 3. PR to agentive-starter-kit adds my-command.md to commands_core or commands_optional
@@ -116,7 +116,7 @@ When a downstream repo creates a useful command that should be shared:
 
 When a downstream repo wants optional commands:
 
-```
+```text
 1. Downstream edits .core-manifest.json
 2. Adds "commands_optional" to opted_in array
 3. Runs sync (or waits for next sync PR)

--- a/.kit/adr/KIT-ADR-0023-builder-project-separation.md
+++ b/.kit/adr/KIT-ADR-0023-builder-project-separation.md
@@ -60,7 +60,7 @@ layer if you don't know exactly what it contains.
 
 All builder infrastructure moves under `.kit/`:
 
-```
+```text
 .kit/                              ← Builder layer (the "how I work" stuff)
 ├── delegation/                    ← Task management (tasks/, handoffs/)
 │   └── tasks/                     ← 1-backlog/ through 9-reference/
@@ -112,7 +112,7 @@ All builder infrastructure moves under `.kit/`:
 
 ### 2. Project Layer Stays in Standard Locations
 
-```
+```text
 .claude/                           ← Implementation-time agents and commands
 ├── agents/
 │   ├── feature-developer.md       ← Implementation agents only
@@ -218,7 +218,7 @@ path guidance.
 
 Once `.kit/` is stable:
 
-```
+```text
 Step 1 (this ADR): .kit/ inside each kit repo
 Step 2 (future):   .kit/ → ~/Github/workspace/.kit/
                    with per-project subdirs or symlinks

--- a/.kit/adr/KIT-ADR-0026-pull-based-consumer-sync.md
+++ b/.kit/adr/KIT-ADR-0026-pull-based-consumer-sync.md
@@ -75,7 +75,7 @@ consumer-side CLI invoke. Three parts:
 Move the tier/path/opt-in logic out of the workflow heredoc into a
 standalone **Python** script in the `scripts_core` tier:
 
-```
+```bash
 python3 scripts/core/sync_from_manifest.py \
     --source <upstream-dir> --target <consumer-dir> \
     [--tier <name>]... [--only <entry>]... [--dry-run] [--is-kit]

--- a/.kit/adr/KIT-ADR-0028-versioned-packages-not-file-copies.md
+++ b/.kit/adr/KIT-ADR-0028-versioned-packages-not-file-copies.md
@@ -103,6 +103,7 @@ KIT-0087 F2 (the single install path becomes the package's job);
 KIT-0082 (acceptance surface collapses to install + doctor).
 
 **Migration is staged, not big-bang** (status annotated 2026-08-11):
+
 1. Publish the packages — **DONE**: agentive-kit 0.1.0→0.3.1
    (KIT-0090/0091/0092); plugin 2.0.0→2.0.3 (KIT-0096–0101)
 2. Switch the door to package-install mode — **DONE**: KIT-0093
@@ -129,6 +130,7 @@ KIT-0082 (acceptance surface collapses to install + doctor).
    operator direction.)
 
 **Costs and risks, stated honestly**:
+
 - PyPI release discipline becomes real work (versioning, changelogs,
   a publish workflow) — but it replaces the sync machinery's larger
   standing cost, and the adversarial-workflow precedent shows the shape

--- a/.kit/adr/KIT-ADR-0029-task-as-folder.md
+++ b/.kit/adr/KIT-ADR-0029-task-as-folder.md
@@ -52,7 +52,7 @@ paper accumulates at a separate address from the thing it belongs to.
 **A task is a folder, not a file**, and it carries its own paperwork
 through the lifecycle:
 
-```
+```text
 .kit/tasks/<status>/<TASK-ID>-<slug>/
 ├── spec.md          # today's task file
 ├── HANDOFF.md

--- a/.kit/adr/about-kit-adr.md
+++ b/.kit/adr/about-kit-adr.md
@@ -83,6 +83,7 @@ similar numbers.
 ## When to Reference These
 
 Reference these KIT-ADRs when:
+
 - Understanding how the starter kit works
 - Deciding whether to adopt or modify a pattern
 - Training agents on project conventions
@@ -97,6 +98,7 @@ If you need to change a pattern from the starter kit:
 3. **Document the rationale** for diverging
 
 Example:
+
 ```markdown
 # ADR-0001: Custom Logging Format
 

--- a/.kit/context/ASK-UNIFIED-REGISTRY-TASK-STARTER.md
+++ b/.kit/context/ASK-UNIFIED-REGISTRY-TASK-STARTER.md
@@ -41,11 +41,13 @@ The ADR has been through 3 revision rounds informed by 4 adversarial evaluators 
 4. Verify: existing Claude Code agent loader ignores unknown frontmatter keys (it does — verified March 2026)
 
 **Content hash procedure** (from ADR):
+
 - For Markdown: SHA-256 of everything after closing `---` of frontmatter
 - Normalize: LF line endings, strip trailing whitespace per line, single trailing `\n`, UTF-8
 - Format: `sha256:<64-char-hex>`
 
 **What NOT to do in Phase 1**:
+
 - Don't touch evaluators yet (they live in adversarial-evaluator-library, a separate repo)
 - Don't build CLI tooling yet
 - Don't change any runtime behavior
@@ -53,12 +55,14 @@ The ADR has been through 3 revision rounds informed by 4 adversarial evaluators 
 ### Phase 2: CLI Tooling (PR 2)
 
 Implement `kit registry` subcommands:
+
 - `kit registry status` — compare local artifacts against index, show drift/updates
 - `kit registry sync` — pull updates from source repos (scan-then-execute: validate all, then write all)
 - `kit registry install <name>` — install a specific artifact
 - `kit registry diff <name>` — show diff between local and upstream
 
 This requires:
+
 - A `manifest.yml` parser (project policy: sources, tiers, pins, exclusions)
 - A `lock.yml` generator (pinned SHAs for reproducibility)
 - Content hash computation matching the spec above

--- a/.kit/context/KIT-0083-SESSION-FINDINGS.md
+++ b/.kit/context/KIT-0083-SESSION-FINDINGS.md
@@ -89,7 +89,7 @@ Verified independent of this task's work: removing the new
 
 **Where "3" came from** — the pre-commit `pytest-fast` hook stops early:
 
-```
+```text
 !!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 3 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
 ===== 3 failed, 323 passed, 45 deselected, 1 warning in 184.42s (0:03:04) =====
 ```

--- a/.kit/context/KIT-0104-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0104-REVIEW-STARTER.md
@@ -121,3 +121,81 @@ APPROVED. Every thread replied + resolved.
   a root-anchored target (`agentive new /x`) resolves the preset home
   to `/agentive-config` — edge of the PR 1 target-parent anchor
   decision; seeding still requires the directory to already exist.
+
+---
+
+# PR 3 — the prose sweep (F5/F6 + KIT-0094 passenger), 2026-08-14
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/131
+**Branch**: `feature/KIT-0104-pr3-prose` (worktree ../ask-worktrees/KIT-0104)
+**Status**: bots clean (round 2: CodeRabbit APPROVED + BugBot pass,
+0 unresolved threads), tests/lint green on 3.10/3.12/3.14. FINAL PR
+of the task.
+
+## What shipped
+
+- **KIT-0094 (passenger, complete)**: `.markdownlint-cli2.jsonc`
+  (rule decisions recorded once, incl. MD029 `one_or_ordered` per
+  KIT-0092 retro #6; scope = live markdown, `.coderabbitignore`
+  precedent) + tree-wide pre-commit gate (`pass_filenames: false` —
+  CLI paths extend config globs and bypass ignores, verified) +
+  class sweep: ~1,150 violations / 95 files → 0 (199 files linted)
+  + falsified once (planted bare fence → hook exit 1).
+  **Acceptance observed, not assumed**: CodeRabbit's round 1 on this
+  markdown-heavy PR produced ZERO markdown-style threads (its 7
+  findings were all content, none lint) — the class is retired.
+- **F5**: factory-clone precondition retired by class.
+  STARTING-A-PROJECT teaches the sibling layout; README leads with
+  `uv tool install agentive-kit && agentive new` (pipx named as
+  alternative); `/new-project` + `/setup-preset` (both 1.3.0) derive
+  from `agentive new --help`; config-home prose matches the packaged
+  target-parent anchor everywhere (preset.example, doctor notes +
+  packaged twins, `scripts/core/project` docstring). Grep proofs in
+  the PR body; survivors are records + the optional guided-route
+  session mechanics.
+- **F6**: verified — no hardcoded flag list in either command
+  (single `--no-preset` prose mention, present in help); pinned by
+  `test_door_units.py::TestUsageText` (9 tests).
+- Stale claims corrected while in there: adopt-copies caveat
+  (packaged since PR 2), kit-clone `.env` carryover (the packaged
+  door has none — `note_env_keys`), setup-preset config-home recipe
+  off-by-one (pre-existing; recipe now verified live), playbook
+  launcher policy unified (`.kit/launchers/launch` is the single
+  survivor, KIT-0075).
+
+## Bot rounds
+
+Round 1: 8 threads (1 BugBot Medium — run-step/help-fallback
+asymmetry in new-project.md, fixed `6a1be58`; 7 CodeRabbit — 5 fixed
+same commit, 2 resolved-without-fix with reasons: plugin-release
+coordination = planner-owned KIT-0096 post-merge, project-intake
+door reference = KIT-0105/KIT-0107-F5 scope). Round 2: clean,
+CodeRabbit APPROVED, BugBot pass. Every thread replied + resolved.
+
+## Preflight
+
+6/7 PASS. Gate 1 reads FAIL solely on the **Plugin Drift Guard** —
+pre-existing red on main since 2026-08-12 (4 findings before this
+PR; the sweep mechanically widens the list to 20). Tests pass.
+Remedy is yours post-merge: cut the plugin release (KIT-0096
+procedure) so it picks up the lint-clean bodies once. Precedent:
+#129/#130 merged over the same red.
+
+## Evaluator (Gate 5)
+
+Fast-only per the prose-sweep exception (recorded in
+`.kit/context/reviews/KIT-0104-evaluator-review.md`): FAIL verdict
+refuted against the tree (the "conflicting ADR-0021 pair" is a
+superseded-by-declaration pair from 2026-03; this PR only tagged
+fences). The behavior-bearing hunks (lint config + hook) were
+falsified live instead.
+
+## Next (planner)
+
+- **Merge gate: yours — this PR shape needs tree-grounded
+  verification** (sectioned verifiers against the branch), per the
+  prose-sweep rule. The trio was deliberately not the gate here.
+- After merge: cut the plugin release (drift guard back to green),
+  move KIT-0104 to 4-in-review/5-done (all three PRs landed),
+  KIT-0094 can complete alongside (its acceptance evidence is in
+  this starter), unblock KIT-0105.

--- a/.kit/context/README.md
+++ b/.kit/context/README.md
@@ -5,9 +5,11 @@ This directory contains coordination files for the agentive development workflow
 ## Contents
 
 ### `agent-handoffs.json`
+
 Current state of all agents - who's working on what, task status, and handoff notes.
 
 **Structure**:
+
 ```json
 {
   "agent-name": {
@@ -21,23 +23,29 @@ Current state of all agents - who's working on what, task status, and handoff no
 ```
 
 ### `current-state.json`
+
 Project-wide state tracking - version, configuration, metrics.
 
 ### `workflows/`
+
 Documented procedures for common operations:
+
 - `COMMIT-PROTOCOL.md` - How to make commits
 - `TESTING-WORKFLOW.md` - TDD process
 - `AGENT-CREATION-WORKFLOW.md` - Creating new agents
 - `ADR-CREATION-WORKFLOW.md` - Architectural decisions
 
 ### `templates/`
+
 Templates for handoff documents and coordination files:
+
 - `review-starter-template.md` - copied by the `review-handoff` skill to
   create `<TASK-ID>-REVIEW-STARTER.md` (implementer → reviewer)
 - `review-template.md` - used by the `code-reviewer` agent for its
   review output (reviewer → implementer)
 
 ### `archive/`
+
 Handoffs, review starters, and session artifacts for tasks that have
 reached a terminal folder (`5-done`, `6-canceled`, `7-blocked`,
 `8-archive`), plus dated one-off session records. Frozen history —
@@ -48,12 +56,15 @@ here (KIT-0077).
 ## Usage
 
 ### Checking Agent Status
+
 ```bash
 cat .kit/context/agent-handoffs.json | jq '.["agent-name"]'
 ```
 
 ### Updating After Task Completion
+
 Agents should update `agent-handoffs.json` when:
+
 - Starting a new task
 - Completing a task
 - Encountering blockers
@@ -62,7 +73,8 @@ Agents should update `agent-handoffs.json` when:
 ## File Naming Convention
 
 For dated files in this directory:
-```
+
+```text
 YYYY-MM-DD-DESCRIPTION.md
 ```
 

--- a/.kit/context/REVIEW-INSIGHTS.md
+++ b/.kit/context/REVIEW-INSIGHTS.md
@@ -9,11 +9,13 @@ Distilled knowledge from code reviews. Updated by planner during task completion
 ## How to Use This File
 
 **For Agents Starting Work**:
+
 1. Check relevant module sections before implementation
 2. Review "Patterns & Anti-Patterns" for established conventions
 3. Note any integration requirements that affect your work
 
 **For Planner Completing Tasks**:
+
 1. After moving task to `5-done/`, read the review file
 2. Extract high-signal insights (not everything, just what's reusable)
 3. Append entries under appropriate sections

--- a/.kit/context/research/miriad/AGENT-DEFINITIONS.md
+++ b/.kit/context/research/miriad/AGENT-DEFINITIONS.md
@@ -39,6 +39,7 @@ interface McpReference {
 ### Agent as Artifact
 
 Agents are stored as artifacts with:
+
 - **Type**: `system.agent`
 - **Slug**: URL-safe identifier (e.g., `builder`, `researcher`)
 - **Props**: Configuration from schema above
@@ -50,7 +51,7 @@ Agents are stored as artifacts with:
 
 ### Pluggable Engine System
 
-```
+```text
 ┌─────────────────────────────────────────────────┐
 │               EngineManager                      │
 ├─────────────────────────────────────────────────┤
@@ -130,7 +131,7 @@ interface EngineProcess {
 
 ### State Machine
 
-```
+```text
                     ┌───────────┐
                     │  offline  │ (initial state)
                     └─────┬─────┘
@@ -199,7 +200,7 @@ interface SystemMcpProps {
 
 ### Tool Discovery & Execution
 
-```
+```text
 Agent                    MCP Endpoint                 MCP Server
   │                          │                            │
   │── tools/list ───────────►│                            │
@@ -289,6 +290,7 @@ stream.push({ role: 'user', content: 'New instruction mid-task' });
 ```
 
 This enables:
+
 - Human intervention during long tasks
 - Agent-to-agent communication mid-execution
 - Dynamic context updates
@@ -419,6 +421,7 @@ You are a feature implementation specialist...
 ### What We Can Adopt
 
 1. **Structured MCP Configuration**
+
    ```yaml
    mcp:
      - slug: serena
@@ -428,12 +431,14 @@ You are a feature implementation specialist...
    ```
 
 2. **Engine Abstraction** (future)
+
    ```yaml
    engine: claude-code  # Current default
    # Future: custom-engine, local-llm, etc.
    ```
 
 3. **Agent Metadata**
+
    ```yaml
    singleton: true      # Only one instance allowed
    featured: true       # Show in suggestions
@@ -441,6 +446,7 @@ You are a feature implementation specialist...
    ```
 
 4. **Environment Injection**
+
    ```yaml
    environment:
      GITHUB_TOKEN: ${GITHUB_TOKEN}

--- a/.kit/context/research/miriad/ARCHITECTURE.md
+++ b/.kit/context/research/miriad/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 **Date**: 2026-02-05
 **Research Phase**: 1 (High-Level Architecture)
 **Status**: Complete
-**Repository**: https://github.com/sanity-labs/miriad-app
+**Repository**: <https://github.com/sanity-labs/miriad-app>
 
 ---
 
@@ -17,7 +17,7 @@ Miriad (also called "Cast") is a multi-agent collaboration platform from Sanity.
 
 ## System Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                           MIRIAD PLATFORM                                │
 ├─────────────────────────────────────────────────────────────────────────┤
@@ -64,7 +64,7 @@ Miriad (also called "Cast") is a multi-agent collaboration platform from Sanity.
 
 ## Package Structure (Backend Monorepo)
 
-```
+```text
 backend/packages/
 ├── core/           # Shared types, utilities, Tymbal protocol types
 ├── server/         # Hono-based API server
@@ -78,6 +78,7 @@ backend/packages/
 ### Key Dependencies
 
 **From `local-runtime/package.json`**:
+
 ```json
 {
   "@anthropic-ai/claude-agent-sdk": "latest",
@@ -96,6 +97,7 @@ backend/packages/
 Tymbal is a custom streaming protocol for agent communication.
 
 ### Transport Layer
+
 - **WebSocket** for real-time bidirectional communication
 - **NDJSON framing** (newline-delimited JSON)
 - **HTTP fallback** for non-streaming operations
@@ -124,7 +126,9 @@ Tymbal is a custom streaming protocol for agent communication.
 | `AgentMessage` | Agent-to-agent communication |
 
 ### Addressing
+
 Messages include `agentId` and `boardId` for routing:
+
 ```typescript
 interface TymbalFrame {
   type: 'start' | 'append' | 'set' | 'control';
@@ -141,6 +145,7 @@ interface TymbalFrame {
 ## Agent Architecture
 
 ### Agent Roles (from Miriad)
+
 - **Lead** - Orchestrates other agents
 - **Builder** - Implements code
 - **Researcher** - Gathers information
@@ -149,6 +154,7 @@ interface TymbalFrame {
 - **Writer** - Creates documentation
 
 ### Agent Lifecycle
+
 1. User @mentions an agent on a board
 2. Server routes to Runtime
 3. Runtime spawns container for agent
@@ -175,7 +181,7 @@ interface TymbalFrame {
 
 ## Data Flow
 
-```
+```text
 User Input                    Agent Response
     │                              ▲
     ▼                              │
@@ -209,18 +215,21 @@ User Input                    Agent Response
 ## Human Visibility & Intervention
 
 ### Visibility
+
 - All agent messages visible on shared "board"
 - Thinking/reasoning visible (not hidden)
 - Tool calls and results displayed
 - Real-time streaming updates
 
 ### Intervention Points
+
 - @mention to engage specific agent
 - Direct messages to agents
 - Ability to pause/redirect agents
 - Human can take over tasks
 
 ### Permission Model
+
 - Board-level access control
 - Agent capabilities defined per role
 - Tool access controlled via MCP
@@ -259,18 +268,21 @@ User Input                    Agent Response
 ## Compatibility Assessment (Preliminary)
 
 ### What We Can Adopt
+
 - ✅ Message type taxonomy (User, Agent, ToolCall, etc.)
 - ✅ Board/workspace concept for shared context
 - ✅ Thinking visibility pattern
 - ✅ Some Tymbal concepts for future WebSocket implementation
 
 ### What Needs Adaptation
+
 - ⚠️ Tymbal protocol → file-based equivalent for CLI
 - ⚠️ Web UI → terminal-based visualization
 - ⚠️ Container runtime → local process model
 - ⚠️ PostgreSQL storage → filesystem-based
 
 ### Fundamental Differences
+
 - ❌ Long-running vs ephemeral agents
 - ❌ Browser vs CLI human interface
 - ❌ Cloud-native vs local-first
@@ -291,12 +303,14 @@ User Input                    Agent Response
 ## Next Steps
 
 **Phase 2: Agent Communication Deep-Dive**
+
 - Study Tymbal protocol implementation details
 - Understand message delivery guarantees
 - Evaluate adopt vs adapt vs build decision
 - Determine if ephemeral agents can use Tymbal concepts
 
 **GO/NO-GO Decision Point**: After Phase 2, we'll have enough information to decide:
+
 - **ADOPT**: Use Tymbal patterns directly
 - **ADAPT**: Take concepts, build file-based implementation
 - **ABORT**: Their approach doesn't fit our constraints

--- a/.kit/context/research/miriad/CLAUDE-INTEGRATION.md
+++ b/.kit/context/research/miriad/CLAUDE-INTEGRATION.md
@@ -19,6 +19,7 @@ Miriad integrates with Claude using the **@anthropic-ai/claude-agent-sdk**, Anth
 ### What It Is
 
 The Claude Agent SDK enables:
+
 - Programmatic agent creation with Claude Code capabilities
 - File reading, writing, and editing
 - Shell command execution
@@ -60,7 +61,7 @@ for await (const message of query({
 
 ### Integration Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                    Miriad Local Runtime                      │
 ├─────────────────────────────────────────────────────────────┤
@@ -95,7 +96,7 @@ for await (const message of query({
 
 ### TymbalBridge Translation
 
-```
+```text
 SDK Message Type        →    Tymbal Frame Type
 ─────────────────────────────────────────────
 system (init)           →    (session setup)
@@ -220,7 +221,7 @@ options: {
 
 ### Tool Naming Convention
 
-```
+```text
 mcp__<server-name>__<tool-name>
 
 Examples:
@@ -232,11 +233,13 @@ mcp__postgres__query
 ### MCP Tool Search (Large Tool Sets)
 
 When tool definitions exceed 10% of context:
+
 1. Tools marked with `defer_loading: true`
 2. Claude uses search tool to discover relevant tools
 3. Only needed tools loaded into context
 
 Configure via environment:
+
 ```typescript
 env: {
   ENABLE_TOOL_SEARCH: "auto"    // Default: 10% threshold
@@ -270,7 +273,8 @@ setTimeout(() => {
 ### Message Formatting
 
 Messages include sender attribution:
-```
+
+```text
 --- @{sender} says:
 {content}
 ```
@@ -278,6 +282,7 @@ Messages include sender attribution:
 ### Cost Tracking
 
 SDK returns usage metrics:
+
 ```typescript
 interface CostFrame {
   inputTokens: number;
@@ -320,6 +325,7 @@ for await (const message of query({
 ```
 
 **Pros**:
+
 - Full streaming control
 - Session management (resume/fork)
 - Programmatic tool permissions
@@ -328,6 +334,7 @@ for await (const message of query({
 - Multi-turn conversations
 
 **Cons**:
+
 - Requires Node.js runtime
 - More complex setup
 - Need to handle message types
@@ -340,12 +347,14 @@ claude "Review and fix bugs" --allowedTools Read,Edit,Glob
 ```
 
 **Pros**:
+
 - Simple, one-line invocation
 - No code required
 - Built-in terminal UI
 - Immediate use
 
 **Cons**:
+
 - Less programmatic control
 - Session handling via filesystem
 - Tool permissions via flags/config
@@ -404,6 +413,7 @@ Keep CLI for simplicity, but learn from SDK patterns:
 ### Short-term
 
 1. **Add MCP config format** to agent definitions:
+
    ```yaml
    mcp:
      - slug: serena

--- a/.kit/context/research/miriad/NUUM-MEMORY-ARCHITECTURE.md
+++ b/.kit/context/research/miriad/NUUM-MEMORY-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Nuum Memory Architecture (Sanity.io)
 
-**Source**: https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem
+**Source**: <https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem>
 **Date Captured**: 2026-02-05
 **Relevance**: Critical for KIT-ADR-0021 - informs agent lifecycle decisions
 
@@ -9,6 +9,7 @@
 ## The Problem: "Agentic Burn-Out"
 
 As context windows fill during extended sessions, agents:
+
 - Lose coherence
 - Forget earlier decisions
 - Repeat questions
@@ -35,7 +36,7 @@ For each conversation segment, create two outputs:
 
 ## Three-Tier Memory Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │  TIER 1: Temporal Memory                                    │
 │  - Full-fidelity message history                            │
@@ -65,16 +66,19 @@ For each conversation segment, create two outputs:
 ## Key Mechanisms
 
 ### Background Distillation
+
 - Runs invisibly while agent works
 - Compresses older segments automatically
 - Targets ~40-60% context window saturation
 
 ### "Reflect" Tool
+
 - Enables perfect recall
 - Searches original Tier 1 messages
 - Agent can retrieve exact details when needed
 
 ### Recursive Compression
+
 - Tier 2 summaries themselves get summarized
 - Creates natural gradient: recent=detailed, old=abstract
 - Preserves decision rationale while discarding noise
@@ -84,6 +88,7 @@ For each conversation segment, create two outputs:
 ## Results
 
 **Nuum agent stats**:
+
 - 7,400+ messages
 - 6 days continuous operation
 - Maintained coherence throughout
@@ -122,7 +127,7 @@ For each conversation segment, create two outputs:
 
 ### Potential Adaptation Path
 
-```
+```text
 Ephemeral Agent Model + External Memory
 ────────────────────────────────────────
 

--- a/.kit/context/research/miriad/SHARED-BOARD-ARTIFACTS.md
+++ b/.kit/context/research/miriad/SHARED-BOARD-ARTIFACTS.md
@@ -57,7 +57,8 @@ interface RosterEntry {
 ```
 
 **Status Flow**:
-```
+
+```text
 active ←→ idle ←→ busy
    ↓         ↓      ↓
 paused ←→ offline → archived
@@ -144,7 +145,7 @@ interface StoredArtifact {
 
 Artifacts form a tree via `path`:
 
-```
+```text
 project-docs/                    (folder)
 ├── architecture/                (folder)
 │   ├── adr-001-database.md     (decision)
@@ -186,6 +187,7 @@ GET /channels/:channelId/artifacts?type=task&status=in_progress
 ```
 
 **Query Parameters**:
+
 - `type` - Filter by artifact type
 - `status` - Filter by status
 - `assignee` - Filter by assignee
@@ -271,7 +273,7 @@ GET /channels/:channelId/artifacts/:slug/diff?from=v1.0&to=v1.1
 
 Tasks are artifacts with status-based lifecycle:
 
-```
+```text
 ┌─────────┐
 │ pending │ (created, not started)
 └────┬────┘
@@ -297,6 +299,7 @@ Tasks are artifacts with status-based lifecycle:
 ### Task Display
 
 In tree views, task status is shown in parentheses:
+
 - `task-auth (pending)`
 - `task-auth (in_progress)`
 - `task-auth (done)`
@@ -318,6 +321,7 @@ Artifacts can reference each other via the `refs` field:
 ```
 
 This enables:
+
 - Dependency tracking
 - Related artifact discovery
 - Impact analysis
@@ -340,6 +344,7 @@ connectionManager.broadcast(channelId, {
 ### Conflict Resolution
 
 CAS (Compare-And-Swap) prevents lost updates:
+
 1. Client reads artifact (version N)
 2. Client sends PATCH with `version: N`
 3. Server checks current version
@@ -375,6 +380,7 @@ CAS (Compare-And-Swap) prevents lost updates:
 ### What We Can Adopt
 
 1. **Structured Task Metadata**
+
    ```yaml
    # In task frontmatter
    type: task
@@ -436,7 +442,7 @@ updated: 2026-02-05
 
 ### Channel-Like Organization
 
-```
+```text
 .kit/context/
 ├── channels/
 │   ├── main/                  # Default channel

--- a/.kit/context/research/miriad/SYNTHESIS.md
+++ b/.kit/context/research/miriad/SYNTHESIS.md
@@ -40,6 +40,7 @@ We cannot adopt Miriad directly (requires persistent connections, long-running a
 **Finding**: Tymbal is NDJSON-framed streaming with 5 frame types and 9 message types. Uses ULID ordering, eventual consistency, mention-based routing.
 
 **Relevance**:
+
 - ✅ Message taxonomy (User, Agent, ToolCall, ToolResult, Thinking) - directly adoptable
 - ✅ @mention routing - adaptable to file naming
 - ✅ NDJSON framing - works for file-based logs
@@ -50,6 +51,7 @@ We cannot adopt Miriad directly (requires persistent connections, long-running a
 **Finding**: 12 artifact types with status workflows, CAS updates, versioning, cross-references.
 
 **Relevance**:
+
 - ✅ Artifact types (doc, task, decision, code) - we already use equivalents
 - ✅ Status workflow (pending → in_progress → done) - matches our folder system
 - ✅ Cross-references via `refs` field - adoptable for dependency tracking
@@ -60,6 +62,7 @@ We cannot adopt Miriad directly (requires persistent connections, long-running a
 **Finding**: Agents defined as `system.agent` artifacts with engine, MCP servers, identity. Pluggable engine system (claude-sdk, nuum).
 
 **Relevance**:
+
 - ✅ Structured agent metadata - enhance our `.claude/agents/*.md` files
 - ✅ MCP server configuration - adopt their format
 - ⚠️ Engine abstraction - future consideration
@@ -70,6 +73,7 @@ We cannot adopt Miriad directly (requires persistent connections, long-running a
 **Finding**: Uses `@anthropic-ai/claude-agent-sdk` with session resume/fork, MCP integration, permission modes.
 
 **Relevance**:
+
 - ✅ Session management concepts - adapt for file-based sessions
 - ✅ MCP configuration format - directly adoptable
 - ✅ Permission modes - inform our tool access patterns
@@ -162,7 +166,7 @@ The evaluator flagged KIT-ADR-0021 as NEEDS_REVISION with these concerns:
 
 **Our adaptation**:
 
-```
+```text
 Error Handling Strategy (File-Based)
 ────────────────────────────────────
 
@@ -195,7 +199,7 @@ Error Handling Strategy (File-Based)
 
 **Our adaptation**:
 
-```
+```text
 Resource Management Strategy
 ────────────────────────────
 
@@ -228,7 +232,7 @@ Add Option C (file watcher) for agents needing faster response.
 
 **Our response**:
 
-```
+```text
 Testing Strategy
 ────────────────
 
@@ -269,7 +273,7 @@ Testing Strategy
 
 ## Revised ADR Recommendations
 
-### Update KIT-ADR-0021 with:
+### Update KIT-ADR-0021 with
 
 1. **Concrete file-based protocol** (not just fallback)
 2. **Error handling strategy** from Miriad learnings
@@ -298,7 +302,7 @@ Testing Strategy
 
 **Deliverables**:
 
-```
+```text
 .kit/context/
 ├── channels/
 │   └── main/
@@ -311,6 +315,7 @@ Testing Strategy
 ```
 
 **Functions**:
+
 ```python
 # message.py
 class Message:
@@ -336,6 +341,7 @@ def update_roster(channel: str, agent: str, status: str) -> None
 ```
 
 **Tests**:
+
 - `tests/test_message.py`
 - `tests/test_channel.py`
 
@@ -345,7 +351,7 @@ def update_roster(channel: str, agent: str, status: str) -> None
 
 **Deliverables**:
 
-```
+```text
 scripts/
 ├── agent-wrapper.sh           # Wraps agent with inbox check
 └── project (updated)
@@ -353,7 +359,8 @@ scripts/
 ```
 
 **Agent Startup Flow**:
-```
+
+```text
 1. Agent starts
 2. Read roster.json, update own status to "active"
 3. Read messages.ndjson, filter to own @mentions
@@ -364,6 +371,7 @@ scripts/
 ```
 
 **CLI Commands**:
+
 ```bash
 ./scripts/project message send @feature-developer "Task ready"
 ./scripts/project message list --channel main --since 1h
@@ -376,7 +384,7 @@ scripts/
 
 **Deliverables**:
 
-```
+```text
 scripts/
 ├── channel-watch.sh           # Real-time message display
 └── project (updated)
@@ -384,6 +392,7 @@ scripts/
 ```
 
 **Human Capabilities**:
+
 ```bash
 # Watch channel in real-time
 ./scripts/project channel watch main
@@ -396,7 +405,8 @@ scripts/
 ```
 
 **Display Format** (terminal):
-```
+
+```text
 [10:30:05] @human → @planner
   Please prioritize ASK-0050
 
@@ -413,7 +423,7 @@ scripts/
 
 **Deliverables**:
 
-```
+```markdown
 # Enhanced task frontmatter
 ---
 id: ASK-0050
@@ -429,6 +439,7 @@ channel: main
 ```
 
 **Dependency CLI**:
+
 ```bash
 ./scripts/project task deps ASK-0050
 ./scripts/project task refs KIT-ADR-0021
@@ -495,6 +506,7 @@ Miriad demonstrates that real-time multi-agent communication is achievable and v
 By building a **file-based Tymbal variant**, we get the benefits of structured agent communication while preserving our CLI-first, file-based, ephemeral-agent architecture.
 
 **Next Steps**:
+
 1. Revise KIT-ADR-0021 with these recommendations
 2. Run evaluation on revised ADR
 3. Create implementation task (ASK-00XX)

--- a/.kit/context/research/miriad/TYMBAL-PROTOCOL.md
+++ b/.kit/context/research/miriad/TYMBAL-PROTOCOL.md
@@ -29,7 +29,7 @@ Tymbal is Miriad's custom streaming protocol for real-time agent communication. 
 
 ### Connection Lifecycle
 
-```
+```text
 Client ────► WebSocket Connect to /threads/{threadId}/stream
          ◄──── Server accepts (even before thread exists)
 
@@ -85,7 +85,7 @@ Server ────► Close code 1000 (normal) / 4004 (not found) / 4009 (compl
 
 ### Message Flow Pattern
 
-```
+```text
 User Input
     │
     ▼
@@ -126,6 +126,7 @@ getAddressedAgents(content) → ['builder', 'reviewer']
 ### Visibility Scoping
 
 Agents see messages only when:
+
 1. They are explicitly `@mentioned`
 2. They are the sender
 3. Message is a `@channel` broadcast
@@ -138,7 +139,7 @@ Agents see messages only when:
 
 ### State Machine
 
-```
+```text
 ┌─────────┐
 │ offline │ (initial / suspended)
 └────┬────┘
@@ -172,7 +173,7 @@ Agents see messages only when:
 
 ### Reconnection Strategy
 
-```
+```text
 Disconnect detected
     │
     ├── Wait 1s, retry
@@ -222,14 +223,14 @@ Disconnect detected
 | **Transport** | Real-time streaming | Async file I/O |
 | **Server** | Required (Hono/PostgreSQL) | Optional |
 
-### Cannot Adopt Directly Because:
+### Cannot Adopt Directly Because
 
 1. **Persistent Connections Required**: Tymbal assumes WebSocket stays open
 2. **Long-Running Agents Assumed**: State transitions (offline→online→busy) require continuity
 3. **Server Infrastructure**: Needs backend for routing, storage, sync
 4. **Web Interface**: Designed for browser rendering, not CLI
 
-### Can Adapt These Concepts:
+### Can Adapt These Concepts
 
 1. **Message Taxonomy**: User, Agent, ToolCall, ToolResult, Thinking types
 2. **Mention Routing**: `@agent` addressing pattern
@@ -244,6 +245,7 @@ Disconnect detected
 ### Decision: **ADAPT**
 
 Build a **file-based Tymbal variant** that:
+
 - Uses the same message type taxonomy
 - Implements mention-based routing via file naming/metadata
 - Provides visibility scoping through file organization
@@ -281,7 +283,7 @@ Build a **file-based Tymbal variant** that:
 
 ### Directory Structure
 
-```
+```text
 .kit/context/channels/
 ├── main/                    # Default channel
 │   ├── messages.ndjson      # Append-only message log
@@ -305,7 +307,7 @@ Build a **file-based Tymbal variant** that:
 
 ### Ephemeral Agent Flow
 
-```
+```text
 Agent Starts
     │
     ├── Read roster.json (am I active?)

--- a/.kit/context/retros/KIT-0104-pr3-retro.md
+++ b/.kit/context/retros/KIT-0104-pr3-retro.md
@@ -1,0 +1,156 @@
+## KIT-0104 — Ship the door in the package, PR 3 of 3: the prose sweep + KIT-0094 passenger (PR #131)
+
+**Date**: 2026-08-14
+**Agent**: feature-developer-f5
+**Mode**: single-repo
+**Scorecard**: 8 threads, 1 regression, 1 fix round, 6 commits
+<!-- PR 3 only. Task aggregate across the series (planner totals):
+     PR 1 (#129) + PR 2 (#130, 8 threads/3 rounds per its starter) +
+     PR 3 (#131, 8 threads/1 round). -->
+
+### What Worked
+
+1. **Land the gate before the churn** — the handoff's "lint config
+   EARLY" ordering meant commits 1–2 (config, sweep) preceded every
+   prose edit, so all later commits passed the gate they installed.
+   The acceptance criterion was then *observed*, not argued:
+   CodeRabbit's round on a 110-file markdown-heavy PR produced ZERO
+   markdown-style threads — all 7 of its findings were content. The
+   KIT-0094 bet (own the lint, retire the nit class) paid out on its
+   own PR.
+2. **Falsify-once beat evaluator opinion for the behavioral hunk** —
+   the only behavior in the PR (pre-commit gate) was proven by
+   planting a bare fence (hook exit 1) and restoring (pass), which
+   is stronger evidence than any diff-reading. Paired with fast-only
+   trio per the prose-sweep exception, Gate 5 cost ~$0.01 and the
+   FAIL verdict was correctly refuted against the tree in minutes
+   (the "conflicting ADR-0021 pair" carries a literal `Supersedes:`
+   header — third consecutive prose-sweep where the evaluator's
+   verdict was noise and tree-grounding was the real filter).
+3. **Empirical check of the hook mechanics prevented a footgun** —
+   before wiring pre-commit, a 2-minute experiment showed
+   markdownlint-cli2 CLI paths EXTEND config globs and BYPASS
+   `ignores` (an explicitly-passed excluded task spec got linted).
+   `pass_filenames: false` + tree-wide run (~2 s) was chosen from
+   evidence, not the hook's README default — a filename-passing hook
+   would have false-failed every task-bookkeeping commit.
+4. **Autofix + verify-by-sorted-diff for the CHANGELOG merge** — the
+   MD024 fix (merging 10 duplicate section headings) was verified by
+   diffing sorted non-blank lines old-vs-new: exactly the 10 heading
+   lines vanished, zero content lines. Cheap proof that a 366-line
+   structural diff was content-preserving.
+5. **Reading the door's source before writing its docs** — F5 claims
+   were pulled from `door/__init__.py` (`note_env_keys`, target-parent
+   anchor) and the live `--help`, which caught two stale claims the
+   spec didn't list (adopt-copies caveat, kit-clone `.env` carryover)
+   and let me refute CodeRabbit's "should the door prompt for keys?"
+   thread with the recorded PR 1 decision.
+
+### What Was Surprising
+
+1. **The autofix renumbered lists into semantic changes** —
+   markdownlint `--fix` on MD029 turned "6./7." continuation steps
+   into "1./1." (babysit-pr.md Phase 4, bootstrap.md Step 6),
+   changing rendered numbering. The right fix was structural
+   (indent the fences INTO the list items) and had to be done by
+   hand. Autofix output needs a semantic pass, not just a lint pass.
+2. **BugBot reviewed while its check said "skipping"** — the
+   check-run stayed `skipping` the entire session while BugBot
+   posted a Medium-severity thread (KIT-0062's both-ways lying,
+   fifth face: skipping-yet-reviewing). Threads were the truth, as
+   the handoff warned.
+3. **CodeRabbit took ~35 min on the large diff** — round 1 on the
+   110-file PR far exceeded the usual cadence; the two-quiet-polls →
+   1200 s backoff rule handled it without burn. Round 2 (6-file
+   incremental) landed in under 10 min.
+4. **The sweep surfaced a pre-existing off-by-one in a printed
+   recipe** — setup-preset's config-home recipe ("take the parent of
+   the `--git-common-dir` path") has computed `<clone>` instead of
+   `<projects-parent>` since KIT-0058; nobody's preset ever loaded
+   from where that doc pointed. CodeRabbit caught it only because
+   the surrounding paragraph entered the diff. Fixed and verified
+   live from this worktree.
+
+### What Should Change
+
+1. **The MD029/list-continuation hazard belongs in the bot-triage /
+   patterns knowledge** — "markdownlint --fix renumbers continued
+   lists; repair structurally by indenting the interrupting block
+   into the list item" is a class, and the next doc sweep will hit
+   it. Suggest a `patterns.yml` entry (autofix_needs_semantic_pass)
+   citing babysit-pr.md/bootstrap.md.
+2. **Printed multi-step recipes should get the falsify-once
+   treatment** — the KIT-0058 config-home recipe shipped wrong and
+   stayed wrong for weeks because it was never executed as printed.
+   `displayed_commands_are_contracts` already exists; the delta is:
+   when WRITING a recipe, run it once in the session and paste the
+   output next to the claim (I did this for the corrected recipe;
+   the original never was).
+3. **Plugin Drift Guard needs a decided posture for content-touching
+   PRs** — it is red on main since 2026-08-12 and every PR touching
+   `.claude/` inherits + widens the red. Merging over a red required
+   documenting precedent by hand (PR comment + starter section).
+   Either the guard becomes advisory-on-PRs (required only on
+   main/release), or the release cadence keeps it green. Planner
+   call; the current state trains people to ignore a red check —
+   which is how KIT-0062 class incidents start.
+4. **Retro filename for multi-PR tasks** — this file is
+   `KIT-0104-pr3-retro.md` because PR 1/2 sessions were separate;
+   the template assumes one retro per task. Worked fine, but the
+   planner's archive sweep should know the per-PR pattern exists.
+
+### Permission Prompts Hit
+
+None. The workflow ran end-to-end (git, gh, npx markdownlint-cli2,
+pytest, pre-commit, evaluator via `bash -c` + `.env`) without a
+single permission stall.
+
+### Process Actions Taken
+
+- [ ] Add `autofix_needs_semantic_pass` (or extend an existing entry)
+      to `.kit/context/patterns.yml`: lint autofix renumbers
+      continued lists; repair structurally (planner)
+- [ ] Extend `displayed_commands_are_contracts` guidance: recipes are
+      executed once at authoring time, output pasted alongside
+      (planner; evidence: KIT-0058 config-home recipe wrong since
+      authoring)
+- [ ] Decide Plugin Drift Guard posture: advisory-on-PR vs
+      keep-required + release cadence (planner; then cut the plugin
+      release per KIT-0096 so the guard greens)
+- [ ] Record KIT-0062 fifth face in the bot-triage skill if not
+      already covered: BugBot check `skipping` while its review
+      thread is live
+- [ ] KIT-0094 completion: acceptance evidence in the PR 3 review
+      starter (zero markdown-style threads observed); move the task
+      when KIT-0104 closes
+
+### Incident Closure
+
+1. **markdownlint-cli2 CLI paths bypass config `ignores` and extend
+   globs** — *not-checkable note*: recorded where the decision
+   lives, in `.pre-commit-config.yaml`'s hook comment block (the
+   `pass_filenames: false` rationale names the behavior and the
+   empirical verification). A doctor check would be testing a
+   third-party CLI's argument semantics on every run — the config
+   comment at the single point of use is the cheap, correct home.
+2. **BugBot check-run `skipping` while a review thread was live** —
+   *triage-guide entry*: this is KIT-0062's documented class
+   (statuses lie both ways; threads are the truth) already carried
+   in the bot-triage skill and both fd agents' Phase 7; this session
+   adds the `skipping`-yet-reviewing face to the retro record. No
+   new surface needed — the existing rule ("verify via threads, not
+   status") diagnosed it correctly in real time.
+3. **Plugin Drift Guard red inherited from main by every
+   `.claude/`-touching PR** — *ESCALATED — awaiting planner
+   classification*: (a) the guard fails on all PRs and main pushes
+   since 2026-08-12 because the published plugin lags the tree, and
+   PRs #129/#130/#131 each merged/passed over it with hand-written
+   justification; (b) a doctor check doesn't fit (this is CI
+   posture, not local environment), a not-checkable note doesn't fit
+   (it IS checked — the check is just permanently red between
+   releases), a triage-guide entry alone would institutionalize
+   ignoring a required-looking red check; (c) question for the
+   planner: **should the drift guard be advisory on PRs (required
+   only on main/release-cut), or stay required with a release
+   cadence that keeps it green?** The answer converts this to either
+   a workflow-file change or a KIT-0096 cadence rule.

--- a/.kit/context/reviews/KIT-0104-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0104-evaluator-review.md
@@ -200,3 +200,51 @@ Trio complete pre-PR (KIT-0035 ordering honored). Fix commit for the
 probe follows this record. Full suite green (1110 passed, 13 skipped);
 grep proof of matrix single-ownership pinned as
 `tests/test_setup_door.py::TestShimStatic`.
+
+---
+
+## PR 3 — the prose sweep (F5/F6 + KIT-0094 passenger), 2026-08-14
+
+**Tier decision (recorded, not silent)**: PROSE-DOMINATED sweep →
+code-reviewer-fast ONLY, per the standing prose-sweep exception
+(KIT-0069 trio 0-for-7, KIT-0073 0-for-8; planner decision
+2026-07-28). Deep tier and claude-code deliberately skipped: the only
+behavior-bearing hunks are `.markdownlint-cli2.jsonc` +
+`.pre-commit-config.yaml` (the KIT-0094 gate), and that gate was
+**falsified live** — a planted bare fence failed the hook (exit 1),
+restore passed — which is stronger evidence than a diff-reading
+opinion. Everything else is markdown/comment/docstring prose. Input
+was `--format diff` (strings/docs-only shape, per the Phase 5 rule).
+
+**This PR still needs tree-grounded verification before merge**
+(sectioned verifiers against the branch) — that is the real gate for
+this PR shape; the planner owns it.
+
+### code-reviewer-fast (FAIL — verdict refuted against the tree)
+
+Log: `.adversarial/logs/KIT-0104-code-review-input--code-reviewer-fast.md`
+
+1. **"Conflicting ADRs KIT-ADR-0021 vs -B" (the FAIL driver)** —
+   REFUTED against the tree: `KIT-ADR-0021-B` line 9 declares
+   `**Supersedes**: KIT-ADR-0021 (original proposal)`; both are
+   Status: Proposed research records coexisting since 2026-03-30.
+   This PR touched them only to add MD040 fence languages. The
+   evaluator reconstructed a conflict from diff-only context — the
+   exact blind-spot class the prose-sweep exception exists for.
+2. **"Ambiguous API key handling on `agentive new`"** — NO CHANGE:
+   the doc states what the packaged door verifiably does
+   (`note_env_keys` in `door/__init__.py`: no kit-clone carryover,
+   says "No API keys seeded" out loud; PR 1 operator decision). The
+   doc already states the choice explicitly, which is what the
+   finding asked for.
+3. **"CHANGELOG references files not in the diff"** — NO CHANGE:
+   the KIT-0077 entry is a historical Unreleased entry from an
+   earlier PR; it appears in this diff only because the MD024
+   duplicate-heading merge moved section blocks. Changelogs
+   describing past PRs is the format working as intended.
+
+0 findings actioned / 3 dispositioned (1 refuted, 2 no-change-needed)
+— consistent with the two prior prose-sweep shutouts. KIT-0094
+acceptance evidence: config committed, sweep leaves in-scope files at
+0 issues (199 files linted), gate falsified once, full fast suite
+1018 passed both before and after the F5 rewrite.

--- a/.kit/context/templates/review-starter-template.md
+++ b/.kit/context/templates/review-starter-template.md
@@ -16,17 +16,20 @@
 ## Files Changed
 
 ### New Files
+
 - `path/to/new/file.py` - [brief description]
 
 ### Modified Files
+
 - `path/to/modified/file.py` - [what changed]
 
 ### Deleted Files
+
 - `path/to/deleted/file.py` - [why removed]
 
 ## Test Results
 
-```
+```text
 [Paste test output summary]
 - X tests passing
 - Y% coverage (if applicable)
@@ -62,6 +65,7 @@ Before requesting review, verify:
 **Ready for code-reviewer agent in new tab**
 
 To start review:
+
 1. Open new Claude Code tab
 2. Run: `.kit/launchers/launch code-reviewer`
 3. Reviewer will auto-detect this starter file

--- a/.kit/context/templates/review-template.md
+++ b/.kit/context/templates/review-template.md
@@ -71,7 +71,7 @@ List all issues found, categorized by severity:
 
 ---
 
-### If CHANGES_REQUESTED:
+### If CHANGES_REQUESTED
 
 **Required Changes** (must be addressed before re-review):
 
@@ -84,11 +84,12 @@ List all issues found, categorized by severity:
 
 ---
 
-### If ESCALATE_TO_HUMAN:
+### If ESCALATE_TO_HUMAN
 
 **Reason for Escalation**: [Why human judgment is needed]
 
 **Options for Human to Consider**:
+
 1. [Option A with trade-offs]
 2. [Option B with trade-offs]
 
@@ -96,7 +97,7 @@ List all issues found, categorized by severity:
 
 ---
 
-### If APPROVED:
+### If APPROVED
 
 **Ready for**: Move task to `5-done`
 

--- a/.kit/context/workflows/ADR-CREATION-WORKFLOW.md
+++ b/.kit/context/workflows/ADR-CREATION-WORKFLOW.md
@@ -13,6 +13,7 @@
 - ✅ When implementation approach changes significantly
 
 **Don't use for**:
+
 - ❌ Minor implementation details
 - ❌ Trivial code changes
 - ❌ Every small decision
@@ -89,11 +90,13 @@ class Example:
 
 ## Consequences
 
-### Positive:
+### Positive
+
 - What benefits do we get?
 - What problems does this solve?
 
-### Negative:
+### Negative
+
 - What trade-offs did we make?
 - What limitations does this introduce?
 - What technical debt did we accept?
@@ -101,12 +104,14 @@ class Example:
 ## Alternatives Considered
 
 ### Alternative 1: [Name]
+
 - **Description**: What was this approach?
 - **Pros**: Benefits
 - **Cons**: Drawbacks
 - **Why Not Chosen**: Specific reasons
 
 ### Alternative 2: [Name]
+
 - **Description**: ...
 - **Pros**: ...
 - **Cons**: ...
@@ -115,6 +120,7 @@ class Example:
 ## Results
 
 Real-world outcomes:
+
 - Test results (e.g., "300/350 tests passing, 0 regressions")
 - Performance metrics (e.g., "3ms average, down from 45ms")
 - User feedback (if available)
@@ -131,7 +137,8 @@ Real-world outcomes:
 
 **Last Updated**: YYYY-MM-DD
 **Reviewed**: YYYY-MM-DD
-```
+
+```markdown
 
 ---
 
@@ -211,4 +218,5 @@ created the ADR, e.g.:
 ---
 
 **Related Workflows**:
+
 - [TASK-COMPLETION-PROTOCOL.md](./TASK-COMPLETION-PROTOCOL.md) - Document completion when creating ADR

--- a/.kit/context/workflows/AGENT-CREATION-WORKFLOW.md
+++ b/.kit/context/workflows/AGENT-CREATION-WORKFLOW.md
@@ -37,7 +37,7 @@
 
 ### Decision Tree
 
-```
+```text
 Do I need a new agent?
     ↓
 Is this a distinct role that will be reused?
@@ -67,6 +67,7 @@ CREATE NEW AGENT ✅
 ### Required Information
 
 Before creating agent, gather:
+
 - **Agent name** (kebab-case, e.g., "api-tester", "docs-generator")
 - **One-sentence description** of agent's primary responsibility
 - **3-6 core responsibilities** (specific, actionable)
@@ -82,16 +83,19 @@ Before creating agent, gather:
 ### Step 1: Use Agent Template
 
 **Option A: Manual Copy**
+
 ```bash
 cp .kit/templates/AGENT-TEMPLATE.md .claude/agents/your-agent-name.md
 ```
 
 **Option B: Automation Script (Recommended)**
+
 ```bash
 scripts/optional/create-agent.sh your-agent-name "One sentence description"
 ```
 
 The automation script will:
+
 - Copy template to correct location
 - Perform basic substitutions ([agent-name], [description])
 - Create properly named file
@@ -122,10 +126,12 @@ tools:  # Select tools this agent needs
 ```
 
 **Model Selection Guide**:
+
 - **claude-sonnet-5**: Complex tasks, architectural decisions, coordination, code review
 - **claude-haiku-4-5**: Simple tasks, testing, straightforward implementations
 
 **Common Tool Combinations**:
+
 - **Implementation agents**: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 - **Review agents**: Read, Grep, Glob, WebSearch, WebFetch
 - **Coordination agents**: Read, Write, Edit, Bash, Glob, Grep, TodoWrite, WebSearch
@@ -148,6 +154,7 @@ Always begin your responses with your identity header:
 ```
 
 **Choose an appropriate emoji**:
+
 - 📋 Coordinator
 - 💻 Feature Developer
 - 🧪 Test Runner
@@ -175,6 +182,7 @@ List 3-6 specific, actionable responsibilities:
 ```
 
 **Good practices**:
+
 - ✅ Start with action verbs (Test, Validate, Create, Document, Report)
 - ✅ Be specific about domain (e.g., "external API" not "APIs")
 - ✅ Include coordination responsibilities if applicable
@@ -207,6 +215,7 @@ Follow these practices when testing APIs:
 **Critical**: Update the "When to Request Evaluation" scenarios for this agent's role.
 
 **Template provides generic examples**:
+
 ```markdown
 **When to Request Evaluation**:
 - [Role-specific scenario 1]
@@ -216,6 +225,7 @@ Follow these practices when testing APIs:
 ```
 
 **Replace with role-specific scenarios**:
+
 ```markdown
 **When to Request Evaluation**:
 - Ambiguous test acceptance criteria in task specification
@@ -395,11 +405,13 @@ git push -u origin [branch-name]
 ### Why This Matters
 
 The Evaluator workflow is a **critical quality assurance mechanism** that prevents:
+
 - ❌ Phantom work (implementing wrong solutions)
 - ❌ Wasted time (discovering issues after implementation)
 - ❌ Architectural drift (making decisions without validation)
 
 **Consistency across agents ensures**:
+
 - ✅ All agents have access to quality assurance
 - ✅ Uniform invocation pattern (reduces confusion)
 - ✅ Proper escalation safeguards (prevents infinite loops)
@@ -470,6 +482,7 @@ scripts/optional/create-agent.sh api-tester "API testing and validation speciali
 ### After Running Script
 
 You still need to manually:
+
 1. Edit agent file and customize all remaining [bracketed] sections
 2. Choose appropriate model (sonnet vs haiku)
 3. Select correct tools for agent's role
@@ -482,6 +495,7 @@ You still need to manually:
 ### Script Limitations
 
 The script handles **basic setup only**. It cannot:
+
 - ❌ Choose the right model for your use case
 - ❌ Select appropriate tools
 - ❌ Write role-specific guidelines
@@ -494,6 +508,7 @@ The script handles **basic setup only**. It cannot:
 ### Script Error Handling
 
 If script fails:
+
 - Check you provided both name and description
 - Ensure you're in project root directory
 - Verify template file exists at `.kit/templates/AGENT-TEMPLATE.md`
@@ -508,6 +523,7 @@ If script fails:
 **Symptom**: Agent fails to load, YAML parsing errors
 
 **Solution**:
+
 1. Check frontmatter YAML is properly formatted
 2. Ensure `---` delimiters are on their own lines
 3. Verify proper indentation (2 spaces for YAML)
@@ -539,6 +555,7 @@ name: api-tester
 **Symptom**: Created agent file but can't launch agent
 
 **Solution**:
+
 1. Verify file is in `.claude/agents/` directory
 2. Check filename matches `name:` in frontmatter
 3. Ensure file has `.md` extension
@@ -552,6 +569,7 @@ name: api-tester
 **Symptom**: Agent can't invoke Evaluator, gets errors
 
 **Solution**:
+
 1. Verify `.env` file exists with `OPENAI_API_KEY`
 2. Check `adversarial` CLI is installed and in PATH
 3. Ensure agent has `Bash` tool in tools list
@@ -565,6 +583,7 @@ name: api-tester
 **Symptom**: Agent file has [bracketed] text still present
 
 **Solution**:
+
 1. Search for all `[` characters in file
 2. Replace each [placeholder] with actual content
 3. Verify no placeholders remain before committing

--- a/.kit/context/workflows/COMMIT-PROTOCOL.md
+++ b/.kit/context/workflows/COMMIT-PROTOCOL.md
@@ -16,7 +16,7 @@
 
 ## Commit Message Format
 
-```
+```text
 <type>: <description>
 
 [optional body]
@@ -26,7 +26,7 @@
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
-### Types:
+### Types
 
 - `feat`: New feature
 - `fix`: Bug fix
@@ -36,7 +36,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - `chore`: Build, dependencies, tooling
 - `perf`: Performance improvements
 
-### Description Rules:
+### Description Rules
 
 - Use imperative mood ("Add feature" not "Added feature")
 - Start with lowercase (unless proper noun)
@@ -91,7 +91,8 @@ EOF
 
 ## Pre-commit Checks
 
-### Automatic (via pre-commit hooks):
+### Automatic (via pre-commit hooks)
+
 - ✅ trailing-whitespace: Remove trailing spaces
 - ✅ end-of-file-fixer: Ensure newline at EOF
 - ✅ check-yaml: Validate YAML syntax
@@ -101,7 +102,8 @@ EOF
 - ✅ flake8: Critical linting errors
 - ✅ pattern-lint: Project-specific DK rules (DK001, DK003)
 
-### Manual (you should do):
+### Manual (you should do)
+
 - ✅ Run pytest: Ensure tests pass
 - ✅ **Pre-run Black on new/edited Python files before staging**
   (`black <files>`) — letting the hook reformat mid-commit aborts the
@@ -130,6 +132,7 @@ EOF
 ### What It Does
 
 Runs the **SAME checks** as GitHub Actions:
+
 - Full test suite (including slow tests)
 - Coverage threshold check (`fail_under` gate in pyproject.toml, currently 80%)
 - Pre-commit hooks (formatting, linting)
@@ -162,6 +165,7 @@ After pushing to GitHub, you **MUST** verify that GitHub Actions CI/CD passes:
 ```
 
 **What It Does**:
+
 - Monitors GitHub Actions workflow runs
 - Polls every 20 seconds
 - Reports when workflows complete (pass/fail)
@@ -170,6 +174,7 @@ After pushing to GitHub, you **MUST** verify that GitHub Actions CI/CD passes:
 ### Why This Is Critical
 
 Even if `ci-check.sh` passes locally, CI can still fail due to:
+
 - Environment differences (Python versions, dependencies)
 - Race conditions not caught locally
 - Caching issues
@@ -195,6 +200,7 @@ Even if `ci-check.sh` passes locally, CI can still fail due to:
 **Soft Block Policy:**
 
 If CI is still running after timeout:
+
 - Check status manually: `gh run watch <run-id>`
 - You may proceed if you're confident (soft block)
 - Document decision in task completion notes
@@ -222,14 +228,16 @@ If CI is still running after timeout:
 
 ## Best Practices
 
-### ✅ DO:
+### ✅ DO
+
 - One logical change per commit
 - Descriptive commit message (explain WHY, not just WHAT)
 - Run tests before committing
 - Use HEREDOC format for multi-line messages
 - Include Claude Code attribution and co-author
 
-### ❌ DON'T:
+### ❌ DON'T
+
 - Don't commit secrets (.env files, credentials)
 - Don't commit generated files (unless required)
 - Don't use --no-verify (bypasses hooks) without good reason
@@ -242,12 +250,14 @@ If CI is still running after timeout:
 
 ## Special Cases
 
-### Amending Commits:
+### Amending Commits
+
 - Only amend commits that **haven't been pushed**
 - Check authorship first: `git log -1 --format='%an %ae'`
 - Use with caution: `git commit --amend`
 
-### Pre-commit Hook Failures:
+### Pre-commit Hook Failures
+
 - If black/ruff auto-formats files, stage the changes and commit again
 - If validation fails, fix the issues before committing
 - Don't skip hooks unless absolutely necessary
@@ -283,7 +293,8 @@ After pushing changes that affect task files (status changes, new tasks, complet
 ```
 
 **Expected Output (In Sync)**:
-```
+
+```text
 Linear Sync Status
 ==================
 Team: Your Team
@@ -296,7 +307,8 @@ Last sync: 2025-11-29 02:32:31 UTC
 ```
 
 **Expected Output (Mismatch)**:
-```
+
+```text
 Linear Sync Status
 ==================
 Team: Your Team
@@ -327,5 +339,6 @@ The GitHub Actions workflow runs `./scripts/core/project linearsync` on push. Af
 ---
 
 **Related Workflows**:
+
 - [TESTING-WORKFLOW.md](./TESTING-WORKFLOW.md) - Run tests before committing
 - [TASK-COMPLETION-PROTOCOL.md](./TASK-COMPLETION-PROTOCOL.md) - Completing tasks with commits

--- a/.kit/context/workflows/PR-SIZE-WORKFLOW.md
+++ b/.kit/context/workflows/PR-SIZE-WORKFLOW.md
@@ -80,12 +80,14 @@ Agent prompts, handoff files, and CLAUDE.md all contain hardcoded path reference
 break silently when the directory structure is inconsistent.
 
 **Indicators that a task is a structural migration:**
+
 - Primary work is `git mv` + find-and-replace path updates
 - Most changed files are renames (verifiable via `git diff --stat`)
 - The change is mechanically verifiable, not logically complex
 - Splitting would create a state where path references are inconsistent
 
 **The large-PR concern is mitigated because:**
+
 - Renames show as renames in `git diff`, not as add/delete
 - Path rewrites are mechanical and grep-verifiable
 - Reviewers can verify with `git diff --stat` + spot-checks

--- a/.kit/context/workflows/REVIEW-FIX-WORKFLOW.md
+++ b/.kit/context/workflows/REVIEW-FIX-WORKFLOW.md
@@ -4,7 +4,7 @@ When code-reviewer returns `CHANGES_REQUESTED`, this document describes the proc
 
 ## Overview
 
-```
+```text
                                     ┌─────────────────┐
                                     │  4-in-review/   │
                                     │   (task stays)  │

--- a/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md
+++ b/.kit/context/workflows/TASK-COMPLETION-PROTOCOL.md
@@ -34,12 +34,13 @@
 
 ## Handoff Document Format
 
-### Filename:
-```
+### Filename
+
+```text
 .kit/context/<TASK-ID>-HANDOFF-<agent-type>.md
 ```
 
-### Required Sections:
+### Required Sections
 
 ```markdown
 ## Task Summary
@@ -99,14 +100,16 @@ What should the next agent do with this?
 
 ## Best Practices
 
-### ✅ DO:
+### ✅ DO
+
 - Be thorough - don't skip checklist items
 - Include test metrics in handoff (before/after pass rates)
 - Document any known issues or limitations honestly
 - Provide clear next steps for the user or reviewing agent
 - Update agent-handoffs.json status to "task_complete" (planner, on main — KIT-0086)
 
-### ❌ DON'T:
+### ❌ DON'T
+
 - Don't mark task complete if tests are failing
 - Don't skip handoff document (critical for coordination)
 - Don't leave uncommitted changes
@@ -118,6 +121,7 @@ What should the next agent do with this?
 
 See existing handoffs for examples (finished tasks' handoffs live under
 `.kit/context/archive/`; write new ones to the flat `.kit/context/`):
+
 - `.kit/context/archive/ASK-0043-HANDOFF-feature-developer.md`
 - `.kit/context/archive/ASK-0044-HANDOFF-feature-developer.md`
 
@@ -133,6 +137,7 @@ See existing handoffs for examples (finished tasks' handoffs live under
 ---
 
 **Related Workflows**:
+
 - [TESTING-WORKFLOW.md](./TESTING-WORKFLOW.md) - Verify tests before completion
 - [COMMIT-PROTOCOL.md](./COMMIT-PROTOCOL.md) - Commit changes properly
 - [Evaluation guidance](../../../.claude/skills/code-review-evaluator/SKILL.md) - For planners assigning tasks

--- a/.kit/context/workflows/TESTING-WORKFLOW.md
+++ b/.kit/context/workflows/TESTING-WORKFLOW.md
@@ -161,6 +161,7 @@ is a commit-latency tool, not a merge gate.
 Tests now run automatically before every commit via pre-commit hooks:
 
 ### Fast Test Subset
+
 - **What runs**: All tests except those marked with `@pytest.mark.slow`
   (`pytest tests/ -x -m "not slow" --maxfail=3`)
 - **Real duration in THIS repo: ~3.5–4 minutes** (measured ~213 s /
@@ -177,6 +178,7 @@ Tests now run automatically before every commit via pre-commit hooks:
 ### Usage
 
 **Normal workflow** (tests run automatically):
+
 ```bash
 git commit -m "feat: Add new feature"
 # → Pre-commit hooks run:
@@ -188,6 +190,7 @@ git commit -m "feat: Add new feature"
 ```
 
 **Skip for WIP commits** (use sparingly):
+
 ```bash
 SKIP_TESTS=1 git commit -m "WIP: Work in progress"
 # → Tests skipped with warning
@@ -197,6 +200,7 @@ SKIP_TESTS=1 git commit -m "WIP: Work in progress"
 ### When Tests Fail
 
 If pre-commit hook blocks your commit:
+
 1. **Read the error message** - Shows which test(s) failed
 2. **Fix the test failure** - Address the root cause
 3. **Try committing again** - Tests will re-run
@@ -269,6 +273,7 @@ git commit -m "feat: add my feature"
 ### TDD Template
 
 See `tests/test_template.py` for a ready-to-use template with examples:
+
 - AAA pattern (Arrange, Act, Assert)
 - Edge case testing
 - Error handling tests
@@ -288,6 +293,7 @@ See `tests/test_template.py` for a ready-to-use template with examples:
 ### What ci-check.sh Does
 
 Runs the **SAME checks** as GitHub Actions CI:
+
 1. ✅ Full test suite (including slow tests)
 2. ✅ Coverage check (`fail_under` gate in pyproject.toml, currently 80%)
 3. ✅ Pre-commit hooks (formatting, linting)
@@ -318,6 +324,7 @@ kit never overwrites it, and it rides no sync tier. Without the hook,
 ### Usage
 
 **Before EVERY push**:
+
 ```bash
 ./scripts/core/ci-check.sh
 ```
@@ -328,6 +335,7 @@ GitHub (`./scripts/core/verify-ci.sh` or `/check-ci`).
 ### When ci-check.sh Fails
 
 If the script fails:
+
 1. **Read error output** - Shows which check failed (tests/coverage/hooks)
 2. **Fix the issue** - Address test failures or coverage drops
 3. **Run again** - Verify fix with `./scripts/core/ci-check.sh`
@@ -339,13 +347,15 @@ If the script fails:
 
 ## Best Practices
 
-### ✅ DO:
+### ✅ DO
+
 - Run full test suite before committing
 - Fix all new failures your code introduces
 - Maintain or improve overall pass rate
 - Update tests if implementation changes intentionally
 
-### ⚠️ USE CAUTION:
+### ⚠️ USE CAUTION
+
 - Don't commit if tests are failing (unless xfailed with justification)
 - Don't skip tests without good reason
 
@@ -415,6 +425,7 @@ that shells out must build an explicitly scrubbed env
 ---
 
 **Related Workflows**:
+
 - [COVERAGE-WORKFLOW.md](./COVERAGE-WORKFLOW.md) - Coverage measurement
 - [COMMIT-PROTOCOL.md](./COMMIT-PROTOCOL.md) - Committing after tests pass
 

--- a/.kit/context/workflows/WORKFLOW-FREEZE-POLICY.md
+++ b/.kit/context/workflows/WORKFLOW-FREEZE-POLICY.md
@@ -3,6 +3,7 @@
 ## Rule
 
 Do NOT edit workflow definitions during an active feature task. This includes:
+
 - Skill files (`.claude/skills/`)
 - Command files (`.claude/commands/`)
 - Agent definition files (`.claude/agents/`)
@@ -11,6 +12,7 @@ Do NOT edit workflow definitions during an active feature task. This includes:
 ## Rationale
 
 Mixing workflow changes with feature work creates:
+
 - **Noisy diffs**: Reviewers can't distinguish feature code from process changes
 - **Coupled risk**: A workflow typo can break an unrelated feature PR
 - **Untestable changes**: Workflow edits aren't covered by pytest

--- a/.kit/docs/KIT-MIGRATION-PLAYBOOK.md
+++ b/.kit/docs/KIT-MIGRATION-PLAYBOOK.md
@@ -39,7 +39,7 @@ your-project/
 │   │   ├── templates/     #     review-starter template, etc.
 │   │   └── workflows/     #     COMMIT-PROTOCOL, TESTING-WORKFLOW, etc.
 │   ├── docs/              #   builder documentation
-│   ├── launchers/         #   launch, onboarding, preflight scripts (from agents/ at root)
+│   ├── launchers/         #   launch ONLY (interactive agent menu); onboarding/preflight retired (KIT-0067 D1 — see Step 4)
 │   ├── skills/            #   RETIRED — KIT-0057 moved ALL skills to .claude/skills/;
 │   ├── tasks/             #   task specs (from delegation/tasks/)
 │   │   ├── 1-backlog/
@@ -193,10 +193,13 @@ git mv delegation/handoffs/* .kit/context/ 2>/dev/null
 
 ### Step 4: Retire launchers
 
-> **Updated (KIT-0067 D1)**: the kit retired `.kit/launchers/`
-> entirely — agents are invoked via new Claude Code tabs or
+> **Updated (KIT-0067 D1)**: the kit retired the legacy launcher
+> scripts (`agents/launch`, `agents/onboarding`, `agents/preflight`)
+> — agents are invoked via new Claude Code tabs or
 > `claude --agent <file>`, and setup runs through the one door
-> (`agentive new` / `agentive adopt` + `/new-project`). Do NOT
+> (`agentive new` / `agentive adopt` + `/new-project`). The single
+> survivor is `.kit/launchers/launch`, the interactive agent menu
+> (kept deliberately — KIT-0075); it is seeded fresh, so do NOT
 > migrate old launchers forward; delete them.
 
 ```bash
@@ -312,10 +315,11 @@ find . -type f \( -name "*.md" -o -name "*.yml" -o -name "*.yaml" \
     {} +
 ```
 
-Launcher references (`agents/launch`, `agents/onboarding`,
-`agents/preflight`) have no new path — the launchers were retired
-(KIT-0067 D1). Grep for them after the bulk sed and rewrite each site
-to the current invocation (`claude --agent .claude/agents/<name>.md`,
+Launcher references: `agents/onboarding` and `agents/preflight` have
+no new path — they were retired (KIT-0067 D1); `agents/launch`'s
+successor is `.kit/launchers/launch` (the interactive agent menu).
+Grep for all three after the bulk sed and rewrite each site to the
+current invocation (`claude --agent .claude/agents/<name>.md`,
 setup via `agentive new` / `agentive adopt`).
 
 **After sed — CRITICAL VERIFICATION:**

--- a/.kit/docs/KIT-MIGRATION-PLAYBOOK.md
+++ b/.kit/docs/KIT-MIGRATION-PLAYBOOK.md
@@ -22,7 +22,7 @@ as context. The agent should create a single feature branch and PR for the migra
 
 After migration, every kit repo should look like this:
 
-```
+```text
 your-project/
 ├── .adversarial/          # Evaluation (stays at root — CLI hardcodes path)
 ├── .claude/               # Implementation layer (stays — Claude Code constraint)
@@ -120,6 +120,7 @@ grep -r 'docs/decisions/' --include='*.md' --include='*.yml' --include='*.json' 
 ### 3. Check for repo-specific extras
 
 Look for things not in the standard layout:
+
 - `delegation/handoffs/` (old handoff location — some repos have this)
 - `delegation/tasks/evaluations/` (ADV has this)
 - `agents/` at root (launcher scripts — all repos have this)
@@ -329,6 +330,7 @@ grep -r 'docs/decisions/' --include='*.md' --include='*.yml' --include='*.json' 
 ```
 
 Any remaining references need manual attention. Common cases:
+
 - **Historical references** in retros, changelogs, commit messages: leave as-is
 - **Python code** referencing `delegation/` paths: update carefully (check logic)
 - **`.claude/settings.local.json`** permission patterns: update path globs
@@ -369,6 +371,7 @@ hardcoded paths.
 ### Step 13: Update Linear sync paths
 
 If the repo uses Linear sync, update:
+
 - `scripts/core/project` or `scripts/project` — task directory path
 - `scripts/optional/sync_tasks_to_linear.py` — task directory path
 - `.github/workflows/sync-tasks.yml` — path triggers

--- a/.kit/docs/KIT-MIGRATION-PLAYBOOK.md
+++ b/.kit/docs/KIT-MIGRATION-PLAYBOOK.md
@@ -196,8 +196,8 @@ git mv delegation/handoffs/* .kit/context/ 2>/dev/null
 > **Updated (KIT-0067 D1)**: the kit retired `.kit/launchers/`
 > entirely — agents are invoked via new Claude Code tabs or
 > `claude --agent <file>`, and setup runs through the one door
-> (`scripts/local/bootstrap` + `/new-project`). Do NOT migrate old
-> launchers forward; delete them.
+> (`agentive new` / `agentive adopt` + `/new-project`). Do NOT
+> migrate old launchers forward; delete them.
 
 ```bash
 # Retire the pre-kit launcher scripts (superseded by the setup door)
@@ -316,7 +316,7 @@ Launcher references (`agents/launch`, `agents/onboarding`,
 `agents/preflight`) have no new path — the launchers were retired
 (KIT-0067 D1). Grep for them after the bulk sed and rewrite each site
 to the current invocation (`claude --agent .claude/agents/<name>.md`,
-setup via `scripts/local/bootstrap`).
+setup via `agentive new` / `agentive adopt`).
 
 **After sed — CRITICAL VERIFICATION:**
 

--- a/.kit/templates/AGENT-TEMPLATE.md
+++ b/.kit/templates/AGENT-TEMPLATE.md
@@ -18,10 +18,12 @@ tools:
 You are a specialized [role description] agent for the this project. Your role is to [primary responsibilities].
 
 ## Response Format
+
 Always begin your responses with your identity header:
 [EMOJI] **[AGENT-NAME-UPPERCASE]** | Task: [current task description or "Agent Role Name"]
 
 ## Core Responsibilities
+
 - [Responsibility 1 - Be specific about what this agent does]
 - [Responsibility 2 - Focus on the unique value this agent provides]
 - [Responsibility 3 - Include coordination with other agents if applicable]
@@ -29,6 +31,7 @@ Always begin your responses with your identity header:
 - [Responsibility 5 - Optional: Add more as needed]
 
 ## Project Context
+
 - **Project**: [Your project name and brief description]
 - **Architecture**: [Your project's architecture - e.g., Python CLI, web app, etc.]
 - **Testing**: pytest-based TDD workflow (mandatory pre-commit hooks)
@@ -50,11 +53,13 @@ When you begin working on a task from `2-todo/`:
 ```
 
 This command:
+
 1. Moves the task file from `2-todo/` to `3-in-progress/`
 2. Updates `**Status**: Todo` → `**Status**: In Progress` in the file header
 3. Syncs to Linear (if task monitor daemon is running)
 
 **Example**:
+
 ```bash
 ./scripts/core/project start ASK-0042
 # Output: Moved ASK-0042 to 3-in-progress/, updated Status to In Progress
@@ -101,6 +106,7 @@ Request independent evaluation from an external evaluator agent when you encount
 **📖 Complete Guide**: `.claude/skills/code-review-evaluator/SKILL.md`
 
 **When to Request Evaluation**:
+
 - [Role-specific scenario 1 - e.g., "Ambiguous requirements in task specification"]
 - [Role-specific scenario 2 - e.g., "Design decisions with multiple valid approaches"]
 - [Role-specific scenario 3 - e.g., "Unclear acceptance criteria"]
@@ -119,6 +125,7 @@ adversarial evaluate .kit/tasks/2-todo/TASK-FILE.md
 ```
 
 **Reading Results**:
+
 ```bash
 # Evaluation output automatically saved to:
 # .adversarial/logs/<input-name>--<evaluator>.md
@@ -128,6 +135,7 @@ cat .adversarial/logs/TASK-2025-042-feature-name--*.md
 ```
 
 **Evaluation Output Format**:
+
 - **Verdict**: APPROVED / NEEDS_REVISION / REJECT
 - **Confidence**: HIGH / MEDIUM / LOW
 - **Strengths**: What the plan does well
@@ -136,6 +144,7 @@ cat .adversarial/logs/TASK-2025-042-feature-name--*.md
 - **Questions**: Clarifications needed from you
 
 **How to Use Feedback**:
+
 1. Read evaluation results from `.adversarial/logs/`
 2. Address CRITICAL concerns (must fix)
 3. Consider MEDIUM/LOW suggestions (use judgment)
@@ -144,6 +153,7 @@ cat .adversarial/logs/TASK-2025-042-feature-name--*.md
 6. Proceed with implementation when APPROVED
 
 **Iteration Limits (Prevent Infinite Loops)**:
+
 - **Maximum evaluations**: 2-3 iterations per task
 - **After 2 NEEDS_REVISION verdicts**: Escalate to user
 - **Diminishing returns**: Additional evaluations rarely add value
@@ -152,6 +162,7 @@ cat .adversarial/logs/TASK-2025-042-feature-name--*.md
 **When to Ask User Instead of Evaluator**:
 
 **❌ DON'T use Evaluator for:**
+
 - Strategic business decisions (pricing, features priority)
 - Subjective preferences (code style, naming conventions)
 - Resource allocation (time/budget trade-offs)
@@ -159,6 +170,7 @@ cat .adversarial/logs/TASK-2025-042-feature-name--*.md
 - Contradictory feedback from previous evaluation
 
 **✅ DO ask user when:**
+
 - Evaluator gives contradictory feedback across iterations
 - NEEDS_REVISION after 2 attempts (not making progress)
 - Design decision requires business context Evaluator lacks
@@ -166,6 +178,7 @@ cat .adversarial/logs/TASK-2025-042-feature-name--*.md
 - Blocking uncertainty that evaluation can't resolve
 
 **Example Escalation**:
+
 ```markdown
 "I've received evaluation feedback twice on TASK-2025-042:
 - Round 1: Suggested approach A ([reason])
@@ -179,6 +192,7 @@ This will help me proceed without further evaluation loops."
 ```
 
 **Technical Details**:
+
 - **Evaluator**: External AI via adversarial-workflow
 - **Runs**: Non-interactively via `echo y | ADVERSARIAL_UNATTENDED=1 adversarial <evaluator> <input>`
 - **API Key**: Varies by evaluator (see `adversarial list-evaluators`)
@@ -188,17 +202,20 @@ This will help me proceed without further evaluation loops."
 ## Quick Reference Documentation
 
 **Agent Coordination**:
+
 - Task specifications: `.kit/tasks/` (numbered folders: `2-todo/`, `3-in-progress/`, `5-done/`, etc.)
 - Agent procedures: `CLAUDE.md`
 - Your role context: `.kit/context/agent-handoffs.json` → `"[agent-name]"`
 - [Role-specific workflow documents - e.g., "Testing workflow: `.kit/context/workflows/TESTING-WORKFLOW.md`"]
 
 **Evaluation Workflow**:
+
 - **Complete guide**: `.claude/skills/code-review-evaluator/SKILL.md`
 - Quick command: `adversarial evaluate <task-file>` (you run this directly)
 - Output location: `.adversarial/logs/<input-name>--<evaluator>.md`
 
 **[Role-Specific Documentation]**:
+
 - [Link to relevant ADRs, e.g., "KIT-ADR-0004: Adversarial Workflow Integration"]
 - [Link to relevant technical docs]
 - [Link to relevant code examples or patterns]
@@ -270,12 +287,14 @@ If you push code changes to GitHub:
 [Add any additional sections specific to this agent's role]
 
 ### Example: Testing Requirements (for implementation agents)
+
 - Pre-commit: Tests run automatically (fast tests only)
 - Pre-push: Run `./scripts/core/ci-check.sh` before pushing (full test suite)
 - Manual: `pytest tests/ -v` for local verification
 - Coverage: Maintain or improve coverage baseline
 
 ### Example: Code Review Standards (for review agents)
+
 - Check for test coverage
 - Verify error handling
 - Ensure documentation updated

--- a/.kit/templates/OPERATIONAL-RULES.md
+++ b/.kit/templates/OPERATIONAL-RULES.md
@@ -21,6 +21,7 @@
 ### Resolution (2025-11-12)
 
 Added the following permissions to `.claude/settings.local.json`:
+
 - `Write`
 - `Edit`
 - `Glob`
@@ -33,7 +34,7 @@ Subagents can now perform filesystem operations when launched via Task tool.
 
 ## ✅ Task Tool Usage Guidelines
 
-### Task Tool CAN Now Be Used For:
+### Task Tool CAN Now Be Used For
 
 With proper permissions configured in `.claude/settings.local.json`, subagents launched via Task tool can:
 
@@ -53,11 +54,13 @@ With proper permissions configured in `.claude/settings.local.json`, subagents l
 ### Best Practices
 
 **When to use Task tool for implementation:**
+
 - ✅ Complex multi-step tasks that benefit from specialized agent context
 - ✅ Tasks where delegation improves clarity and separation of concerns
 - ✅ When you want implementation work tracked in a separate agent context
 
 **When to use direct tools:**
+
 - ✅ Simple, single-file edits in main conversation
 - ✅ Quick fixes that don't need specialized agent overhead
 - ✅ When you're already in the appropriate agent context
@@ -65,6 +68,7 @@ With proper permissions configured in `.claude/settings.local.json`, subagents l
 ### User Instruction Clarification
 
 The `.claude/CLAUDE.md` instruction **"Always launch agents in new tabs"** can mean:
+
 - ✅ **UI tabs in Claude Desktop** (multiple conversations) - preferred for user visibility
 - ✅ **Task tool invocations** (now functional with proper permissions) - acceptable for complex delegated work
 
@@ -73,11 +77,13 @@ The `.claude/CLAUDE.md` instruction **"Always launch agents in new tabs"** can m
 ## Verification
 
 After completing work that should modify files (whether via Task tool or direct):
+
 1. ✅ Check `git status` shows actual changes
 2. ✅ Verify files exist at expected paths
 3. ✅ Confirm commits appear in `git log`
 
 If any verification fails, check:
+
 - Are the required tools in `.claude/settings.local.json` permissions?
 - Did the operation complete without errors?
 
@@ -118,6 +124,7 @@ If subagents report creating files but nothing appears on disk, check `.claude/s
 **Correct location**: `docs/adr/ADR-NNNN-short-title.md`
 
 **DO NOT create ADRs in**:
+
 - ❌ `.claude/` (agent/settings directory, not for project documentation)
 - ❌ Root directory
 - ❌ `.kit/context/` (coordination files only)
@@ -129,6 +136,7 @@ If subagents report creating files but nothing appears on disk, check `.claude/s
 **Correct location**: `.kit/tasks/[status-folder]/TASK-NNNN-title.md`
 
 Status folders:
+
 - `1-backlog/` - Planned but not started
 - `2-todo/` - Ready for work
 - `3-in-progress/` - Currently being worked on
@@ -166,7 +174,8 @@ All agent definitions and slash commands live in `.claude/`. Templates, launcher
 ### Why This Matters
 
 macOS Homebrew Python is "externally managed" and blocks system-wide pip installs:
-```
+
+```text
 error: externally-managed-environment
 × This environment is externally managed
 ```
@@ -192,7 +201,8 @@ pip install -e ".[dev]"
 ### Detecting Corrupted venv
 
 If you see:
-```
+
+```text
 ⚠️  Corrupted venv detected (missing python)
 ```
 

--- a/.kit/templates/TASK-STARTER-TEMPLATE.md
+++ b/.kit/templates/TASK-STARTER-TEMPLATE.md
@@ -89,7 +89,7 @@ a minimal one. Include each WHEN it applies; omit silently when not:
   agent must leave alone, with the parking place for discovered gaps
   (usually `1-backlog/`).
 - **Evaluation status** — if the spec was evaluated, one line: verdict
-  + where the dispositions live ("don't re-litigate").
+  - where the dispositions live ("don't re-litigate").
 - **Success metrics** — quantitative/qualitative targets, for tasks
   where "done" has measurable shape beyond the ACs.
 - **Contract-string cautions** — when the task touches text that tests

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,76 @@
+// markdownlint-cli2 config — KIT-0094: own the markdown lint locally so
+// style violations fail pre-commit instead of becoming bot review
+// threads (CodeRabbit runs markdownlint-cli2 against every PR; this
+// config is the same tool, run before the push).
+//
+// Scope: LIVE markdown only. Historical records stay as written — the
+// ignore list below mirrors the .coderabbitignore precedent (evaluator
+// artifacts, reviews, retros, handoffs, task specs) plus the archive
+// folders.
+{
+  "config": {
+    "default": true,
+
+    // Line length: OFF. This repo's prose deliberately uses long
+    // tables, links, and one-line shell commands (KIT-0094 F1).
+    "MD013": false,
+
+    // Ordered-list prefix style: allow BOTH `1. 1. 1.` and sequential
+    // `1. 2. 3.` (each list self-consistent). Decision recorded once
+    // here (KIT-0092 retro #6): the PR #118 MD029 thread was CodeRabbit
+    // linting numbering that only looked wrong inside a diff hunk —
+    // MD029-on-adjacent-hunk-context-lines is a known false-positive
+    // class; judge it against the whole file, never the hunk.
+    "MD029": { "style": "one_or_ordered" },
+
+    // Inline HTML: the kit's markdown carries structural HTML on
+    // purpose (KIT-LOCAL region markers render as comments, but agent
+    // docs also embed <details>/<summary> and line-break tags).
+    "MD033": false,
+
+    // Duplicate headings: allowed when not siblings — retro/handoff
+    // formats repeat section names across different parents.
+    "MD024": { "siblings_only": true },
+
+    // First line need not be a top-level heading: command/agent files
+    // open with YAML frontmatter followed by blockquote banners.
+    "MD041": false,
+
+    // Emphasis-as-heading: OFF. Templates and agent docs use bold
+    // pseudo-headings (`**Status**`, `**Watch for**`) deliberately;
+    // converting them to real headings would reword prose, which the
+    // KIT-0094 sweep explicitly does not do.
+    "MD036": false,
+
+    // Table pipe/column style: OFF. Introduced in markdownlint v0.41;
+    // never bot-flagged here, and enforcing one pipe-spacing style
+    // across ~1,200 hand-aligned table cells is churn without value.
+    "MD060": false
+  },
+  "globs": ["**/*.md"],
+  "ignores": [
+    // Tooling / dependency trees
+    "node_modules/**",
+    ".venv/**",
+    // Test fixtures are test DATA, not prose — several are byte-pinned
+    // by the suite; a lint autofix here breaks tests, not style
+    "tests/fixtures/**",
+    // Historical records stay as written (.coderabbitignore precedent)
+    ".adversarial/inputs/**",
+    ".adversarial/logs/**",
+    ".adversarial/artifacts/**",
+    ".kit/context/reviews/**",
+    ".kit/context/retros/**",
+    ".kit/context/archive/**",
+    ".kit/context/*-REVIEW-STARTER.md",
+    ".kit/context/*-HANDOFF-*.md",
+    // Task specs are working records, not published docs — CodeRabbit
+    // does not review them (.coderabbitignore) and neither do we
+    ".kit/tasks/**",
+    // Archived docs
+    "docs/archive/**",
+    // Byte-pinned packaged twins of live docs (tests/test_door_data_sync.py):
+    // linting the kit-tree source is sufficient; fixes mirror by test.
+    "packages/agentive-kit/src/agentive_kit/door/data/**"
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,21 @@ repos:
           '--select=E9,F63,F7,F82'
         ]
 
+  # Markdown lint (KIT-0094) — same tool CodeRabbit runs, gated locally
+  # so style violations fail here instead of becoming bot threads.
+  # pass_filenames: false is deliberate: the config's `ignores`
+  # (historical records, task specs, packaged twins) do NOT shield
+  # files passed explicitly on the command line, and CLI paths EXTEND
+  # the config globs rather than replace them — so the hook lints the
+  # whole tree via the config's own globs (~2 s), exactly the surface
+  # CodeRabbit sees. Scope and rule decisions: .markdownlint-cli2.jsonc
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.23.2
+    hooks:
+      - id: markdownlint-cli2
+        name: Lint markdown (markdownlint-cli2, KIT-0094)
+        pass_filenames: false
+
   # Project-specific pattern lint (catches recurring bot-finding patterns)
   - repo: local
     hooks:

--- a/.serena/claude-code/SETUP-GUIDE.md
+++ b/.serena/claude-code/SETUP-GUIDE.md
@@ -12,16 +12,19 @@
 This guide provides step-by-step instructions for installing and configuring Serena MCP (Model Context Protocol) server for semantic code navigation in Claude Code.
 
 **What is Serena?**
+
 - LSP-based semantic code navigation tool
 - Provides symbol finding, reference tracking, and code structure analysis
 - Integrates with Claude Code via MCP
 
 **What you'll get**:
+
 - 70-85% token reduction for Python code navigation
 - 2-4x faster symbol/reference finding
 - 100% precision (vs 43-60% for traditional Grep)
 
 **Limitations**:
+
 - ⚠️ **Python-only** (TypeScript/JavaScript not currently indexed)
 - ✅ Works in main conversations
 - ❓ Agent tab support (requires testing - see note below)
@@ -33,18 +36,21 @@ This guide provides step-by-step instructions for installing and configuring Ser
 ### Required Software
 
 1. **Claude Code CLI**
+
    ```bash
    claude --version
    # Should show version 0.1.x or higher
    ```
 
 2. **UV (Python Package Manager)**
+
    ```bash
    uv --version
    # Should show 0.4.x or higher
    ```
 
    **If not installed**:
+
    ```bash
    # macOS/Linux
    curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -54,12 +60,14 @@ This guide provides step-by-step instructions for installing and configuring Ser
    ```
 
 3. **Python 3.10+**
+
    ```bash
    python3 --version
    # Should show 3.10.x or higher
    ```
 
 4. **Python LSP Server (pylsp)**
+
    ```bash
    # Check if installed
    which pylsp
@@ -83,16 +91,19 @@ This guide provides step-by-step instructions for installing and configuring Ser
 ### Step 1: Install Serena MCP Server
 
 **Command**:
+
 ```bash
 claude mcp add-json "serena" '{"command":"uvx","args":["--from","git+https://github.com/oraios/serena","serena","start-mcp-server"]}'
 ```
 
 **Expected Output**:
-```
+
+```text
 Added MCP server 'serena' to config
 ```
 
 **What this does**:
+
 - Registers Serena as an MCP server in Claude Code configuration
 - Uses `uvx` to run Serena from GitHub repository
 - No manual JSON editing required (unlike Claude Desktop setup)
@@ -102,17 +113,20 @@ Added MCP server 'serena' to config
 ### Step 2: Verify Installation
 
 **Command**:
+
 ```bash
 claude mcp list
 ```
 
 **Expected Output**:
-```
+
+```text
 Configured MCP servers:
   serena: ✓ Connected
 ```
 
 **If you see**:
+
 - ✅ `serena: ✓ Connected` → Installation successful
 - ❌ `serena: ✗ Not connected` → Troubleshoot (see below)
 - ❌ `No MCP servers configured` → Re-run Step 1
@@ -124,6 +138,7 @@ Configured MCP servers:
 **Important**: MCP tools load at conversation start
 
 **If testing immediately after installation**:
+
 1. Exit current conversation
 2. Start new Claude Code conversation
 3. MCP tools will be available in new session
@@ -135,11 +150,13 @@ Configured MCP servers:
 ### Test 1: Check Tool Availability
 
 **In Claude Code conversation**, ask:
-```
+
+```text
 Do you have tools starting with "mcp__serena__"? If so, list them.
 ```
 
 **Expected Tools** (29 total):
+
 - `mcp__serena__find_symbol`
 - `mcp__serena__activate_project`
 - `mcp__serena__search_for_pattern`
@@ -158,11 +175,13 @@ Do you have tools starting with "mcp__serena__"? If so, list them.
 ### Test 2: Activate Project
 
 **In your codebase directory**, run in Claude Code:
-```
+
+```text
 Use mcp__serena__activate_project to activate the current project
 ```
 
 **Expected Output**:
+
 ```json
 {
   "result": "The project 'your-project' at /path/to/project is activated.\nProgramming languages: python; file encoding: utf-8"
@@ -170,6 +189,7 @@ Use mcp__serena__activate_project to activate the current project
 ```
 
 **Verify**:
+
 - ✅ Shows your project path
 - ✅ Lists "Programming languages: python"
 - ✅ No errors
@@ -179,11 +199,13 @@ Use mcp__serena__activate_project to activate the current project
 ### Test 3: Find a Symbol
 
 **Try finding a real class** in your codebase:
-```
+
+```text
 Use mcp__serena__find_symbol to find a class named "YourClassName"
 ```
 
 **Expected**:
+
 ```json
 {
   "name_path": "YourClassName",
@@ -206,6 +228,7 @@ Use mcp__serena__find_symbol to find a class named "YourClassName"
 **Symptom**: `claude mcp list` shows no servers
 
 **Solution**:
+
 ```bash
 # Re-run installation command
 claude mcp add-json "serena" '{"command":"uvx","args":["--from","git+https://github.com/oraios/serena","serena","start-mcp-server"]}'
@@ -219,6 +242,7 @@ claude mcp list
 ### Issue 2: "serena: ✗ Not connected"
 
 **Possible Causes**:
+
 1. UV not installed or not in PATH
 2. Network issues (GitHub repository access)
 3. Python LSP server not installed
@@ -226,6 +250,7 @@ claude mcp list
 **Solutions**:
 
 **Check UV**:
+
 ```bash
 which uvx
 # Should show: /Users/you/.local/bin/uvx or similar
@@ -235,6 +260,7 @@ export PATH="$HOME/.local/bin:$PATH"
 ```
 
 **Check LSP**:
+
 ```bash
 which pylsp
 # Should show path to pylsp
@@ -244,6 +270,7 @@ pip install 'python-lsp-server[all]'
 ```
 
 **Test Serena manually**:
+
 ```bash
 uvx --from 'git+https://github.com/oraios/serena' serena start-mcp-server
 # Should show Serena server output (Ctrl+C to exit)
@@ -258,6 +285,7 @@ uvx --from 'git+https://github.com/oraios/serena' serena start-mcp-server
 **Cause**: Tools load at conversation start (not dynamically)
 
 **Solution**:
+
 1. Exit current Claude Code conversation
 2. Start fresh conversation
 3. Tools will load in new session
@@ -273,6 +301,7 @@ uvx --from 'git+https://github.com/oraios/serena' serena start-mcp-server
 **Explanation**: **This is expected behavior** - Serena currently indexes Python only
 
 **Impact**:
+
 - ✅ Python files: Full semantic navigation
 - ❌ TypeScript/JavaScript: Not indexed (use traditional tools)
 
@@ -287,7 +316,8 @@ uvx --from 'git+https://github.com/oraios/serena' serena start-mcp-server
 **Cause**: Must call `activate_project` before other Serena operations
 
 **Solution**:
-```
+
+```text
 First use mcp__serena__activate_project("project-name")
 Then use other Serena tools
 ```
@@ -329,11 +359,13 @@ claude mcp remove serena  # to re-register from scratch
 ### Step 1: Activate Your Project
 
 **First time using Serena in a codebase**:
-```
+
+```text
 mcp__serena__activate_project("your-project-name")
 ```
 
 **This will**:
+
 - Index Python files in current directory
 - Configure LSP server for project
 - Enable semantic navigation
@@ -345,16 +377,19 @@ mcp__serena__activate_project("your-project-name")
 ### Step 2: Verify Indexing
 
 **Check what was indexed**:
-```
+
+```text
 Ask Claude: "How many Python files did Serena index?"
 ```
 
 **Example Output**:
-```
+
+```text
 Project activated: 1,123 Python files indexed out of 7,802 total files
 ```
 
 **Excluded automatically**:
+
 - `node_modules/`
 - `venv/`, `.venv/`
 - `.git/`
@@ -367,13 +402,15 @@ Project activated: 1,123 Python files indexed out of 7,802 total files
 ### Example 1: Find Class Definition
 
 **Traditional approach** (Grep + Read):
-```
+
+```text
 1. Grep for "class MyClass"
 2. Read entire file (~1,500 tokens for 700-line file)
 ```
 
 **Serena approach**:
-```
+
+```text
 mcp__serena__find_symbol("MyClass", include_body=false, depth=1)
 → Returns class structure with all methods (~500 tokens)
 → 70% token savings!
@@ -384,13 +421,15 @@ mcp__serena__find_symbol("MyClass", include_body=false, depth=1)
 ### Example 2: Find All References
 
 **Traditional approach**:
-```
+
+```text
 grep -r "MyClass"
 → Returns 7 files (3 code, 4 docs - manual filtering required)
 ```
 
 **Serena approach**:
-```
+
+```text
 mcp__serena__find_referencing_symbols("MyClass")
 → Returns 3 code references only (100% precision)
 → No manual filtering needed!
@@ -401,12 +440,14 @@ mcp__serena__find_referencing_symbols("MyClass")
 ### Example 3: Navigate Large File
 
 **Traditional approach**:
-```
+
+```text
 Read 707-line file → ~8,700 tokens
 ```
 
 **Serena approach**:
-```
+
+```text
 mcp__serena__find_symbol("MyClass/my_method", include_body=true)
 → Returns method only (~200 tokens)
 → 98% token savings!
@@ -421,6 +462,7 @@ mcp__serena__find_symbol("MyClass/my_method", include_body=true)
 **Current Status**: Only Python files are indexed
 
 **Impact**:
+
 - ✅ Python: Full semantic navigation
 - ❌ TypeScript/JavaScript: Not indexed
 - ❌ Shell/YAML/JSON: File finding only
@@ -436,9 +478,11 @@ mcp__serena__find_symbol("MyClass/my_method", include_body=true)
 **Status**: ❓ **Agent tab support unclear - requires testing**
 
 **Known Working**:
+
 - ✅ Main conversation in Claude Code: Tools available
 
 **Requires Testing**:
+
 - ❓ Agent tabs (specialized agents invoked in separate tabs)
 - ❓ Autonomous agent workflows
 
@@ -451,6 +495,7 @@ mcp__serena__find_symbol("MyClass/my_method", include_body=true)
 **Limit**: 25,000 token maximum for single tool response
 
 **Impact**:
+
 - ❌ Full recursive directory listing of large repos exceeds limit
 - ❌ Very broad pattern searches may overflow
 
@@ -463,6 +508,7 @@ mcp__serena__find_symbol("MyClass/my_method", include_body=true)
 **Limitation**: LSP cannot resolve runtime behavior
 
 **Impact**:
+
 - ✅ Decorators: Supported
 - ⚠️ Dynamic imports: May not resolve
 - ❌ Metaprogramming: Limited understanding
@@ -538,9 +584,9 @@ mcp__serena__find_symbol("MyClass/my_method", include_body=true)
 
 ### External Resources
 
-- **Serena GitHub**: https://github.com/oraios/serena
-- **Serena MCP Guide**: https://playbooks.com/mcp/oraios-serena
-- **LSP Protocol**: https://microsoft.github.io/language-server-protocol/
+- **Serena GitHub**: <https://github.com/oraios/serena>
+- **Serena MCP Guide**: <https://playbooks.com/mcp/oraios-serena>
+- **LSP Protocol**: <https://microsoft.github.io/language-server-protocol/>
 
 ### Project-Specific
 
@@ -553,6 +599,7 @@ mcp__serena__find_symbol("MyClass/my_method", include_body=true)
 ### Version 1.0 (2025-11-19)
 
 **Initial release** based on Phase 1-5 validation:
+
 - Installation via `claude mcp add-json` command
 - Python-only support documented
 - Token/speed metrics validated
@@ -577,6 +624,7 @@ After successful installation:
 You're now ready to use Serena for semantic Python code navigation in Claude Code.
 
 **Remember**:
+
 - ✅ Use for Python navigation (70-85% token savings)
 - ❌ Fall back to traditional tools for TypeScript/docs
 - 📊 Monitor your token usage to see real savings

--- a/.serena/claude-code/TYPESCRIPT-SETUP.md
+++ b/.serena/claude-code/TYPESCRIPT-SETUP.md
@@ -11,6 +11,7 @@
 This guide explains how to set up and verify TypeScript/JavaScript semantic navigation with Serena MCP for the `frontend/` directory.
 
 **Benefits**:
+
 - 65% average token reduction (vs traditional grep + file reads)
 - 2-3x faster code navigation
 - 100% precision reference tracking (no false positives)
@@ -23,18 +24,21 @@ This guide explains how to set up and verify TypeScript/JavaScript semantic navi
 ### Required Software
 
 ✅ **Node.js v16+** (Installed: v22.18.0)
+
 ```bash
 node --version
 # Output: v22.18.0 (or higher)
 ```
 
 ✅ **npm v8+** (Installed: v11.5.2)
+
 ```bash
 npm --version
 # Output: 11.5.2 (or higher)
 ```
 
 ✅ **Serena MCP** (Already configured)
+
 ```bash
 claude mcp list
 # Output should show: serena: ✓ Connected
@@ -51,6 +55,7 @@ claude mcp list
 The TypeScript Language Server is already installed globally via npm.
 
 **Verification**:
+
 ```bash
 which typescript-language-server
 # Expected: a path inside your node installation (e.g. ~/.nvm/versions/node/<version>/bin/typescript-language-server)
@@ -60,6 +65,7 @@ typescript-language-server --version
 ```
 
 **If not installed** (for other team members):
+
 ```bash
 npm install -g typescript-language-server typescript
 ```
@@ -71,6 +77,7 @@ npm install -g typescript-language-server typescript
 **IMPORTANT**: Serena detects language servers at MCP startup, not dynamically.
 
 **Required Action**:
+
 1. Close your current Claude Code session completely
 2. Restart Claude Code (or start a fresh conversation in new tab)
 3. This allows Serena to detect the TypeScript LSP
@@ -83,17 +90,19 @@ npm install -g typescript-language-server typescript
 
 In your **new** Claude Code conversation:
 
-```
+```text
 Please activate Serena for this project:
 mcp__serena__activate_project("your-project")
 ```
 
 **Expected Output**:
-```
+
+```text
 "Programming languages: python, swift, typescript"
 ```
 
 **If TypeScript is NOT shown**:
+
 1. Verify TypeScript LSP is installed (Step 1)
 2. Ensure you restarted Claude Code (Step 2)
 3. Check that TypeScript LSP is in your PATH
@@ -110,12 +119,14 @@ Run these tests in Claude Code to verify TypeScript semantic navigation works.
 **Objective**: Verify `find_symbol` works for React components
 
 **Test**:
-```
+
+```text
 Can you find the App component in the frontend directory using Serena?
 Expected tool: mcp__serena__find_symbol
 ```
 
 **Expected Result**:
+
 - Component found: `App` (Function, lines 6-13)
 - File: `frontend/src/App.tsx`
 - ✅ PASS if component found
@@ -127,12 +138,14 @@ Expected tool: mcp__serena__find_symbol
 **Objective**: Verify reference tracking works across files
 
 **Test**:
-```
+
+```text
 Can you find all references to the useWizard hook using Serena?
 File: frontend/src/context/WizardContext.tsx
 ```
 
 **Expected Result**:
+
 - References found in 4+ files
 - Includes imports and usages
 - ✅ PASS if references span multiple files
@@ -144,12 +157,14 @@ File: frontend/src/context/WizardContext.tsx
 **Objective**: Verify symbol overview for large files
 
 **Test**:
-```
+
+```text
 Can you get a symbol overview of WizardContext.tsx using Serena?
 Expected tool: mcp__serena__get_symbols_overview
 ```
 
 **Expected Result**:
+
 - 10 top-level symbols found
 - Includes: Functions, interfaces, constants
 - ✅ PASS if overview shows symbols without full file content
@@ -161,11 +176,13 @@ Expected tool: mcp__serena__get_symbols_overview
 **Objective**: Ensure Python still works
 
 **Test**:
-```
+
+```text
 Can you find the sync_task_to_linear function in the scripts directory using Serena?
 ```
 
 **Expected Result**:
+
 - Python function found in `scripts/linear_sync_stubs.py`
 - ✅ PASS if Python symbols still work
 
@@ -176,6 +193,7 @@ Can you find the sync_task_to_linear function in the scripts directory using Ser
 ### When to Use Serena for TypeScript
 
 ✅ **Use Serena for**:
+
 - Navigating React components (100+ lines)
 - Finding component references across files
 - Understanding component structure (hooks, handlers, state)
@@ -183,6 +201,7 @@ Can you find the sync_task_to_linear function in the scripts directory using Ser
 - Understanding context providers and consumers
 
 ❌ **Use traditional tools for**:
+
 - Small files (< 50 lines) - savings are minimal
 - Reading full file content - Serena shows structure, not full code
 - Simple string searches - grep is fine for non-symbol searches
@@ -196,7 +215,8 @@ Can you find the sync_task_to_linear function in the scripts directory using Ser
 **Goal**: Understand the structure of a large React component without reading full file.
 
 **Serena Approach**:
-```
+
+```text
 1. Get symbol overview:
    mcp__serena__get_symbols_overview("frontend/src/components/wizard/WizardContext.tsx")
 
@@ -218,7 +238,8 @@ Can you find the sync_task_to_linear function in the scripts directory using Ser
 **Goal**: Find all usages of a custom hook across the codebase.
 
 **Serena Approach**:
-```
+
+```text
 mcp__serena__find_referencing_symbols(
     name_path="useWizard",
     relative_path="frontend/src/context/WizardContext.tsx"
@@ -226,6 +247,7 @@ mcp__serena__find_referencing_symbols(
 ```
 
 **Benefit**:
+
 - 100% precision (only code references, no comments)
 - Shows context snippets for each usage
 - 60% token savings vs grep + reading multiple files
@@ -237,7 +259,8 @@ mcp__serena__find_referencing_symbols(
 **Goal**: Quickly jump to a component definition.
 
 **Serena Approach**:
-```
+
+```text
 mcp__serena__find_symbol(
     name_path_pattern="WizardRouter",
     relative_path="frontend/src"
@@ -281,12 +304,14 @@ Based on validation testing:
 **Solutions**:
 
 **A. Restart Claude Code (Most Common)**
+
 1. Close Claude Code completely
 2. Restart application
 3. Start fresh conversation
 4. Activate project again
 
 **B. Verify TypeScript LSP Installation**
+
 ```bash
 which typescript-language-server
 # Should return a path
@@ -296,6 +321,7 @@ typescript-language-server --version
 ```
 
 If not installed:
+
 ```bash
 npm install -g typescript-language-server typescript
 ```
@@ -316,6 +342,7 @@ export PATH="$HOME/.nvm/versions/node/<your-version>/bin:$PATH"  # substitute yo
 ```
 
 **D. Test LSP Server Directly**
+
 ```bash
 typescript-language-server --stdio
 # Should start without errors (Ctrl+C to exit)
@@ -330,14 +357,17 @@ typescript-language-server --stdio
 **Solutions**:
 
 **A. Check File Path**
+
 - Ensure `relative_path` points to correct directory
 - Example: `frontend/src` not `frontend`
 
 **B. Check Symbol Name**
+
 - Try partial name with `substring_matching=true`
 - Use `get_symbols_overview` first to see available symbols
 
 **C. Check File Type**
+
 - `.tsx` files work best for React components
 - `.ts` files (non-React) may have reduced support for re-exports
 
@@ -350,10 +380,12 @@ typescript-language-server --stdio
 **Solutions**:
 
 **A. Verify Symbol Definition**
+
 - Run `find_symbol` first to confirm symbol exists
 - Use exact `name_path` from find_symbol result
 
 **B. Check Import Paths**
+
 - References using path aliases (`@/components`) are tracked
 - References using relative paths (`../components`) are tracked
 - Both should work if `tsconfig.json` is correctly configured
@@ -367,17 +399,20 @@ typescript-language-server --stdio
 **Solutions**:
 
 **A. Check Project Size**
+
 - Serena indexes on-demand
 - First query may be slower (~5-10s)
 - Subsequent queries should be fast (~2-3s)
 
 **B. Restart Language Server**
-```
+
+```text
 Use Serena tool:
 mcp__serena__restart_language_server
 ```
 
 **C. Check System Resources**
+
 - Ensure adequate RAM (8GB+ recommended)
 - Close other resource-intensive applications
 
@@ -432,6 +467,7 @@ Serena correctly resolves these path aliases defined in `tsconfig.json`:
 ```
 
 **Supported Aliases**:
+
 - `@/components` → `src/components`
 - `@/context` → `src/context`
 - `@/hooks` → `src/hooks`
@@ -451,6 +487,7 @@ Serena correctly resolves these path aliases defined in `tsconfig.json`:
    - Verify Serena MCP connected: `claude mcp list`
 
 2. **Installation** (2 minutes)
+
    ```bash
    npm install -g typescript-language-server typescript
    ```
@@ -470,14 +507,16 @@ Serena correctly resolves these path aliases defined in `tsconfig.json`:
 ### Training Resources
 
 **Documentation**:
+
 - This setup guide (`.serena/claude-code/TYPESCRIPT-SETUP.md`)
 - Use case matrix (`docs/archive/SERENA-USE-CASES.md`, archived KIT-0077)
 - Python setup guide (`.serena/claude-code/SETUP-GUIDE.md`) - similar patterns
 
 **External References**:
-- TypeScript LSP: https://github.com/typescript-language-server/typescript-language-server
-- Serena GitHub: https://github.com/oraios/serena
-- LSP Protocol: https://microsoft.github.io/language-server-protocol/
+
+- TypeScript LSP: <https://github.com/typescript-language-server/typescript-language-server>
+- Serena GitHub: <https://github.com/oraios/serena>
+- LSP Protocol: <https://microsoft.github.io/language-server-protocol/>
 
 ---
 
@@ -486,6 +525,7 @@ Serena correctly resolves these path aliases defined in `tsconfig.json`:
 ### Q: Do I need to install TypeScript LSP separately from TypeScript compiler?
 
 **A**: Yes, but they're typically installed together:
+
 ```bash
 npm install -g typescript-language-server typescript
 ```
@@ -497,6 +537,7 @@ The LSP server (`typescript-language-server`) is separate from the TypeScript co
 ### Q: Will this affect my TypeScript compilation or build process?
 
 **A**: No. The TypeScript LSP is only for code navigation in Claude Code. It does not affect:
+
 - TypeScript compilation (`tsc`)
 - Build processes (`npm run build`)
 - Testing (`npm run test`)
@@ -521,7 +562,8 @@ The LSP server (`typescript-language-server`) is separate from the TypeScript co
 ### Q: What if I'm working on a different TypeScript project?
 
 **A**: The TypeScript LSP is installed globally and works for any TypeScript project. Just activate the project:
-```
+
+```text
 mcp__serena__activate_project("/path/to/your/project")
 ```
 
@@ -532,6 +574,7 @@ mcp__serena__activate_project("/path/to/your/project")
 **A**: Yes! Serena complements traditional tools (grep, read). Use Serena for semantic navigation and traditional tools for other tasks.
 
 **Best Practice**:
+
 - Serena: Component structure, reference tracking, symbol navigation
 - Traditional: Reading full implementations, string searches, file content
 
@@ -546,9 +589,9 @@ mcp__serena__activate_project("/path/to/your/project")
 
 ### External Support
 
-- **Serena GitHub**: https://github.com/oraios/serena
-- **TypeScript LSP Issues**: https://github.com/typescript-language-server/typescript-language-server/issues
-- **Claude Code Docs**: https://docs.claude.com/en/docs/claude-code
+- **Serena GitHub**: <https://github.com/oraios/serena>
+- **TypeScript LSP Issues**: <https://github.com/typescript-language-server/typescript-language-server/issues>
+- **Claude Code Docs**: <https://docs.claude.com/en/docs/claude-code>
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tests/test_preflight_check.py`, `tests/test_prepare_review_input.py`
   and `tests/test_gh_review_helper.py`, with no scenario coverage lost.
 
+- **dispatch-kit integration retired** (KIT-0077) — the operator no
+  longer runs it. `.dispatch/config.yml` is archived to
+  `docs/archive/dispatch-config.yml.archived`; `setup-dev.sh` loses its
+  `--with-dispatch` gate and both dispatch steps (2.0.0 — a removed
+  flag); the `local` extra leaves `pyproject.toml` (dispatch-kit was
+  its only member); and the unguarded `dispatch emit` instructions leave
+  the `code-reviewer` agent and the `/wrap-up` command.
+  What is retired is the kit's **adoption** of dispatch — configuration,
+  installer, and agent instructions. **Kept**: the `origin: dispatch-kit`
+  provenance headers; the guarded fire-and-forget emits in shipped
+  `scripts/core/` and the shipped commands (they still serve
+  `movito/dispatch-kit` as a downstream sync consumer, and on any machine
+  with the CLI on PATH they genuinely fire); the `.dispatch/` runtime
+  entries in `.gitignore` — precisely because those emits still
+  regenerate `bus.jsonl`, so it must stay ignored (verified: a preflight
+  run recreated it during this task); and every historical record.
+- **Two version-pinned docs archived** (KIT-0077):
+  `.kit/docs/UPGRADE-0.4.0.md` and `.serena/claude-code/USE-CASES.md`
+  moved to `docs/archive/` (the latter as `SERENA-USE-CASES.md`), with
+  all six live citers repointed.
+
 ### Changed
 
 - **The door ships in the package — KIT-ADR-0030** (KIT-0104, PRs
@@ -95,6 +116,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`agentive-config`) only, not the package name; ALLOWED back to the
   three genuine readers.
 
+- **`agent-handoffs.json` becomes single-writer** (KIT-0086 F1, landed
+  inside `agentive_kit.lifecycle` per KIT-0090 F6): lifecycle moves
+  write the shared coordination JSON only when the checkout is on
+  `main`; feature-branch (and undeterminable-branch) moves now produce
+  zero diff in it, ending the KIT-0084 / PR #105 squash-merge conflict
+  class. The task's own `HANDOFF-*.md` files are still rewritten on
+  every branch. The stale-path drift WARN (KIT-0086 F2) follows as a
+  doctor check in the doctor-migration PR.
+
+- **`.kit/context/` is legible again** (KIT-0077): the 100 handoffs,
+  review starters, and session records belonging to tasks in a terminal
+  folder moved to `.kit/context/archive/`. The flat listing is now live
+  coordination only (`agent-handoffs.json`, `patterns.yml`,
+  `current-state.json`, `REVIEW-INSIGHTS.md`, the in-flight task's
+  handoff). Pure `git mv` — no history lost. Both consumer copy paths
+  learned to drop the new directory: `engine-export.sh` gained an
+  explicit `rm -rf` (its `.kit/context/` scrubs are `-maxdepth 1`) and
+  `engine-materials.sh` an `--exclude='context/archive/'` (its task-ID
+  pattern is anchored at depth 1). A guard test now covers each path.
+
 ### Added
 
 - **`agentive-kit` package skeleton — KIT-ADR-0028 phase 1, PR 1**
@@ -145,53 +186,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keeps testing the package-less fallback path — recorded decision),
   and the script's help carries the one-release-cycle shim deprecation
   note (F5).
-
-### Changed
-
-- **`agent-handoffs.json` becomes single-writer** (KIT-0086 F1, landed
-  inside `agentive_kit.lifecycle` per KIT-0090 F6): lifecycle moves
-  write the shared coordination JSON only when the checkout is on
-  `main`; feature-branch (and undeterminable-branch) moves now produce
-  zero diff in it, ending the KIT-0084 / PR #105 squash-merge conflict
-  class. The task's own `HANDOFF-*.md` files are still rewritten on
-  every branch. The stale-path drift WARN (KIT-0086 F2) follows as a
-  doctor check in the doctor-migration PR.
-
-- **`.kit/context/` is legible again** (KIT-0077): the 100 handoffs,
-  review starters, and session records belonging to tasks in a terminal
-  folder moved to `.kit/context/archive/`. The flat listing is now live
-  coordination only (`agent-handoffs.json`, `patterns.yml`,
-  `current-state.json`, `REVIEW-INSIGHTS.md`, the in-flight task's
-  handoff). Pure `git mv` — no history lost. Both consumer copy paths
-  learned to drop the new directory: `engine-export.sh` gained an
-  explicit `rm -rf` (its `.kit/context/` scrubs are `-maxdepth 1`) and
-  `engine-materials.sh` an `--exclude='context/archive/'` (its task-ID
-  pattern is anchored at depth 1). A guard test now covers each path.
-
-### Removed
-
-- **dispatch-kit integration retired** (KIT-0077) — the operator no
-  longer runs it. `.dispatch/config.yml` is archived to
-  `docs/archive/dispatch-config.yml.archived`; `setup-dev.sh` loses its
-  `--with-dispatch` gate and both dispatch steps (2.0.0 — a removed
-  flag); the `local` extra leaves `pyproject.toml` (dispatch-kit was
-  its only member); and the unguarded `dispatch emit` instructions leave
-  the `code-reviewer` agent and the `/wrap-up` command.
-  What is retired is the kit's **adoption** of dispatch — configuration,
-  installer, and agent instructions. **Kept**: the `origin: dispatch-kit`
-  provenance headers; the guarded fire-and-forget emits in shipped
-  `scripts/core/` and the shipped commands (they still serve
-  `movito/dispatch-kit` as a downstream sync consumer, and on any machine
-  with the CLI on PATH they genuinely fire); the `.dispatch/` runtime
-  entries in `.gitignore` — precisely because those emits still
-  regenerate `bus.jsonl`, so it must stay ignored (verified: a preflight
-  run recreated it during this task); and every historical record.
-- **Two version-pinned docs archived** (KIT-0077):
-  `.kit/docs/UPGRADE-0.4.0.md` and `.serena/claude-code/USE-CASES.md`
-  moved to `docs/archive/` (the latter as `SERENA-USE-CASES.md`), with
-  all six live citers repointed.
-
-### Added
 
 - Builder-only commands (`/new-project`, `/setup-preset`, `/wrap-up`)
   now declare `distribution: builder-only` in frontmatter with a note
@@ -256,72 +250,6 @@ sweep + doc curation that grounded the docs in the tree.
   vector is closed — `project setup` refuses symlinked venvs), plus
   the `55-worktree-provisioning.sh` doctor check.
 
-### Changed
-
-- **Truth sweep + doc curation** (KIT-0069, KIT-0073): the pre-0.9.0
-  cruft audit's prose findings fixed and verified tree-grounded
-  (complete-coverage verification, residuals fixed same-day); a
-  33-document curation pass (trims, merges, archives) cut the README
-  from ~580 to 96 lines.
-- **Whole-repo aider purge + Python ceiling lift** (KIT-0065; core
-  scripts 3.7.0). Aider is retired everywhere; the four dead
-  `.adversarial/scripts/*.sh` wrappers (evaluate_plan,
-  proofread_content, review_implementation, validate_tests) are
-  deleted — the evaluation path is the `adversarial` CLI +
-  `scripts/core/prepare-review-input.sh`. Verified `adversarial init`
-  (1.0.x) does not re-provision them. The Python `requires-python`
-  ceiling `<3.13` — justified only by the retired dependency — is
-  lifted after the full suite and dev stack passed on 3.14
-  (`>=3.10` now; CI matrix runs 3.10/3.12/3.14). `project setup`
-  drops the uv-based 3.12-venv workaround and its detection helpers;
-  agent/template docs point at the current
-  `<input-name>--<evaluator>.md` log naming and the
-  `echo y | ADVERSARIAL_UNATTENDED=1` unattended invocation.
-
-### Fixed
-
-- **Functional repairs from the pre-0.9.0 cruft audit** (KIT-0068;
-  core scripts 3.6.0). Behavior-broken surfaces only — the audit's
-  prose findings are KIT-0069's, aider residue KIT-0065's:
-  - `project linearsync`, `project create-agent`, and `project
-    reconfigure`'s identity rewrite now target the real v0.4.0+ paths
-    (`scripts/optional/…`, `scripts/core/logging_config.py`) with
-    friendly errors naming the missing file on consumer checkouts
-    (A00/A01/A02/A11). The reconfigure test fixture that modeled the
-    pre-v0.4.0 layout — and masked the breakage for months — now
-    models the real tree, and a fixture-path guard test pins every
-    modeled path to the actual repo.
-  - Linear sync: the root `.env` resolves again from
-    `scripts/optional/` (A15), and any `[A-Z]{2,6}-NNNN` task id is
-    accepted — the hardcoded `TASK-|ASK-` patterns rejected every
-    live KIT-* task (A14).
-  - `engine-materials.sh` no longer ships `scripts/local/`, kit-only
-    tests, the kit's planning corpus (prefix-agnostic task/context
-    excludes), or `.kit/adversarial/` into consumers, names its drops
-    in output, and gained a `--scaffold-only` test seam with an
-    export-content test (A12/A13).
-  - `.adversarial/config.yml` regenerated from the template and
-    verified against the installed CLI 1.0.1; unread keys
-    (`auto_run`, `git_integration`, `save_artifacts`) deleted from
-    config + template (A67). Self-referential
-    `.adversarial/evaluators/evaluators` symlink removed and
-    `new-worktree.sh` now refuses to link over an existing
-    destination — the creation vector (A69).
-  - Toolchain agreement: pre-commit Black rev matches the pyproject
-    pin with a consistency test (A84); ruff is now enforced
-    (ci-check.sh step 4/7 + CI lint step; 24 mechanical violations
-    fixed) instead of declared-but-never-run (A88); ci-check.sh's
-    flake8 args byte-match CI's, also test-pinned (A91).
-  - `project version` reads `scripts/core/VERSION` (was a hardcoded
-    v1.1.0, six minor releases stale — A04); the evaluator-library
-    pin read fails loud naming pyproject.toml instead of silently
-    installing v0.5.3, with a Python 3.10 tomli/regex fallback (A08);
-    `main()` prefers `.venv` and the recovery hint says
-    `./scripts/core/project setup` (A10); `scripts/core/__init__.py`
-    docstring describes the actual package (A05).
-
-### Added
-
 - **Visible config home + `/setup-preset`** (KIT-0058, ADR-0027 P7
   amendment; core scripts 3.5.0):
   - The operator config moved from the invisible
@@ -344,29 +272,6 @@ sweep + doc curation that grounded the docs in the tree.
     `bootstrap --help` at runtime (no hardcoded question list),
     refuses pasted secrets (path references only), and validates
     written keys against the door's accepted set.
-
-### Changed
-
-- **Canonical homes + the prune** (KIT-0057, KIT-ADR-0027 P6 — the
-  arc's final task):
-  - ONE skills home: the three builder skills (code-review-evaluator,
-    review-handoff, self-review) moved from `.kit/skills/` into
-    `.claude/skills/`; `.kit/skills/<name>` survives one release as
-    read-both symlinks, removed in 0.9.0 (KIT-0059). Plugin copy
-    refresh filed (KIT-0060).
-  - Kit identity: `pyproject.toml` is `agentive-starter-kit`; the
-    export engine now resets a `--new` target's name to the
-    placeholder + TODO itself (characterized — targets never inherit
-    the kit's name).
-  - Seam-guards from KIT-0056's retro: baked planning-manifest
-    `core_version` == `scripts/core/VERSION` (proven to fire on
-    desync), and a cross-reader bots-declaration conformance harness
-    (one fixture table through door/project/preflight, incl.
-    duplicate-key first-wins).
-  - Docs converge on the canonical map (CLAUDE.md/README trees,
-    DISTRIBUTION-ARCHITECTURE canonical-homes table).
-
-### Added
 
 - **Degraded modes + operator presets** (KIT-0056, KIT-ADR-0027
   P5+P7; core scripts 3.4.0):
@@ -442,7 +347,88 @@ sweep + doc curation that grounded the docs in the tree.
     `KIT-LOCAL: project-rules` region (content unchanged); bootstrap
     seeds consumers' Project Rules per profile from that single source.
 
+### Changed
+
+- **Truth sweep + doc curation** (KIT-0069, KIT-0073): the pre-0.9.0
+  cruft audit's prose findings fixed and verified tree-grounded
+  (complete-coverage verification, residuals fixed same-day); a
+  33-document curation pass (trims, merges, archives) cut the README
+  from ~580 to 96 lines.
+- **Whole-repo aider purge + Python ceiling lift** (KIT-0065; core
+  scripts 3.7.0). Aider is retired everywhere; the four dead
+  `.adversarial/scripts/*.sh` wrappers (evaluate_plan,
+  proofread_content, review_implementation, validate_tests) are
+  deleted — the evaluation path is the `adversarial` CLI +
+  `scripts/core/prepare-review-input.sh`. Verified `adversarial init`
+  (1.0.x) does not re-provision them. The Python `requires-python`
+  ceiling `<3.13` — justified only by the retired dependency — is
+  lifted after the full suite and dev stack passed on 3.14
+  (`>=3.10` now; CI matrix runs 3.10/3.12/3.14). `project setup`
+  drops the uv-based 3.12-venv workaround and its detection helpers;
+  agent/template docs point at the current
+  `<input-name>--<evaluator>.md` log naming and the
+  `echo y | ADVERSARIAL_UNATTENDED=1` unattended invocation.
+
+- **Canonical homes + the prune** (KIT-0057, KIT-ADR-0027 P6 — the
+  arc's final task):
+  - ONE skills home: the three builder skills (code-review-evaluator,
+    review-handoff, self-review) moved from `.kit/skills/` into
+    `.claude/skills/`; `.kit/skills/<name>` survives one release as
+    read-both symlinks, removed in 0.9.0 (KIT-0059). Plugin copy
+    refresh filed (KIT-0060).
+  - Kit identity: `pyproject.toml` is `agentive-starter-kit`; the
+    export engine now resets a `--new` target's name to the
+    placeholder + TODO itself (characterized — targets never inherit
+    the kit's name).
+  - Seam-guards from KIT-0056's retro: baked planning-manifest
+    `core_version` == `scripts/core/VERSION` (proven to fire on
+    desync), and a cross-reader bots-declaration conformance harness
+    (one fixture table through door/project/preflight, incl.
+    duplicate-key first-wins).
+  - Docs converge on the canonical map (CLAUDE.md/README trees,
+    DISTRIBUTION-ARCHITECTURE canonical-homes table).
+
 ### Fixed
+
+- **Functional repairs from the pre-0.9.0 cruft audit** (KIT-0068;
+  core scripts 3.6.0). Behavior-broken surfaces only — the audit's
+  prose findings are KIT-0069's, aider residue KIT-0065's:
+  - `project linearsync`, `project create-agent`, and `project
+    reconfigure`'s identity rewrite now target the real v0.4.0+ paths
+    (`scripts/optional/…`, `scripts/core/logging_config.py`) with
+    friendly errors naming the missing file on consumer checkouts
+    (A00/A01/A02/A11). The reconfigure test fixture that modeled the
+    pre-v0.4.0 layout — and masked the breakage for months — now
+    models the real tree, and a fixture-path guard test pins every
+    modeled path to the actual repo.
+  - Linear sync: the root `.env` resolves again from
+    `scripts/optional/` (A15), and any `[A-Z]{2,6}-NNNN` task id is
+    accepted — the hardcoded `TASK-|ASK-` patterns rejected every
+    live KIT-* task (A14).
+  - `engine-materials.sh` no longer ships `scripts/local/`, kit-only
+    tests, the kit's planning corpus (prefix-agnostic task/context
+    excludes), or `.kit/adversarial/` into consumers, names its drops
+    in output, and gained a `--scaffold-only` test seam with an
+    export-content test (A12/A13).
+  - `.adversarial/config.yml` regenerated from the template and
+    verified against the installed CLI 1.0.1; unread keys
+    (`auto_run`, `git_integration`, `save_artifacts`) deleted from
+    config + template (A67). Self-referential
+    `.adversarial/evaluators/evaluators` symlink removed and
+    `new-worktree.sh` now refuses to link over an existing
+    destination — the creation vector (A69).
+  - Toolchain agreement: pre-commit Black rev matches the pyproject
+    pin with a consistency test (A84); ruff is now enforced
+    (ci-check.sh step 4/7 + CI lint step; 24 mechanical violations
+    fixed) instead of declared-but-never-run (A88); ci-check.sh's
+    flake8 args byte-match CI's, also test-pinned (A91).
+  - `project version` reads `scripts/core/VERSION` (was a hardcoded
+    v1.1.0, six minor releases stale — A04); the evaluator-library
+    pin read fails loud naming pyproject.toml instead of silently
+    installing v0.5.3, with a Python 3.10 tomli/regex fallback (A08);
+    `main()` prefers `.venv` and the recovery hint says
+    `./scripts/core/project setup` (A10); `scripts/core/__init__.py`
+    docstring describes the actual package (A05).
 
 - `create-project.sh`'s derived-prefix fallback crashed on macOS
   (BSD `tr` read the leading dash of its delete-set as an option) —
@@ -499,49 +485,6 @@ project upgrades were deliberately deferred to the next phase.
   8–10 (wrapper exit-code convention, scoped staging, verify shipped
   hints against installed tools).
 
-### Changed
-
-- **`ci-check.sh` warns on venv Black version drift** against the
-  `pyproject.toml` pin (KIT-0035) — stale-venv phantom failures now read
-  as environment issues; warn-only, the format gate is unchanged.
-- **Evaluator trio runs before PR open for doc-dominated tasks**
-  (KIT-0035, adopted into the code-review-evaluator skill and both
-  feature-developer agents) — validated twice with zero-noise first bot
-  rounds.
-- **`prepare-review-input.sh` 1.5.1** — non-TTY large-input evaluator
-  runs use the verified `echo y |` confirm pattern; the previously
-  advertised `ADVERSARIAL_UNATTENDED` flag never existed in the installed
-  library (KIT-0035 → KIT-0044).
-- **`docs/PLUGIN-UPGRADE-GUIDE.md` detection greps hardened** and
-  `.claude/agents/upgrader.md` re-synced in lockstep (KIT-0035).
-- **`sync-core-scripts.yml` push trigger parked** — `CROSS_REPO_TOKEN`
-  was never provisioned (22/22 failed runs since 2026-03-09);
-  dispatch-only until KIT-0045 re-enables it deliberately, with the
-  re-enable checklist embedded in the workflow file. Matrix `fail-fast`
-  disabled so one leg can't mask the others.
-- **Dependency floors refreshed** (dependabot #46–#50, #55):
-  `pytest>=9.1.1`, `pytest-asyncio>=1.3.0`, `ruff>=0.15.21`,
-  `python-dotenv>=1.2.2`, `gql>=4.0.0`; `actions/checkout@v7`.
-- **Core scripts 3.1.0** (two consumer-visible script changes on top of
-  the 3.0.0 sync-engine major).
-
-### Fixed
-
-- **`kit_markers.py` marker-merge robustness** (KIT-0040 F3, resolves the
-  two BugBot findings open on PR #58 since the KIT-0033 merge):
-  - A prose mention of a region's BEGIN marker inside another (preserved)
-    region no longer aborts re-bootstrap as "malformed" — the malformed
-    check is now line-anchored instead of a raw substring test.
-  - Benign whitespace drift inside a marker line (extra spaces/tabs) no
-    longer makes the region unparseable — previously a drifted marker
-    silently replaced customized consumer content with placeholder TODO
-    text on re-bootstrap. Drift beyond the whitespace tolerance is now
-    *detected* by a deliberately looser line-anchored check and fails
-    fast instead of clobbering. Well-formed and drifted regions still
-    round-trip byte-for-byte.
-
-### Added
-
 - **Stub-`gh` regression harness for `preflight-check.sh`**
   (`tests/test_preflight_check.py`, KIT-0040 F1) — runs the real script
   against canned `gh` payloads via a fake `gh` on PATH, covering the
@@ -597,7 +540,43 @@ project upgrades were deliberately deferred to the next phase.
   - `tests/test_kit_markers.py` covers the merge logic, including the
     re-bootstrap byte-preservation guarantee.
 
+- **KIT-0033 backlog task** (`.kit/tasks/1-backlog/`) — portable agents
+  downstream: marker-based Project Context / Stack Notes overwrite,
+  `.kit/` skeleton scaffolding during bootstrap, F3 opt-out, and
+  re-bootstrap refresh that survives both consumer customization regions.
+  Captures the deferred work that surfaced via PR #57 bot review.
+- **`bootstrap-consumer.sh --no-kit` now prunes pre-existing kit agents**
+  on re-run (#68), `feature-developer-f5` wired into
+  `KIT_AGENTS`/`AGENT_EXCLUDES` (#66), and a marker-membership test
+  guards the whole class mechanically (KIT-0034).
+- **Worktree provisioning symlinks gitignored** so `git worktree remove`
+  works cleanly after a session (KIT-0044).
+
 ### Changed
+
+- **`ci-check.sh` warns on venv Black version drift** against the
+  `pyproject.toml` pin (KIT-0035) — stale-venv phantom failures now read
+  as environment issues; warn-only, the format gate is unchanged.
+- **Evaluator trio runs before PR open for doc-dominated tasks**
+  (KIT-0035, adopted into the code-review-evaluator skill and both
+  feature-developer agents) — validated twice with zero-noise first bot
+  rounds.
+- **`prepare-review-input.sh` 1.5.1** — non-TTY large-input evaluator
+  runs use the verified `echo y |` confirm pattern; the previously
+  advertised `ADVERSARIAL_UNATTENDED` flag never existed in the installed
+  library (KIT-0035 → KIT-0044).
+- **`docs/PLUGIN-UPGRADE-GUIDE.md` detection greps hardened** and
+  `.claude/agents/upgrader.md` re-synced in lockstep (KIT-0035).
+- **`sync-core-scripts.yml` push trigger parked** — `CROSS_REPO_TOKEN`
+  was never provisioned (22/22 failed runs since 2026-03-09);
+  dispatch-only until KIT-0045 re-enables it deliberately, with the
+  re-enable checklist embedded in the workflow file. Matrix `fail-fast`
+  disabled so one leg can't mask the others.
+- **Dependency floors refreshed** (dependabot #46–#50, #55):
+  `pytest>=9.1.1`, `pytest-asyncio>=1.3.0`, `ruff>=0.15.21`,
+  `python-dotenv>=1.2.2`, `gql>=4.0.0`; `actions/checkout@v7`.
+- **Core scripts 3.1.0** (two consumer-visible script changes on top of
+  the 3.0.0 sync-engine major).
 
 - **`./scripts/core/project sync` now means core-file sync, not Linear sync**
   (KIT-0036) — **BREAKING**. `sync` was previously an alias for `linearsync`;
@@ -631,6 +610,21 @@ project upgrades were deliberately deferred to the next phase.
   agent table, `README.md` create-project blurb, `.kit/docs/tmux-tips.md`
   example commands.
 
+### Fixed
+
+- **`kit_markers.py` marker-merge robustness** (KIT-0040 F3, resolves the
+  two BugBot findings open on PR #58 since the KIT-0033 merge):
+  - A prose mention of a region's BEGIN marker inside another (preserved)
+    region no longer aborts re-bootstrap as "malformed" — the malformed
+    check is now line-anchored instead of a raw substring test.
+  - Benign whitespace drift inside a marker line (extra spaces/tabs) no
+    longer makes the region unparseable — previously a drifted marker
+    silently replaced customized consumer content with placeholder TODO
+    text on re-bootstrap. Drift beyond the whitespace tolerance is now
+    *detected* by a deliberately looser line-anchored check and fails
+    fast instead of clobbering. Well-formed and drifted regions still
+    round-trip byte-for-byte.
+
 ### Removed
 
 - **`scripts/core/check-sync.sh`** (KIT-0036) — retired in core **3.0.0**. It
@@ -645,20 +639,6 @@ project upgrades were deliberately deferred to the next phase.
   **`.claude/agents/feature-developer-v6.md`**, and
   **`.claude/agents/feature-developer-v7.md`** — content consolidated into
   the canonical `feature-developer.md`.
-
-### Added
-
-- **KIT-0033 backlog task** (`.kit/tasks/1-backlog/`) — portable agents
-  downstream: marker-based Project Context / Stack Notes overwrite,
-  `.kit/` skeleton scaffolding during bootstrap, F3 opt-out, and
-  re-bootstrap refresh that survives both consumer customization regions.
-  Captures the deferred work that surfaced via PR #57 bot review.
-- **`bootstrap-consumer.sh --no-kit` now prunes pre-existing kit agents**
-  on re-run (#68), `feature-developer-f5` wired into
-  `KIT_AGENTS`/`AGENT_EXCLUDES` (#66), and a marker-membership test
-  guards the whole class mechanically (KIT-0034).
-- **Worktree provisioning symlinks gitignored** so `git worktree remove`
-  works cleanly after a session (KIT-0044).
 
 ## [0.7.0] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **The door ships in the package — KIT-ADR-0030** (KIT-0104, PRs
-  #129 + the shim PR): the setup door is now `agentive new` /
+  #129 + #130 + the prose sweep): the setup door is now `agentive new` /
   `agentive adopt` — same flags, same resolution chain (preset home
   anchors to the TARGET's parent in the packaged world), same engines
   running as packaged data, byte-pinned to their kit-tree twins by
@@ -77,7 +77,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BOTH verbs** (KIT-ADR-0032: plain repo + check hook, no `.kit/`, no
   record — `new --no-kit` is the KIT-0104 F4 addition; the old
   seeded-record `--no-kit` is gone). The shape × profile matrix has
-  exactly one implementation: the package.
+  exactly one implementation: the package. The prose sweep (KIT-0104
+  F5/F6) retires the factory-clone precondition from every live
+  surface: `docs/STARTING-A-PROJECT.md` teaches the sibling layout
+  instead of the factory model (creation runs from anywhere; the kit
+  clone is the kit's development home and the seat of the guided
+  flows), README's Quickstart leads with `uv tool install agentive-kit
+  && agentive new`, `/new-project` and `/setup-preset` derive their
+  interviews from `agentive new --help` (runtime-read — no hardcoded
+  flag list, pinned by `tests/agentive_kit/test_door_units.py`), and
+  the preset/config-home docs say what the packaged door actually
+  does: anchor to the TARGET's parent, `<projects-parent>/
+  agentive-config`.
 - **The door switches to package-install mode — KIT-ADR-0028 phase 2**
   (KIT-0093, agentive-kit 0.3.0): `bootstrap --new` (both shapes)
   scaffolds CONTENT — `.kit/` skeleton with workflow docs,
@@ -138,6 +149,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Markdown lint owned locally — KIT-0094** (passenger on the
+  KIT-0104 prose-sweep PR): `.markdownlint-cli2.jsonc` runs the same
+  tool CodeRabbit runs, scoped to live markdown (historical records,
+  task specs, test fixtures, and byte-pinned packaged twins excluded
+  — the `.coderabbitignore` precedent), with the rule decisions
+  recorded once in the config (MD013/MD033/MD036/MD041/MD060 off,
+  MD029 `one_or_ordered` — the KIT-0092 diff-hunk numbering
+  false-positive class is decided here, not per-thread). A tree-wide
+  pre-commit gate (`pass_filenames: false` — CLI paths would extend
+  the config globs and bypass its ignores) fails a violation locally
+  before it can become a bot thread; falsified once by design. One
+  class sweep brought the ~1,150 pre-existing violations across 95
+  in-scope files to zero.
 - **`agentive-kit` package skeleton — KIT-ADR-0028 phase 1, PR 1**
   (KIT-0090): `packages/agentive-kit/` with `src/agentive_kit/`
   modules `gitio` (single home for git invocations; KIT-0080's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ See `.kit/templates/AGENT-TEMPLATE.md` for creating new agents.
 | `./scripts/core/verify-ci.sh` | Verify CI status on GitHub |
 | `./scripts/core/pattern_lint.py` | Check for defensive coding violations |
 | `./scripts/optional/create-agent.sh` | Create a new agent definition |
-| `./scripts/local/bootstrap` | The one setup door: `--new`/`--adopt` × shape × profile (KIT-0053) |
+| `agentive new` / `agentive adopt` | The one setup door, packaged (KIT-ADR-0030): shape × profile, runs from anywhere; `./scripts/local/bootstrap` is an exec shim over it (removal: KIT-0107) |
 
 ## Version
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ evaluation, and architectural decision records. For full details, see `README.md
 
 ## Directory Structure
 
-```
+```text
 .claude/agents/       Implementation agents (feature-developer, ci-checker, etc.)
 .claude/commands/     All slash commands (start-task, babysit-pr, retro, etc.)
 .claude/skills/       ALL skills — implementation (pre-implementation, bot-triage) and builder (self-review, review-handoff, code-review-evaluator)

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 **A bit of structure to help you get more out of agentive software development**
 
-Using agents to build software works better if you add a bit of structure — Anthropic calls this a [harness](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents). This kit packages the structure we use to overcome the usual problems of agentive development: documentation, testing, architecture, and value for money (and tokens). From one permanent clone, you stamp out configured projects in about ten minutes, then tweak anything — agents, models, workflow — as you wish.
+Using agents to build software works better if you add a bit of structure — Anthropic calls this a [harness](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents). This kit packages the structure we use to overcome the usual problems of agentive development: documentation, testing, architecture, and value for money (and tokens). One command — `agentive new` — stamps out a configured project in about ten minutes, from wherever you are; then tweak anything — agents, models, workflow — as you wish.
 
-**Starting a project?** Read **[docs/STARTING-A-PROJECT.md](docs/STARTING-A-PROJECT.md)** — the operator flow from a permanent kit clone to a planner-ready project.
+**Starting a project?** Read **[docs/STARTING-A-PROJECT.md](docs/STARTING-A-PROJECT.md)** — the operator flow from idea (or prototype) to a planner-ready project.
 
 ---
 
 ## What's inside
 
-- A **front door for new projects** — the `/new-project` command and the one setup door (`scripts/local/bootstrap`)
+- A **front door for new projects** — the packaged setup door (`agentive new` / `agentive adopt`, runs from anywhere) and the guided `/new-project` interview
 - **Specialized agents** for planning, implementation, testing, and review (`.claude/agents/`)
 - **Adversarial evaluators** — independent AI second opinions on plans, code, and docs
 - **Task management** as markdown files in status folders (`.kit/tasks/README.md`), with optional Linear sync ([docs/LINEAR-INTEGRATION.md](docs/LINEAR-INTEGRATION.md))
@@ -62,15 +62,24 @@ that shipped the git 2.31 dependency (KIT-0080) and the missing-CLI gap
 
 You need Claude Code, git + gh (authenticated) — see [Requirements](#requirements) above; `agentive doctor` inside any packaged project tells you what's missing.
 
+The direct route — no kit clone required:
+
+```bash
+uv tool install agentive-kit
+agentive new ~/Github/my-project
+```
+
+The guided route — clone the kit and let it interview you:
+
 ```bash
 cd ~/Github
 git clone https://github.com/movito/agentive-starter-kit.git
 cd agentive-starter-kit && claude
 ```
 
-Then run `/new-project` in the session — **the one starting action for every situation** (blank project, prototype graduation, adopting a repo). It interviews you in plain language and drives the setup door; anything not yet installed (the `agentive` CLI, the agent plugin) comes back as a printed install command, never a dead end. When it finishes, open the tab its LAUNCH line names and start with the `planner` agent.
+Then run `/new-project` in the session — **the one guided entry for every situation** (blank project, prototype graduation, adopting a repo). It interviews you in plain language and drives the same setup door; anything not yet installed (the `agentive` CLI, the agent plugin) comes back as a printed install command, never a dead end. When it finishes, open the tab its LAUNCH line names and start with the `planner` agent.
 
-Full guide — factory model, prototype graduation, adopting an existing repo, operator presets: [docs/STARTING-A-PROJECT.md](docs/STARTING-A-PROJECT.md). Authoritative option matrix: `./scripts/local/bootstrap --help`.
+Full guide — the sibling layout, prototype graduation, adopting an existing repo, operator presets: [docs/STARTING-A-PROJECT.md](docs/STARTING-A-PROJECT.md). Authoritative option matrix: `agentive new --help`.
 
 ---
 
@@ -97,7 +106,7 @@ Independent AI review of your plans, code, and documentation, via the `adversari
 | You want | Where |
 |----------|-------|
 | Starting a project (all paths) | [docs/STARTING-A-PROJECT.md](docs/STARTING-A-PROJECT.md) |
-| Setup-door options (shapes × profiles, `--adopt`, `--bots`) | `./scripts/local/bootstrap --help` |
+| Setup-door options (shapes × profiles, adopt, `--bots`) | `agentive new --help` / `agentive adopt --help` |
 | Operator preset (answer the door's questions once) | `/setup-preset` + [docs/STARTING-A-PROJECT.md](docs/STARTING-A-PROJECT.md) |
 | The split-pair pattern | [docs/CROSS-REPO-PATTERN.md](docs/CROSS-REPO-PATTERN.md) |
 | Linear task sync | [docs/LINEAR-INTEGRATION.md](docs/LINEAR-INTEGRATION.md) |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You need Claude Code, git + gh (authenticated) — see [Requirements](#requireme
 The direct route — no kit clone required:
 
 ```bash
-uv tool install agentive-kit
+uv tool install agentive-kit   # or: pipx install agentive-kit
 agentive new ~/Github/my-project
 ```
 

--- a/docs/CROSS-REPO-PATTERN.md
+++ b/docs/CROSS-REPO-PATTERN.md
@@ -93,13 +93,14 @@ for cross-repo projects and preflight-validated.
 
 ### 1. Create the planning repo
 
-From the agentive-starter-kit directory:
+From any terminal (the door ships in the `agentive-kit` package —
+KIT-ADR-0030):
 
 ```bash
-# Using the one setup door (KIT-0053) with the planning shape
+# Using the one setup door with the planning shape
 # (ADR-0027 P2): coordination machinery only, no Python toolchain,
 # profile forced to none, target pointers recorded in CLAUDE.md
-./scripts/local/bootstrap --new ~/Github/my-project-planning \
+agentive new ~/Github/my-project-planning \
   --shape planning \
   --target-path ../my-project \
   --target-github acme/my-project

--- a/docs/CROSS-REPO-PATTERN.md
+++ b/docs/CROSS-REPO-PATTERN.md
@@ -43,7 +43,7 @@ monorepo remains fine for one-offs and small experiments.
 
 ## How It Works
 
-```
+```text
 planning-repo/                    target-repo/
 ├── CLAUDE.md (## Target Repository config)
 ├── .claude/agents/      ←──────── agent definitions live here
@@ -129,7 +129,7 @@ The template → agent → pair recipe composes the door run above:
 
 Both repos must be siblings on disk:
 
-```
+```text
 ~/Github/
 ├── my-project/           # target repo (the codebase)
 └── my-project-planning/  # planning repo (agentive-starter-kit)

--- a/docs/DISTRIBUTION-ARCHITECTURE.md
+++ b/docs/DISTRIBUTION-ARCHITECTURE.md
@@ -203,8 +203,8 @@ wrapped in markers:
 <!-- END KIT-LOCAL: stack-notes -->
 ```
 
-The consumer engine behind the setup door (`scripts/local/bootstrap
---adopt`, engine `engine-consumer.sh`; KIT-0053) fills these on first
+The consumer engine behind the setup door (`agentive adopt`, engine
+`engine-consumer.sh`; KIT-0053/KIT-ADR-0030) fills these on first
 bootstrap and **preserves them byte-for-byte across re-bootstraps** (via
 `scripts/local/kit_markers.py`), while upstream refreshes everything
 *outside* the markers. This is the

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -91,7 +91,8 @@ Three things follow from this model:
   lifecycle scripts via the `agentive-kit` PyPI package,
   agents/skills/commands via the `agentive-workflow` Claude Code
   plugin. The door verifies both installs or prints the exact install
-  commands. This holds for `adopt` too — nothing is copied.
+  commands. This holds for `adopt` too — it writes the same content
+  skeleton and copies no tooling.
 - **Navigation is by tabs, not `cd`.** When a tool finishes creating
   something, it prints where to go next; you open a new tab there
   (see [Tab handoffs](#tab-handoffs-the-launch-convention) below).
@@ -214,9 +215,9 @@ shape — again, `agentive new --help` is the reference.
 
 Install the agentive workflow into a repo that already exists — the
 `.kit/` content skeleton, records, and pins — preserving every file
-already present. Adopt is packaged-mode like `new`: nothing is
-copied; lifecycle scripts come from the `agentive-kit` package and
-agent bodies from the plugin.
+already present. Adopt is packaged-mode like `new`: no kit checkout
+or local tooling is copied; lifecycle scripts come from the
+`agentive-kit` package and agent bodies from the plugin.
 
 ```bash
 agentive adopt ~/Github/my-app
@@ -242,7 +243,7 @@ automates, and single-key evaluation mode is documented in the
 You do not need one. Install the CLI and run the door:
 
 ```bash
-uv tool install agentive-kit
+uv tool install agentive-kit   # or: pipx install agentive-kit
 agentive new ~/Github/my-tool
 ```
 

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -1,8 +1,8 @@
 # Starting a Project
 
 How to go from "I have an idea" (or a prototype) to a working,
-planner-ready project — using one permanent clone of this kit as your
-project factory.
+planner-ready project — with the packaged setup door, `agentive new`
+and `agentive adopt`, which run from wherever you are.
 
 This guide is written for someone who has never seen the kit before.
 It covers the mental model, the ways to create a project, and what to
@@ -28,37 +28,46 @@ Don't audit this by hand. The door validates what it needs as it runs
 failure — and every created project has the health surface:
 
 ```bash
-agentive doctor   # packaged (--new) projects
-# copied-scripts (adopted / pre-packaged) projects instead run:
+agentive doctor   # any project the door created (new or adopted)
+# pre-packaged-era projects (script copies) instead run:
 # ./scripts/core/project doctor
 ```
 
 ---
 
-## The factory model
+## The sibling layout
 
-You clone **agentive-starter-kit once**, keep that clone forever, and
-never build product code inside it. Every project you create is a
-**sibling folder** next to it — stamped out by the kit's one setup
-door (`scripts/local/bootstrap`) and then independent of the factory.
+Project creation is a package command — `agentive new` /
+`agentive adopt`, installed with `uv tool install agentive-kit` — and
+runs from wherever you are. **No kit clone is required to create a
+project.** What is worth keeping is the layout: your projects side by
+side in one folder, with your operator preset as a visible sibling:
 
 ```text
 ~/Github/
-├── agentive-starter-kit/    ← the factory: one permanent clone
 ├── agentive-config/         ← your operator preset (private, optional)
-├── my-product/              ← a code repo the factory created
+├── my-product/              ← a code repo the door created
 ├── my-product-planning/     ← its planning repo (the split pair)
-└── my-notes/                ← a single-repo project
+├── my-notes/                ← a single-repo project
+└── agentive-starter-kit/    ← optional: the kit's development home
 ```
 
-### How every kit conversation starts
+The kit clone is the *development* home for the kit itself — and,
+today, the home of the conversational flows: `/new-project`,
+`/setup-preset`, and the `project-intake` agent are builder-side
+commands whose files live in this repo, so they run in a Claude Code
+session opened there (moving intake into the plugin is KIT-ADR-0031).
+Creating a project never requires it: the door is the package.
+
+### Where the guided flows run
 
 Slash-commands like `/new-project` and `/setup-preset` only exist
-INSIDE a Claude Code session — they are not shell commands. The
-literal keystrokes, every time:
+INSIDE a Claude Code session — they are not shell commands — and their
+command files ship with this repo, so the session is one opened in
+your kit clone:
 
 ```bash
-cd ~/Github/agentive-starter-kit   # the factory clone
+cd ~/Github/agentive-starter-kit   # the kit's development home
 claude                             # opens the Claude Code session
 ```
 
@@ -66,29 +75,29 @@ Then, at Claude's prompt, type the command — `/new-project`,
 `/setup-preset` — or ask for an agent by name. (The interactive agent
 menu is also available from the shell: `./.kit/launchers/launch`.)
 Everywhere this guide says "run /X in the kit clone", it means exactly
-these steps.
+these steps. Prefer flags over interviews? Skip the session entirely
+and run the door directly from any terminal.
 
 Three things follow from this model:
 
-- **The kit clone is where creation happens.** You start a session in
-  `agentive-starter-kit/` (as above) to create projects — the
-  `/new-project` command, the `project-intake` agent, the setup door
-  itself. You do everything else in the created project's own folder.
-- **Projects never contain the factory — and `--new` projects carry
-  no copies of its machinery either.** A project created with the
-  packaged `--new` flow is born *packaged* (KIT-ADR-0028): it contains
-  content (task folders, templates, workflow docs, config, records)
-  while the tooling is **installed** — lifecycle scripts via the
-  `agentive-kit` PyPI package, agents/skills/commands via the
-  `agentive-workflow` Claude Code plugin. The door verifies both
-  installs or prints the exact install commands. (The `--adopt` route
-  is the transition-era exception: it still installs script copies
-  until ADR-0028 phase 3 — see route 4 below.)
+- **Creation happens wherever you are.** `agentive new <dir>` /
+  `agentive adopt <dir>` are package subcommands with no path
+  relationship to any kit checkout. The guided flows above are
+  interviews that drive the same door for you.
+- **Projects never contain the kit — and carry no copies of its
+  machinery.** A project the door creates is born *packaged*
+  (KIT-ADR-0028): it contains content (task folders, templates,
+  workflow docs, config, records) while the tooling is **installed** —
+  lifecycle scripts via the `agentive-kit` PyPI package,
+  agents/skills/commands via the `agentive-workflow` Claude Code
+  plugin. The door verifies both installs or prints the exact install
+  commands. This holds for `adopt` too — nothing is copied.
 - **Navigation is by tabs, not `cd`.** When a tool finishes creating
   something, it prints where to go next; you open a new tab there
   (see [Tab handoffs](#tab-handoffs-the-launch-convention) below).
 
-Set up the factory once:
+Want the kit's development home — for the guided flows, or to work on
+the kit itself? Clone it once:
 
 ```bash
 cd ~/Github  # or wherever your projects live
@@ -97,28 +106,33 @@ git clone https://github.com/movito/agentive-starter-kit.git
 
 ## The one setup door
 
-Every creation flow below ends up running the same script —
-`scripts/local/bootstrap`, "the door". It asks the install questions
-(or reads them from your preset), validates the answers, and runs the
-engines that write the project. You never need a second setup path,
-and this guide deliberately does not duplicate the door's option
+Every creation flow below ends up running the same command —
+`agentive new` / `agentive adopt`, "the door". It asks the install
+questions (or reads them from your preset), validates the answers, and
+runs the engines that write the project. You never need a second setup
+path, and this guide deliberately does not duplicate the door's option
 matrix — the authoritative, always-current reference is:
 
 ```bash
-cd ~/Github/agentive-starter-kit && ./scripts/local/bootstrap --help
+agentive new --help     # and: agentive adopt --help
 ```
 
 If anything here and that help output ever disagree, the help output
-wins.
+wins. (Inside a kit checkout, `scripts/local/bootstrap` still works as
+an exec shim over the same packaged door; its removal is pinned to the
+next minor release — KIT-0107.)
 
 ### The operator preset (answer the questions once)
 
 The door resolves every question as **CLI flag → preset → kit default
 → interactive prompt**. A preset file at
-`<kit-parent>/agentive-config/preset` — a visible sibling of the kit
-clone — pre-answers the door's questions (project shape, review bots,
-evaluator install, secrets file, and so on), so with a filled preset,
-creating a project is genuinely one command with zero questions.
+`<projects-parent>/agentive-config/preset` — the door anchors the
+config home to the TARGET's parent, so keep it a visible sibling of
+your projects folder (`AGENTIVE_KIT_CONFIG_DIR` overrides the
+location) — pre-answers the door's questions (project shape, review
+bots, evaluator install, secrets file, and so on), so with a filled
+preset, creating a project is genuinely one command with zero
+questions.
 
 Author yours conversationally: start a session in the kit clone
 (`cd ~/Github/agentive-starter-kit && claude`) and type
@@ -180,8 +194,9 @@ clone (`cd ~/Github/agentive-starter-kit && claude`) and type
 `/new-project` at Claude's prompt — it asks what you're making, in
 plain language, and drives the door for you.
 
-Direct door use (no interview) works too; see `--shape planning` and
-the target-pointer flags in `bootstrap --help`.
+Direct door use (no interview) works too, from any terminal; see
+`--shape planning` and the target-pointer flags in
+`agentive new --help`.
 
 ### 3. Single repo (small tools, notes, experiments)
 
@@ -189,27 +204,28 @@ Everything — planning and code — in one repo. This is the door's
 default shape. `/new-project` offers it, or run the door directly:
 
 ```bash
-cd ~/Github/agentive-starter-kit && ./scripts/local/bootstrap --new ~/Github/my-tool
+agentive new ~/Github/my-tool
 ```
 
 Docs-only repos (no Python toolchain) are a profile choice within this
-shape — again, `bootstrap --help` is the reference.
+shape — again, `agentive new --help` is the reference.
 
 ### 4. Adopt an existing repo (you already have a project)
 
-Bootstrap an existing repo with the implementation tools — agents,
-scripts, commands, and the minimal `.kit/` workflow skeleton — without
-the full builder layer. (Adopt still installs script copies today;
-its packaged-install switch is ADR-0028 phase 3, coming with the
-consumer migration.)
+Install the agentive workflow into a repo that already exists — the
+`.kit/` content skeleton, records, and pins — preserving every file
+already present. Adopt is packaged-mode like `new`: nothing is
+copied; lifecycle scripts come from the `agentive-kit` package and
+agent bodies from the plugin.
 
 ```bash
-cd ~/Github/agentive-starter-kit && ./scripts/local/bootstrap --adopt ~/Github/my-app
+agentive adopt ~/Github/my-app
 ```
 
-Add `--no-kit` to skip the task-management workflow entirely.
+Add `--no-kit` for rung 0 (KIT-ADR-0032): a plain repo with no
+`.kit/` and no kit install — the flag exists on BOTH verbs.
 Docs-only and planning variants are shape × profile choices —
-`bootstrap --help` is the reference, as always.
+`agentive adopt --help` is the reference, as always.
 
 **Running without the full review stack?** Declare it and the
 completion gates stay honest: `--bots none` (or a subset like
@@ -221,22 +237,25 @@ automates, and single-key evaluation mode is documented in the
 
 ---
 
-## Starting from zero (no kit clone yet)
+## Starting from zero (no kit clone)
 
-One route even here — everything funnels into `/new-project`:
+You do not need one. Install the CLI and run the door:
 
 ```bash
-cd ~/Github  # or wherever your projects live
-git clone https://github.com/movito/agentive-starter-kit.git
-cd agentive-starter-kit && claude
+uv tool install agentive-kit
+agentive new ~/Github/my-tool
 ```
 
-then type `/new-project` at Claude's prompt. That command IS the one
-user-facing entry for every situation — prototype, blank pair, single
-repo — and it routes to the right flow itself. (The retired
-`create-project` agent's job folded into `/new-project` + the door in
-KIT-0093; if you find a live user-facing reference to it, it's stale —
-historical records and changelogs mention it accurately.)
+Clone the kit only when you want the guided flows — the
+`/new-project` interview (the one user-facing entry for every
+situation: prototype, blank pair, single repo — it routes to the
+right flow itself), `/setup-preset`, the `project-intake` agent — or
+to work on the kit itself. See [The sibling
+layout](#the-sibling-layout) above for the clone command. (The
+retired `create-project` agent's job folded into `/new-project` + the
+door in KIT-0093; if you find a live user-facing reference to it,
+it's stale — historical records and changelogs mention it
+accurately.)
 
 ---
 
@@ -287,19 +306,19 @@ Every `--new` project starts with a working `.env`: the door seeds it
 (mode 0600, gitignored) from your preset's `env-source` when you have
 one, else from the project's own `.env.template`, and fills
 `PROJECT_NAME`/`TASK_PREFIX`. What the door cannot invent is your API
-keys. With no `env-source`, a terminal run asks you before copying the
-kit clone's `.env` — the whole file, replacing the just-seeded
-template copy (the door re-fills `PROJECT_NAME`/`TASK_PREFIX`
-afterward); a non-interactive run prints the exact copy command
-(`install -m 600 …`) for you to run.
+keys. With no `env-source` there is nothing to carry them over from —
+the door says so out loud ("No API keys seeded"), and
+`agentive doctor`'s `env-keys` check names what is missing until you
+add them to the project's `.env` by hand (a preset `env-source` seeds
+them automatically next time).
 
-**Run that command yourself — do not ask an agent to.** Copying key
+**Move the keys yourself — do not ask an agent to.** Copying key
 material into a project is an operator-only act: the Claude Code
 permission classifier blocks agents from doing it (correctly — secrets
 handling), so an agent session asked to "fix the missing keys" can
 only stall. The seeded `CLAUDE.md` first-session note and
-`agentive doctor`'s `env-keys` check both surface a skipped copy
-before it can block your first evaluation.
+`agentive doctor`'s `env-keys` check both surface still-missing keys
+before they can block your first evaluation.
 
 ## Checking your environment
 
@@ -321,9 +340,9 @@ instead — see `docs/UPDATING-YOUR-PROJECT.md`.)
 
 | You want | Where |
 |----------|-------|
-| The door's full option reference | `./scripts/local/bootstrap --help` (in the kit clone) |
-| A guided interview instead of flags | `/new-project` (in the kit clone) |
-| Your preset, authored conversationally | `/setup-preset` (in the kit clone) |
+| The door's full option reference | `agentive new --help` / `agentive adopt --help` (any terminal) |
+| A guided interview instead of flags | `/new-project` (in a kit-clone session) |
+| Your preset, authored conversationally | `/setup-preset` (in a kit-clone session) |
 | The split-pair pattern explained | `docs/CROSS-REPO-PATTERN.md` |
 | The prototype handoff template | `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` |
 | Health checks in a created project | `agentive doctor` |

--- a/docs/adr/TEMPLATE-FOR-ADR-FILES.md
+++ b/docs/adr/TEMPLATE-FOR-ADR-FILES.md
@@ -21,14 +21,17 @@
 [List competing concerns and trade-offs]
 
 **Technical Requirements:**
+
 - [Requirement 1]
 - [Requirement 2]
 
 **Constraints:**
+
 - [Constraint 1]
 - [Constraint 2]
 
 **Assumptions:**
+
 - [Assumption 1]
 - [Assumption 2]
 
@@ -48,6 +51,7 @@
 [Provide enough detail for future developers to understand how this decision is implemented]
 
 **Key components:**
+
 - [Component 1]
 - [Component 2]
 
@@ -89,6 +93,7 @@ def example_function():
 **Description**: [What was this alternative?]
 
 **Rejected because**:
+
 - ❌ [Reason 1]
 - ❌ [Reason 2]
 
@@ -97,6 +102,7 @@ def example_function():
 **Description**: [What was this alternative?]
 
 **Rejected because**:
+
 - ❌ [Reason 1]
 - ❌ [Reason 2]
 
@@ -105,14 +111,17 @@ def example_function():
 [If this decision has been implemented, document actual outcomes]
 
 **Before this decision:**
+
 - [Metric 1]: [Value]
 - [Metric 2]: [Value]
 
 **After this decision:**
+
 - [Metric 1]: [New value]
 - [Metric 2]: [New value]
 
 **Impact:**
+
 - [Observed impact 1]
 - [Observed impact 2]
 

--- a/docs/adr/about-adr.md
+++ b/docs/adr/about-adr.md
@@ -16,6 +16,7 @@ See [.kit/adr/about-kit-adr.md](../../.kit/adr/about-kit-adr.md) for the full in
 ## What are ADRs?
 
 ADRs capture important architectural decisions along with their context and consequences:
+
 - **Context**: The forces and factors influencing the decision
 - **Decision**: What was decided and why
 - **Consequences**: The positive, negative, and neutral implications
@@ -50,11 +51,13 @@ Use `TEMPLATE-FOR-ADR-FILES.md` in this directory. Key sections:
 ## Naming Convention
 
 **Format**: `ADR-####-description.md`
+
 - `ADR-` prefix (required)
 - `####` four-digit number (0001, 0002, etc.)
 - `-description` kebab-case summary
 
 **Examples**:
+
 - `ADR-0001-user-authentication-strategy.md`
 - `ADR-0002-database-selection.md`
 
@@ -67,12 +70,14 @@ Use `TEMPLATE-FOR-ADR-FILES.md` in this directory. Key sections:
 ## When to Write an ADR
 
 **Write an ADR when:**
+
 - Making architectural choices that affect project structure
 - Choosing between competing technical approaches
 - Establishing patterns or conventions
 - Making trade-offs with significant implications
 
 **Don't write an ADR for:**
+
 - Routine bug fixes
 - Feature implementations following established patterns
 - Temporary experimental code
@@ -87,6 +92,7 @@ If you need to change a pattern from the starter kit:
 3. Document the rationale for diverging
 
 Example:
+
 ```markdown
 # ADR-0001: Custom Logging Format
 

--- a/docs/preset.example
+++ b/docs/preset.example
@@ -6,19 +6,21 @@
 # writes this file for you (slash-commands exist only inside a
 # Claude Code session, not in the shell).
 #
-# Install location — a VISIBLE sibling of the kit checkout, personal,
-# per-machine, never distributed by any sync/export path (the
-# AGENTIVE_KIT_CONFIG_DIR env var overrides the location):
+# Install location — a VISIBLE sibling of your projects folder (the
+# packaged door anchors the config home to the TARGET's parent),
+# personal, per-machine, never distributed by any sync/export path
+# (the AGENTIVE_KIT_CONFIG_DIR env var overrides the location):
 #
-#   mkdir -p <kit-parent>/agentive-config
-#   cp docs/preset.example <kit-parent>/agentive-config/preset
-#   $EDITOR <kit-parent>/agentive-config/preset
+#   mkdir -p <projects-parent>/agentive-config
+#   cp docs/preset.example <projects-parent>/agentive-config/preset
+#   $EDITOR <projects-parent>/agentive-config/preset
 #
 # On first use the door seeds a .gitignore (env.source, *.env) and a
 # README into the folder — keeping it in a PRIVATE git repo is
 # welcome, and `project doctor` checks that guardrail.
 #
-# The door (scripts/local/bootstrap) resolves every question as
+# The door (agentive new / agentive adopt, KIT-ADR-0030) resolves
+# every question as
 # CLI flag > preset > kit default > interactive prompt. A preset may
 # pre-answer ONLY the door's questions — the keys below, nothing else.
 # Unknown keys are warned about and ignored; a malformed line (no
@@ -26,11 +28,11 @@
 # error. Flat 'key: value' lines only — that is a conscious boundary
 # of the format, not an accident.
 #
-# On --adopt of a target that already carries a kit-install record,
+# On adopt of a target that already carries a kit-install record,
 # the record's values win over the preset (the record is the
 # project's identity). Compare them any time with:
-#   ./scripts/core/project doctor --against-preset   (INFO-only)
-# Bypass the preset entirely for one run with: bootstrap --no-preset
+#   agentive doctor --against-preset   (INFO-only)
+# Bypass the preset entirely for one run with: --no-preset
 #
 # Uncomment and edit the lines you want pre-answered:
 
@@ -61,7 +63,7 @@
 # with mode 0600 — never printed, never staged (.env is gitignored).
 # Key material never lives in the preset itself. Keeping the file
 # next to this preset works well — the seeded .gitignore ignores it.
-#env-source: <kit-parent>/agentive-config/env.source
+#env-source: <projects-parent>/agentive-config/env.source
 
 # target-path / target-github: the product-repo pointer, planning
 # shape only (rarely useful in a global preset — usually per-project).

--- a/packages/agentive-kit/src/agentive_kit/doctor/__init__.py
+++ b/packages/agentive-kit/src/agentive_kit/doctor/__init__.py
@@ -330,14 +330,13 @@ def _config_home(project_dir):
     door and doctor can never disagree on the path. Returns None when
     the checkout is not a git repository (no sibling to name).
 
-    Anchoring note (BugBot, PR #91): each resolver anchors to ITS OWN
-    checkout — the door to the kit clone, doctor to the project it
-    diagnoses. The two name the same folder exactly when kit and
-    project share a parent (the documented sibling layout); a consumer
-    checkout has no pointer to the kit clone's local path, so the
-    kit's parent is not computable from here. When the layouts
-    diverge, the override pins the real location, and every output
-    line below names the resolved path so the anchor is visible.
+    Anchoring note (BugBot, PR #91; updated KIT-0104): each resolver
+    anchors to ITS OWN root — the packaged door to the TARGET's
+    parent at creation time, doctor to the project it diagnoses. The
+    two name the same folder exactly when projects share a parent
+    (the documented sibling layout). When the layouts diverge, the
+    override pins the real location, and every output line below
+    names the resolved path so the anchor is visible.
     """
     override = os.environ.get("AGENTIVE_KIT_CONFIG_DIR")
     if override:
@@ -372,7 +371,7 @@ def _config_home(project_dir):
 def _print_preset_comparison(shape, profile, bots, record_errors, project_dir):
     """`doctor --against-preset` (KIT-0056 F8, ADR-0027 P7): compare
     the project's kit-install record against the operator preset at
-    ``<kit-parent>/agentive-config/preset`` (KIT-0058;
+    ``<projects-parent>/agentive-config/preset`` (KIT-0058;
     ``AGENTIVE_KIT_CONFIG_DIR`` overrides the location).
 
     INFO-only by design: divergence is reported as

--- a/packages/agentive-kit/src/agentive_kit/doctor/checks/90-config-home.sh
+++ b/packages/agentive-kit/src/agentive_kit/doctor/checks/90-config-home.sh
@@ -22,12 +22,12 @@
 # via --git-common-dir (worktree-safe) + /agentive-config. Read-only;
 # network only via gh repo view (the visibility probe).
 #
-# Anchoring note (BugBot, PR #91): this check anchors to the checkout
-# it diagnoses (DOCTOR_ROOT), the door to the kit clone — identical
-# exactly when kit and project share a parent (the documented sibling
-# layout). A consumer checkout cannot compute the kit clone's local
-# path, so when layouts diverge the override is the pin, and every
-# verdict line names the resolved path to keep the anchor visible.
+# Anchoring note (BugBot, PR #91; updated KIT-0104): this check
+# anchors to the checkout it diagnoses (DOCTOR_ROOT), the packaged
+# door to the TARGET's parent at creation time — identical exactly
+# when projects share a parent (the documented sibling layout). When
+# layouts diverge the override is the pin, and every verdict line
+# names the resolved path to keep the anchor visible.
 
 set -u
 

--- a/packages/agentive-kit/src/agentive_kit/door/data/docs/CROSS-REPO-PATTERN.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/docs/CROSS-REPO-PATTERN.md
@@ -93,13 +93,14 @@ for cross-repo projects and preflight-validated.
 
 ### 1. Create the planning repo
 
-From the agentive-starter-kit directory:
+From any terminal (the door ships in the `agentive-kit` package —
+KIT-ADR-0030):
 
 ```bash
-# Using the one setup door (KIT-0053) with the planning shape
+# Using the one setup door with the planning shape
 # (ADR-0027 P2): coordination machinery only, no Python toolchain,
 # profile forced to none, target pointers recorded in CLAUDE.md
-./scripts/local/bootstrap --new ~/Github/my-project-planning \
+agentive new ~/Github/my-project-planning \
   --shape planning \
   --target-path ../my-project \
   --target-github acme/my-project

--- a/packages/agentive-kit/src/agentive_kit/door/data/docs/CROSS-REPO-PATTERN.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/docs/CROSS-REPO-PATTERN.md
@@ -43,7 +43,7 @@ monorepo remains fine for one-offs and small experiments.
 
 ## How It Works
 
-```
+```text
 planning-repo/                    target-repo/
 ├── CLAUDE.md (## Target Repository config)
 ├── .claude/agents/      ←──────── agent definitions live here
@@ -129,7 +129,7 @@ The template → agent → pair recipe composes the door run above:
 
 Both repos must be siblings on disk:
 
-```
+```text
 ~/Github/
 ├── my-project/           # target repo (the codebase)
 └── my-project-planning/  # planning repo (agentive-starter-kit)

--- a/packages/agentive-kit/src/agentive_kit/door/data/kit-templates/TASK-STARTER-TEMPLATE.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/kit-templates/TASK-STARTER-TEMPLATE.md
@@ -89,7 +89,7 @@ a minimal one. Include each WHEN it applies; omit silently when not:
   agent must leave alone, with the parking place for discovered gaps
   (usually `1-backlog/`).
 - **Evaluation status** — if the spec was evaluated, one line: verdict
-  + where the dispositions live ("don't re-litigate").
+  - where the dispositions live ("don't re-litigate").
 - **Success metrics** — quantitative/qualitative targets, for tasks
   where "done" has measurable shape beyond the ACs.
 - **Contract-string cautions** — when the task touches text that tests

--- a/packages/agentive-kit/src/agentive_kit/door/data/workflows/ADR-CREATION-WORKFLOW.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/workflows/ADR-CREATION-WORKFLOW.md
@@ -13,6 +13,7 @@
 - ✅ When implementation approach changes significantly
 
 **Don't use for**:
+
 - ❌ Minor implementation details
 - ❌ Trivial code changes
 - ❌ Every small decision
@@ -89,11 +90,13 @@ class Example:
 
 ## Consequences
 
-### Positive:
+### Positive
+
 - What benefits do we get?
 - What problems does this solve?
 
-### Negative:
+### Negative
+
 - What trade-offs did we make?
 - What limitations does this introduce?
 - What technical debt did we accept?
@@ -101,12 +104,14 @@ class Example:
 ## Alternatives Considered
 
 ### Alternative 1: [Name]
+
 - **Description**: What was this approach?
 - **Pros**: Benefits
 - **Cons**: Drawbacks
 - **Why Not Chosen**: Specific reasons
 
 ### Alternative 2: [Name]
+
 - **Description**: ...
 - **Pros**: ...
 - **Cons**: ...
@@ -115,6 +120,7 @@ class Example:
 ## Results
 
 Real-world outcomes:
+
 - Test results (e.g., "300/350 tests passing, 0 regressions")
 - Performance metrics (e.g., "3ms average, down from 45ms")
 - User feedback (if available)
@@ -131,7 +137,8 @@ Real-world outcomes:
 
 **Last Updated**: YYYY-MM-DD
 **Reviewed**: YYYY-MM-DD
-```
+
+```markdown
 
 ---
 
@@ -211,4 +218,5 @@ created the ADR, e.g.:
 ---
 
 **Related Workflows**:
+
 - [TASK-COMPLETION-PROTOCOL.md](./TASK-COMPLETION-PROTOCOL.md) - Document completion when creating ADR

--- a/packages/agentive-kit/src/agentive_kit/door/data/workflows/AGENT-CREATION-WORKFLOW.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/workflows/AGENT-CREATION-WORKFLOW.md
@@ -37,7 +37,7 @@
 
 ### Decision Tree
 
-```
+```text
 Do I need a new agent?
     ↓
 Is this a distinct role that will be reused?
@@ -67,6 +67,7 @@ CREATE NEW AGENT ✅
 ### Required Information
 
 Before creating agent, gather:
+
 - **Agent name** (kebab-case, e.g., "api-tester", "docs-generator")
 - **One-sentence description** of agent's primary responsibility
 - **3-6 core responsibilities** (specific, actionable)
@@ -82,16 +83,19 @@ Before creating agent, gather:
 ### Step 1: Use Agent Template
 
 **Option A: Manual Copy**
+
 ```bash
 cp .kit/templates/AGENT-TEMPLATE.md .claude/agents/your-agent-name.md
 ```
 
 **Option B: Automation Script (Recommended)**
+
 ```bash
 scripts/optional/create-agent.sh your-agent-name "One sentence description"
 ```
 
 The automation script will:
+
 - Copy template to correct location
 - Perform basic substitutions ([agent-name], [description])
 - Create properly named file
@@ -122,10 +126,12 @@ tools:  # Select tools this agent needs
 ```
 
 **Model Selection Guide**:
+
 - **claude-sonnet-5**: Complex tasks, architectural decisions, coordination, code review
 - **claude-haiku-4-5**: Simple tasks, testing, straightforward implementations
 
 **Common Tool Combinations**:
+
 - **Implementation agents**: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 - **Review agents**: Read, Grep, Glob, WebSearch, WebFetch
 - **Coordination agents**: Read, Write, Edit, Bash, Glob, Grep, TodoWrite, WebSearch
@@ -148,6 +154,7 @@ Always begin your responses with your identity header:
 ```
 
 **Choose an appropriate emoji**:
+
 - 📋 Coordinator
 - 💻 Feature Developer
 - 🧪 Test Runner
@@ -175,6 +182,7 @@ List 3-6 specific, actionable responsibilities:
 ```
 
 **Good practices**:
+
 - ✅ Start with action verbs (Test, Validate, Create, Document, Report)
 - ✅ Be specific about domain (e.g., "external API" not "APIs")
 - ✅ Include coordination responsibilities if applicable
@@ -207,6 +215,7 @@ Follow these practices when testing APIs:
 **Critical**: Update the "When to Request Evaluation" scenarios for this agent's role.
 
 **Template provides generic examples**:
+
 ```markdown
 **When to Request Evaluation**:
 - [Role-specific scenario 1]
@@ -216,6 +225,7 @@ Follow these practices when testing APIs:
 ```
 
 **Replace with role-specific scenarios**:
+
 ```markdown
 **When to Request Evaluation**:
 - Ambiguous test acceptance criteria in task specification
@@ -395,11 +405,13 @@ git push -u origin [branch-name]
 ### Why This Matters
 
 The Evaluator workflow is a **critical quality assurance mechanism** that prevents:
+
 - ❌ Phantom work (implementing wrong solutions)
 - ❌ Wasted time (discovering issues after implementation)
 - ❌ Architectural drift (making decisions without validation)
 
 **Consistency across agents ensures**:
+
 - ✅ All agents have access to quality assurance
 - ✅ Uniform invocation pattern (reduces confusion)
 - ✅ Proper escalation safeguards (prevents infinite loops)
@@ -470,6 +482,7 @@ scripts/optional/create-agent.sh api-tester "API testing and validation speciali
 ### After Running Script
 
 You still need to manually:
+
 1. Edit agent file and customize all remaining [bracketed] sections
 2. Choose appropriate model (sonnet vs haiku)
 3. Select correct tools for agent's role
@@ -482,6 +495,7 @@ You still need to manually:
 ### Script Limitations
 
 The script handles **basic setup only**. It cannot:
+
 - ❌ Choose the right model for your use case
 - ❌ Select appropriate tools
 - ❌ Write role-specific guidelines
@@ -494,6 +508,7 @@ The script handles **basic setup only**. It cannot:
 ### Script Error Handling
 
 If script fails:
+
 - Check you provided both name and description
 - Ensure you're in project root directory
 - Verify template file exists at `.kit/templates/AGENT-TEMPLATE.md`
@@ -508,6 +523,7 @@ If script fails:
 **Symptom**: Agent fails to load, YAML parsing errors
 
 **Solution**:
+
 1. Check frontmatter YAML is properly formatted
 2. Ensure `---` delimiters are on their own lines
 3. Verify proper indentation (2 spaces for YAML)
@@ -539,6 +555,7 @@ name: api-tester
 **Symptom**: Created agent file but can't launch agent
 
 **Solution**:
+
 1. Verify file is in `.claude/agents/` directory
 2. Check filename matches `name:` in frontmatter
 3. Ensure file has `.md` extension
@@ -552,6 +569,7 @@ name: api-tester
 **Symptom**: Agent can't invoke Evaluator, gets errors
 
 **Solution**:
+
 1. Verify `.env` file exists with `OPENAI_API_KEY`
 2. Check `adversarial` CLI is installed and in PATH
 3. Ensure agent has `Bash` tool in tools list
@@ -565,6 +583,7 @@ name: api-tester
 **Symptom**: Agent file has [bracketed] text still present
 
 **Solution**:
+
 1. Search for all `[` characters in file
 2. Replace each [placeholder] with actual content
 3. Verify no placeholders remain before committing

--- a/packages/agentive-kit/src/agentive_kit/door/data/workflows/COMMIT-PROTOCOL.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/workflows/COMMIT-PROTOCOL.md
@@ -16,7 +16,7 @@
 
 ## Commit Message Format
 
-```
+```text
 <type>: <description>
 
 [optional body]
@@ -26,7 +26,7 @@
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
-### Types:
+### Types
 
 - `feat`: New feature
 - `fix`: Bug fix
@@ -36,7 +36,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - `chore`: Build, dependencies, tooling
 - `perf`: Performance improvements
 
-### Description Rules:
+### Description Rules
 
 - Use imperative mood ("Add feature" not "Added feature")
 - Start with lowercase (unless proper noun)
@@ -91,7 +91,8 @@ EOF
 
 ## Pre-commit Checks
 
-### Automatic (via pre-commit hooks):
+### Automatic (via pre-commit hooks)
+
 - ✅ trailing-whitespace: Remove trailing spaces
 - ✅ end-of-file-fixer: Ensure newline at EOF
 - ✅ check-yaml: Validate YAML syntax
@@ -101,7 +102,8 @@ EOF
 - ✅ flake8: Critical linting errors
 - ✅ pattern-lint: Project-specific DK rules (DK001, DK003)
 
-### Manual (you should do):
+### Manual (you should do)
+
 - ✅ Run pytest: Ensure tests pass
 - ✅ **Pre-run Black on new/edited Python files before staging**
   (`black <files>`) — letting the hook reformat mid-commit aborts the
@@ -130,6 +132,7 @@ EOF
 ### What It Does
 
 Runs the **SAME checks** as GitHub Actions:
+
 - Full test suite (including slow tests)
 - Coverage threshold check (`fail_under` gate in pyproject.toml, currently 80%)
 - Pre-commit hooks (formatting, linting)
@@ -162,6 +165,7 @@ After pushing to GitHub, you **MUST** verify that GitHub Actions CI/CD passes:
 ```
 
 **What It Does**:
+
 - Monitors GitHub Actions workflow runs
 - Polls every 20 seconds
 - Reports when workflows complete (pass/fail)
@@ -170,6 +174,7 @@ After pushing to GitHub, you **MUST** verify that GitHub Actions CI/CD passes:
 ### Why This Is Critical
 
 Even if `ci-check.sh` passes locally, CI can still fail due to:
+
 - Environment differences (Python versions, dependencies)
 - Race conditions not caught locally
 - Caching issues
@@ -195,6 +200,7 @@ Even if `ci-check.sh` passes locally, CI can still fail due to:
 **Soft Block Policy:**
 
 If CI is still running after timeout:
+
 - Check status manually: `gh run watch <run-id>`
 - You may proceed if you're confident (soft block)
 - Document decision in task completion notes
@@ -222,14 +228,16 @@ If CI is still running after timeout:
 
 ## Best Practices
 
-### ✅ DO:
+### ✅ DO
+
 - One logical change per commit
 - Descriptive commit message (explain WHY, not just WHAT)
 - Run tests before committing
 - Use HEREDOC format for multi-line messages
 - Include Claude Code attribution and co-author
 
-### ❌ DON'T:
+### ❌ DON'T
+
 - Don't commit secrets (.env files, credentials)
 - Don't commit generated files (unless required)
 - Don't use --no-verify (bypasses hooks) without good reason
@@ -242,12 +250,14 @@ If CI is still running after timeout:
 
 ## Special Cases
 
-### Amending Commits:
+### Amending Commits
+
 - Only amend commits that **haven't been pushed**
 - Check authorship first: `git log -1 --format='%an %ae'`
 - Use with caution: `git commit --amend`
 
-### Pre-commit Hook Failures:
+### Pre-commit Hook Failures
+
 - If black/ruff auto-formats files, stage the changes and commit again
 - If validation fails, fix the issues before committing
 - Don't skip hooks unless absolutely necessary
@@ -283,7 +293,8 @@ After pushing changes that affect task files (status changes, new tasks, complet
 ```
 
 **Expected Output (In Sync)**:
-```
+
+```text
 Linear Sync Status
 ==================
 Team: Your Team
@@ -296,7 +307,8 @@ Last sync: 2025-11-29 02:32:31 UTC
 ```
 
 **Expected Output (Mismatch)**:
-```
+
+```text
 Linear Sync Status
 ==================
 Team: Your Team
@@ -327,5 +339,6 @@ The GitHub Actions workflow runs `./scripts/core/project linearsync` on push. Af
 ---
 
 **Related Workflows**:
+
 - [TESTING-WORKFLOW.md](./TESTING-WORKFLOW.md) - Run tests before committing
 - [TASK-COMPLETION-PROTOCOL.md](./TASK-COMPLETION-PROTOCOL.md) - Completing tasks with commits

--- a/packages/agentive-kit/src/agentive_kit/door/data/workflows/PR-SIZE-WORKFLOW.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/workflows/PR-SIZE-WORKFLOW.md
@@ -80,12 +80,14 @@ Agent prompts, handoff files, and CLAUDE.md all contain hardcoded path reference
 break silently when the directory structure is inconsistent.
 
 **Indicators that a task is a structural migration:**
+
 - Primary work is `git mv` + find-and-replace path updates
 - Most changed files are renames (verifiable via `git diff --stat`)
 - The change is mechanically verifiable, not logically complex
 - Splitting would create a state where path references are inconsistent
 
 **The large-PR concern is mitigated because:**
+
 - Renames show as renames in `git diff`, not as add/delete
 - Path rewrites are mechanical and grep-verifiable
 - Reviewers can verify with `git diff --stat` + spot-checks

--- a/packages/agentive-kit/src/agentive_kit/door/data/workflows/REVIEW-FIX-WORKFLOW.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/workflows/REVIEW-FIX-WORKFLOW.md
@@ -4,7 +4,7 @@ When code-reviewer returns `CHANGES_REQUESTED`, this document describes the proc
 
 ## Overview
 
-```
+```text
                                     ┌─────────────────┐
                                     │  4-in-review/   │
                                     │   (task stays)  │

--- a/packages/agentive-kit/src/agentive_kit/door/data/workflows/TASK-COMPLETION-PROTOCOL.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/workflows/TASK-COMPLETION-PROTOCOL.md
@@ -34,12 +34,13 @@
 
 ## Handoff Document Format
 
-### Filename:
-```
+### Filename
+
+```text
 .kit/context/<TASK-ID>-HANDOFF-<agent-type>.md
 ```
 
-### Required Sections:
+### Required Sections
 
 ```markdown
 ## Task Summary
@@ -99,14 +100,16 @@ What should the next agent do with this?
 
 ## Best Practices
 
-### ✅ DO:
+### ✅ DO
+
 - Be thorough - don't skip checklist items
 - Include test metrics in handoff (before/after pass rates)
 - Document any known issues or limitations honestly
 - Provide clear next steps for the user or reviewing agent
 - Update agent-handoffs.json status to "task_complete" (planner, on main — KIT-0086)
 
-### ❌ DON'T:
+### ❌ DON'T
+
 - Don't mark task complete if tests are failing
 - Don't skip handoff document (critical for coordination)
 - Don't leave uncommitted changes
@@ -118,6 +121,7 @@ What should the next agent do with this?
 
 See existing handoffs for examples (finished tasks' handoffs live under
 `.kit/context/archive/`; write new ones to the flat `.kit/context/`):
+
 - `.kit/context/archive/ASK-0043-HANDOFF-feature-developer.md`
 - `.kit/context/archive/ASK-0044-HANDOFF-feature-developer.md`
 
@@ -133,6 +137,7 @@ See existing handoffs for examples (finished tasks' handoffs live under
 ---
 
 **Related Workflows**:
+
 - [TESTING-WORKFLOW.md](./TESTING-WORKFLOW.md) - Verify tests before completion
 - [COMMIT-PROTOCOL.md](./COMMIT-PROTOCOL.md) - Commit changes properly
 - [Evaluation guidance](../../../.claude/skills/code-review-evaluator/SKILL.md) - For planners assigning tasks

--- a/packages/agentive-kit/src/agentive_kit/door/data/workflows/TESTING-WORKFLOW.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/workflows/TESTING-WORKFLOW.md
@@ -161,6 +161,7 @@ is a commit-latency tool, not a merge gate.
 Tests now run automatically before every commit via pre-commit hooks:
 
 ### Fast Test Subset
+
 - **What runs**: All tests except those marked with `@pytest.mark.slow`
   (`pytest tests/ -x -m "not slow" --maxfail=3`)
 - **Real duration in THIS repo: ~3.5–4 minutes** (measured ~213 s /
@@ -177,6 +178,7 @@ Tests now run automatically before every commit via pre-commit hooks:
 ### Usage
 
 **Normal workflow** (tests run automatically):
+
 ```bash
 git commit -m "feat: Add new feature"
 # → Pre-commit hooks run:
@@ -188,6 +190,7 @@ git commit -m "feat: Add new feature"
 ```
 
 **Skip for WIP commits** (use sparingly):
+
 ```bash
 SKIP_TESTS=1 git commit -m "WIP: Work in progress"
 # → Tests skipped with warning
@@ -197,6 +200,7 @@ SKIP_TESTS=1 git commit -m "WIP: Work in progress"
 ### When Tests Fail
 
 If pre-commit hook blocks your commit:
+
 1. **Read the error message** - Shows which test(s) failed
 2. **Fix the test failure** - Address the root cause
 3. **Try committing again** - Tests will re-run
@@ -269,6 +273,7 @@ git commit -m "feat: add my feature"
 ### TDD Template
 
 See `tests/test_template.py` for a ready-to-use template with examples:
+
 - AAA pattern (Arrange, Act, Assert)
 - Edge case testing
 - Error handling tests
@@ -288,6 +293,7 @@ See `tests/test_template.py` for a ready-to-use template with examples:
 ### What ci-check.sh Does
 
 Runs the **SAME checks** as GitHub Actions CI:
+
 1. ✅ Full test suite (including slow tests)
 2. ✅ Coverage check (`fail_under` gate in pyproject.toml, currently 80%)
 3. ✅ Pre-commit hooks (formatting, linting)
@@ -318,6 +324,7 @@ kit never overwrites it, and it rides no sync tier. Without the hook,
 ### Usage
 
 **Before EVERY push**:
+
 ```bash
 ./scripts/core/ci-check.sh
 ```
@@ -328,6 +335,7 @@ GitHub (`./scripts/core/verify-ci.sh` or `/check-ci`).
 ### When ci-check.sh Fails
 
 If the script fails:
+
 1. **Read error output** - Shows which check failed (tests/coverage/hooks)
 2. **Fix the issue** - Address test failures or coverage drops
 3. **Run again** - Verify fix with `./scripts/core/ci-check.sh`
@@ -339,13 +347,15 @@ If the script fails:
 
 ## Best Practices
 
-### ✅ DO:
+### ✅ DO
+
 - Run full test suite before committing
 - Fix all new failures your code introduces
 - Maintain or improve overall pass rate
 - Update tests if implementation changes intentionally
 
-### ⚠️ USE CAUTION:
+### ⚠️ USE CAUTION
+
 - Don't commit if tests are failing (unless xfailed with justification)
 - Don't skip tests without good reason
 
@@ -415,6 +425,7 @@ that shells out must build an explicitly scrubbed env
 ---
 
 **Related Workflows**:
+
 - [COVERAGE-WORKFLOW.md](./COVERAGE-WORKFLOW.md) - Coverage measurement
 - [COMMIT-PROTOCOL.md](./COMMIT-PROTOCOL.md) - Committing after tests pass
 

--- a/packages/agentive-kit/src/agentive_kit/door/data/workflows/WORKFLOW-FREEZE-POLICY.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/workflows/WORKFLOW-FREEZE-POLICY.md
@@ -3,6 +3,7 @@
 ## Rule
 
 Do NOT edit workflow definitions during an active feature task. This includes:
+
 - Skill files (`.claude/skills/`)
 - Command files (`.claude/commands/`)
 - Agent definition files (`.claude/agents/`)
@@ -11,6 +12,7 @@ Do NOT edit workflow definitions during an active feature task. This includes:
 ## Rationale
 
 Mixing workflow changes with feature work creates:
+
 - **Noisy diffs**: Reviewers can't distinguish feature code from process changes
 - **Coupled risk**: A workflow typo can break an unrelated feature PR
 - **Untestable changes**: Workflow edits aren't covered by pytest

--- a/scripts/core/doctor.d/90-config-home.sh
+++ b/scripts/core/doctor.d/90-config-home.sh
@@ -22,12 +22,12 @@
 # via --git-common-dir (worktree-safe) + /agentive-config. Read-only;
 # network only via gh repo view (the visibility probe).
 #
-# Anchoring note (BugBot, PR #91): this check anchors to the checkout
-# it diagnoses (DOCTOR_ROOT), the door to the kit clone — identical
-# exactly when kit and project share a parent (the documented sibling
-# layout). A consumer checkout cannot compute the kit clone's local
-# path, so when layouts diverge the override is the pin, and every
-# verdict line names the resolved path to keep the anchor visible.
+# Anchoring note (BugBot, PR #91; updated KIT-0104): this check
+# anchors to the checkout it diagnoses (DOCTOR_ROOT), the packaged
+# door to the TARGET's parent at creation time — identical exactly
+# when projects share a parent (the documented sibling layout). When
+# layouts diverge the override is the pin, and every verdict line
+# names the resolved path to keep the anchor visible.
 
 set -u
 

--- a/scripts/core/project
+++ b/scripts/core/project
@@ -1356,7 +1356,7 @@ def _config_home(project_dir):
 def _print_preset_comparison(shape, profile, bots, record_errors, project_dir):
     """`doctor --against-preset` (KIT-0056 F8, ADR-0027 P7): compare
     the project's kit-install record against the operator preset at
-    ``<kit-parent>/agentive-config/preset`` (KIT-0058;
+    ``<projects-parent>/agentive-config/preset`` (KIT-0058;
     ``AGENTIVE_KIT_CONFIG_DIR`` overrides the location).
 
     INFO-only by design: divergence is reported as


### PR DESCRIPTION
## Summary

Final PR of KIT-0104 (KIT-ADR-0030). PRs #129/#130 shipped the door as `agentive new` / `agentive adopt` and reduced `bootstrap` to an exec shim; this PR rewrites the story to match, with KIT-0094 riding as its planned passenger so the doc churn lands lint-clean.

- **F5 — factory-clone precondition retired, by class**: `docs/STARTING-A-PROJECT.md` teaches the sibling layout (creation runs from anywhere; the kit clone is the kit's development home + seat of the guided flows), README Quickstart leads with `uv tool install agentive-kit && agentive new`, `/new-project` + `/setup-preset` (both 1.3.0) derive from `agentive new --help`, config-home prose matches the packaged anchor (`<projects-parent>/agentive-config`, the TARGET's parent) across preset.example, doctor anchoring notes (+ packaged twins), and `scripts/core/project`. Stale adopt-copies caveat and kit-clone `.env`-carryover prose corrected to the door's verified behavior.
- **F6 — runtime derivation verified**: neither command carries a flag list (single `--no-preset` prose mention, present in the help); pinned by `tests/agentive_kit/test_door_units.py::TestUsageText` (9 tests green).
- **KIT-0094 passenger**: `.markdownlint-cli2.jsonc` (same tool CodeRabbit runs; rule decisions incl. MD029 `one_or_ordered` recorded once — KIT-0092 retro #6), tree-wide pre-commit gate (`pass_filenames: false` — CLI paths extend config globs and bypass `ignores`, verified empirically), one class sweep: ~1,150 violations across 95 in-scope files → 0 (199 files linted). **Falsified once**: planted bare fence → hook exit 1; restore → pass.

## Grep proofs (F5 class kill)

No live surface invokes the door via the kit clone:

```text
$ grep -rniE "cd [^ ]*agentive-starter-kit.*(bootstrap|&& *claude)" --include="*.md" . | <records excluded>
README.md:77                      ← guided-route session mechanics (see below)
docs/STARTING-A-PROJECT.md:138    ← /setup-preset session mechanics
docs/STARTING-A-PROJECT.md:193    ← /new-project session mechanics
```

The three survivors open a Claude Code session for `/new-project` / `/setup-preset` — commands whose files live in this repo (builder-side) — and each sits beside a leading direct route stating creation needs no clone. `scripts/local/bootstrap` appears on live surfaces only as what it is: an exec shim over the packaged door, removal pinned KIT-0107. Records (tasks, ADRs, retros, reviews, archives, handoffs) stay as written, per the KIT-0094 scope precedent.

## Evaluator (Gate 5)

Prose-dominated sweep → **code-reviewer-fast only** per the standing exception (KIT-0069/KIT-0073, planner decision 2026-07-28); record in `.kit/context/reviews/KIT-0104-evaluator-review.md`. The FAIL verdict was refuted against the tree (the "conflicting ADR-0021 pair" is a 2026-03 superseded-by-declaration pair this PR touched only to tag fences). The only behavior-bearing hunks (lint config + hook) were falsified live. **Planner: this PR shape needs tree-grounded verification before merge** — sectioned verifiers against the branch.

## Test plan

- [x] Full fast suite: 1018 passed / 13 skipped (before and after the F5 rewrite)
- [x] `tests/test_door_data_sync.py` 29 passed — packaged twins (8 workflow docs, TASK-STARTER-TEMPLATE, CROSS-REPO-PATTERN, doctor check) mirrored same-commit
- [x] `markdownlint-cli2`: 0 issues in 199 files; gate falsified once (exit 1) and restored
- [x] F6 guard tests: 9 passed
- [x] CHANGELOG: door entry extended (PR 3), KIT-0094 Added entry
- [x] KIT-0094 residual acceptance ("next PR's CodeRabbit round produces zero markdown-style threads") is observed on THIS PR's bot round — noting the outcome in the completion report

Task spec: `.kit/tasks/3-in-progress/KIT-0104-ship-the-door-in-the-package.md` (task stays in 3-in-progress; planner moves it at the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GA8HqWKFEiswfgn4bshz8B

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7a5e09c9ba0d082ecb7860244057c07d69cf3901. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->