### PR TITLE
feat(KIT-0110): plugin_resync.py — codify the release resync method (PR 1/2)

### DIFF
--- a/.kit/context/KIT-0110-HANDOFF-feature-developer-f5.md
+++ b/.kit/context/KIT-0110-HANDOFF-feature-developer-f5.md
@@ -5,7 +5,7 @@ not delegate or spawn other agents.**
 
 **Date**: 2026-08-14
 **From**: planner-f5  **To**: feature-developer-f5
-**Task**: .kit/tasks/3-in-progress/KIT-0110-release-signal-integrity.md
+**Task**: .kit/tasks/4-in-review/KIT-0110-release-signal-integrity.md
 **Status**: Ready
 **Evaluation**: arch-review-fast REVISION_SUGGESTED — all 3 findings
 dispositioned in the spec header (base retrieval specified;

--- a/.kit/context/KIT-0110-MARKETPLACE-FOLLOWUPS.md
+++ b/.kit/context/KIT-0110-MARKETPLACE-FOLLOWUPS.md
@@ -1,0 +1,44 @@
+# KIT-0110 — marketplace-side follow-ups from PR movito/agentive-skills#10
+
+**From**: feature-developer-f5 (KIT-0110 session)
+**To**: planner — the KIT-0109 followups-file pattern; these are gaps
+against the MARKETPLACE repo, out of KIT-0110's scope by the handoff's
+routing rule ("marketplace-side → the KIT-0109 followups-file pattern
+via the planner")
+**Date**: 2026-08-14
+
+## F1 — No executable tests for `verify_plugin_integrity.py`
+
+**Severity**: low (CodeRabbit Trivial, PR #10 round 1, thread
+`PRRT_kwDOSj0O5s6ZTwR6`)
+
+The verifier's behavior is currently evidenced by falsification runs
+recorded in the PR body (green tree / bump-without-copy / malformed
+digest / planted unrostered + hidden files), not by automated fixtures.
+The marketplace repo has no test infrastructure at all — adding pytest
+fixtures means adding a second workflow (or extending the first) plus a
+dev-dependency story to a repo that deliberately has none.
+
+Resolution options for the planner:
+
+- accept the falsification-run story as the standing contract (each
+  future change to the script re-runs them, recorded in that PR), or
+- spec a small `tests/` + workflow step marketplace-side (the fixture
+  set is already enumerated in the CodeRabbit thread), or
+- mirror the script into the kit repo's test suite as a
+  characterization import (cross-repo path fragility — probably not).
+
+## F2 — markdownlint CI still absent (KIT-0109 retro item 3, still open)
+
+PR #10 added the repo's first workflow, which makes adding a
+markdownlint job trivially cheap now (the KIT-0109 retro flagged that
+the bots were the entire prose gate). Not done in KIT-0110 — zero
+content changes was an acceptance criterion and lint config is its own
+decision.
+
+## F3 — `merge_group` trigger if a merge queue is ever adopted
+
+CodeRabbit noted the verify workflow should carry a `merge_group:`
+trigger IF `main` uses a merge queue. It does not today; declined on
+the thread. If the operator ever enables a queue there, the trigger
+must be added or the required check blocks the queue.

--- a/.kit/context/KIT-0110-MARKETPLACE-FOLLOWUPS.md
+++ b/.kit/context/KIT-0110-MARKETPLACE-FOLLOWUPS.md
@@ -36,6 +36,24 @@ the bots were the entire prose gate). Not done in KIT-0110 — zero
 content changes was an acceptance criterion and lint config is its own
 decision.
 
+## F4 — Accepted residual: PR-ref execution of the verifier (round 2)
+
+**Severity**: accepted residual (CodeRabbit Major, PR #10 round 2,
+thread `PRRT_kwDOSj0O5s6ZUCvf`)
+
+On `pull_request`, the verify workflow executes the PR's own copy of
+`scripts/verify_plugin_integrity.py`, so a hostile PR could game its
+own check. Declined re-architecture (reusable workflow / second repo)
+because: the `push: branches: [main]` trigger re-runs the verifier
+from trusted post-merge code (a gamed PR check turns main red on
+merge — the loud failure this guard exists for); the threat model is
+accidental bump-without-copy by trusted sessions, not adversarial PRs
+(single-operator repo, human review on merge, fork PRs get read-only
+tokens, no secrets); and a same-repo reusable workflow is still taken
+from the PR ref on `pull_request`, so a real fix means
+`pull_request_target` (ruled out) or a second repo. **Revisit if the
+repo ever takes external contributors.**
+
 ## F3 — `merge_group` trigger if a merge queue is ever adopted
 
 CodeRabbit noted the verify workflow should carry a `merge_group:`

--- a/.kit/context/KIT-0110-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0110-REVIEW-STARTER.md
@@ -1,0 +1,79 @@
+# KIT-0110 — Review Starter
+
+**Task**: `.kit/tasks/4-in-review/KIT-0110-release-signal-integrity.md`
+**Date**: 2026-08-14
+**Agent**: feature-developer-f5 (session bcf683f0-era chain; this task's
+worktree: `../ask-worktrees/KIT-0110`)
+**Status**: Both PRs green, all bot threads resolved, ready for human
+review + merge
+
+## The two PRs (one mechanism, two repos)
+
+| PR | Repo | What | Bots |
+|---|---|---|---|
+| [#132](https://github.com/movito/agentive-starter-kit/pull/132) | kit | `scripts/local/plugin_resync.py` + 24 tests; drift-guard header states the division of verification; PyYAML `.venv` rider; consumer-sync exclusions (+ packaged twin) | 4 threads, all resolved + bot-confirmed |
+| [#10](https://github.com/movito/agentive-skills/pull/10) | marketplace | `plugin_sha256` column (all 27 shipped, computed by the tool — dogfood rule); `scripts/verify_plugin_integrity.py`; **the repo's first CI workflow**; roster header rewritten (what is verified WHERE) | 3 threads, all resolved; **CodeRabbit APPROVED** |
+
+The tool populates the column the check verifies — R1 emits
+`plugin_sha256`, R2's CI fails when a published body no longer matches
+it. Together with the existing kit-side guard this closes the
+bump-hashes-forget-bodies gap (KIT-0109 retro, Incident Closure 1).
+
+## Verification evidence
+
+- **Local**: 24 tests (work-list from hashes, clean merge preserves the
+  ADR-0025 generalization, conflict falsified, base-not-found fails
+  loud with nothing written, preflight missing-body abort, hashes-only
+  emission, schema/traversal rejection, anchored entry bounds).
+  Full `ci-check.sh` green.
+- **Real-tree**: dry-run → work-list empty (kit in sync at 2.0.4);
+  `--hashes-only` → 27 columns, spot-verified against `shasum`.
+- **Falsifications** (marketplace check): bump-without-copy → exit 1
+  naming the component; int-typed hash → schema exit 4 (never a
+  vacuous pass); planted `skills/self-review/HOWTO.md` +
+  `agents/.evil.md` → both flagged unrostered; restored → 27 verified,
+  exit 0.
+- **Cross-check**: kit drift guard re-run over the new column — stays
+  green (additive; parser not schema-fragile).
+- **Gate 5**: trio on PR 1 (fast CONCERNS / o3 FAIL / claude-code
+  APPROVED), fast+deep on PR 2 — every finding verified against code;
+  record `.kit/context/reviews/KIT-0110-evaluator-review.md`
+  (o3's headline mechanisms refuted both rounds: indented-frontmatter
+  YAML claim; pathlib-glob dotfile claim — verified empirically).
+
+## Bot-round summary
+
+- Kit #132 round 1: convergent BugBot Medium + CodeRabbit Major
+  (missing-body abort after merge writes → partial state) — fixed with
+  a preflight existence check + regression test; 2 minor threads
+  (regex, DK comment). Round 2 quiet.
+- Marketplace #10 round 1: workflow hardening (SHA-pinned actions,
+  read-only token, `persist-credentials: false`, `--require-hashes`
+  PyYAML) — all actioned; test-infra ask routed to the planner.
+  Round 2: PR-ref-execution Major dispositioned as accepted residual
+  (push-to-main re-run is the trusted backstop) — CodeRabbit then
+  APPROVED.
+- CodeRabbit rate-limit incident mid-task: org spending cap hit;
+  operator raised it; review completed after `@coderabbitai review`.
+
+## Follow-ups for the planner
+
+`.kit/context/KIT-0110-MARKETPLACE-FOLLOWUPS.md` (rides PR #132):
+F1 verify-script test infra (routed CodeRabbit ask), F2 markdownlint
+CI still open (KIT-0109 retro item 3), F3 conditional `merge_group`
+trigger, F4 accepted residual (PR-ref execution — revisit on external
+contributors).
+
+## Operator steps at completion (planner prompts)
+
+1. **Merge order**: either PR can merge first (kit tool and marketplace
+   column are independent until the next release); both should be in
+   before the KIT-0105 train.
+2. **After #10 merges**: mark **"Verify published bodies against
+   roster.yaml"** REQUIRED in movito/agentive-skills branch protection
+   for `main` (spec AC; the check is this repo's first).
+3. **Post-merge cross-check**: `workflow_dispatch` the kit drift guard
+   once #10 is on main — must stay green over the new column.
+4. **KIT-0105 release train**: first tooled cut — must use
+   `plugin_resync.py` and cite it in the release record (spec AC,
+   remains open until that release).

--- a/.kit/context/retros/KIT-0110-retro.md
+++ b/.kit/context/retros/KIT-0110-retro.md
@@ -1,0 +1,147 @@
+## KIT-0110 — Release tooling + verification: plugin_resync.py + the guard's blind half (PRs #132 + agentive-skills#10)
+
+**Date**: 2026-08-14
+**Agent**: feature-developer-f5
+**Mode**: single-repo by CLAUDE.md, two-repo by role — session home was
+the kit worktree (`../ask-worktrees/KIT-0110`, PR #132); the
+marketplace repo `movito/agentive-skills` was operated via `git -C` on
+a planner-created branch (PR #10). Kit metrics from
+movito/agentive-starter-kit, marketplace metrics from
+movito/agentive-skills, labeled throughout.
+**Scorecard**: 7 threads (4 + 3), 0 regressions, 2 fix rounds (1 + 1),
+10 commits (7 + 3). Both PRs green at handoff; marketplace PR carries
+a CodeRabbit APPROVED; no release artifact this task (the KIT-0105
+train is the tool's first consumer).
+
+### What Worked
+
+1. **Verify-before-believing refuted o3's headline mechanism in BOTH
+   Gate 5 rounds** — round 1: "indented `version:` frontmatter is
+   legal YAML the regex misses" (it is not a top-level mapping key);
+   round 2: "`Path.glob('*.md')` skips dotfiles" (30-second empirical
+   check: pathlib matches `.evil.md`; the dot-skipping is the `glob`
+   module's behavior). Both FAILs still carried salvageable kernels
+   (missing-git traceback; extra-file scan gap) that were actioned —
+   the o3 protocol of reproduce-or-refute per finding, ignoring the
+   verdict, keeps paying.
+2. **Pipelining PR 2 during PR 1's bot bake** — the marketplace
+   column, verify script, and workflow were built, falsified, and
+   Gate-5-reviewed inside PR #132's CI/bot windows. Two-repo task,
+   ~3.5 h wall-clock including a CodeRabbit outage.
+3. **The dogfood rule proved the tool before its own PR merged** —
+   PR 2's 27 `plugin_sha256` values were computed by PR 1's
+   `--hashes-only` mode and one was independently spot-checked against
+   `shasum`. "If the tool can't produce them, the tool isn't done"
+   was directly testable and passed.
+4. **Convergence separated the real defects from the noise** — the two
+   findings that mattered arrived twice each: BugBot Medium +
+   CodeRabbit Major on the partial-write ordering (kit), fast + deep
+   on the narrow-glob scan gap (marketplace). Everything singly-
+   sourced was either refuted or a nit. Convergence-as-signal is
+   worth remembering when triaging mixed rounds.
+5. **Falsification-first check design** — every failure shape of the
+   marketplace check was demonstrated live before its PR opened
+   (bump-without-copy → 1, malformed digest → 4, planted hidden +
+   nested files → 1, restored → 0), and the kit guard was re-run over
+   the new column (green, additive). The evidence table went straight
+   into the PR body, which is likely why round 1 had no
+   correctness findings against the script's core logic.
+
+### What Was Surprising
+
+1. **The bots caught what the trio missed, in both repos, in the same
+   class** — execution-order and CI-architecture defects. The trio
+   read the same `plugin_resync.py` and never flagged that the
+   missing-body abort fired AFTER merge writes (violating the file's
+   own "nothing written" comment); claude-code explicitly analyzed
+   that path and concluded ✅. Marketplace-side, no evaluator
+   mentioned action pinning, token permissions, or PR-ref execution —
+   zizmor (inside CodeRabbit) owned that dimension outright. The
+   known evaluator blind spot (CSS/dual-render) has a sibling:
+   workflow/execution-context classes.
+2. **CodeRabbit hit the org's fair-usage spending cap mid-task** — #10
+   sat unreviewed behind "Next review available in: 51 minutes" +
+   billing-cap notice; its commit-status meanwhile read `pass — Review
+   rate limited` (another lying-status face: *pass* while no review
+   exists). The operator raised the cap live; an explicit
+   `@coderabbitai review` comment was still required to trigger the
+   review afterward.
+3. **YAML typed my falsification input and accidentally falsified the
+   schema gate** — a 64-char all-digit "hash" parses as int, so the
+   intended hash-mismatch test hit the schema validator instead
+   (exit 4). One planted defect exercised two failure paths; the
+   letter-bearing retry then proved the mismatch path separately.
+4. **`agentive review-input` cannot serve a second repo** — it
+   resolves the repo from the CWD's CLAUDE.md and writes relative to
+   CWD, so PR 2's evaluator input was hand-assembled from the
+   template (KIT-0109 hit the same wall from the other side). The
+   fallback is documented and worked, but it is manual labor on
+   every marketplace-side review.
+
+### What Should Change
+
+1. **Pattern candidate: an all-or-nothing invariant must hold on EVERY
+   abort path** — the partial-write defect existed because the
+   "nothing written" preflight was built for one abort cause
+   (base-not-found) while a sibling cause (body-missing) aborted
+   mid-write. Same shape as `fix_by_class_not_instance`, but for
+   invariants: when code states an atomicity guarantee, enumerate the
+   abort paths and test each one against it. Planner call whether
+   this earns a patterns.yml entry.
+2. **`agentive review-input` could take `--repo-root`/`--output`** —
+   two tasks running (KIT-0109, KIT-0110) have now hand-assembled
+   marketplace review inputs. A small flag pair would make the helper
+   serve any local checkout. Rider-sized; planner to home it.
+3. **Marketplace follow-ups are filed, not lost** —
+   `.kit/context/KIT-0110-MARKETPLACE-FOLLOWUPS.md` (F1 test infra,
+   F2 markdownlint, F3 conditional `merge_group`, F4 accepted
+   residual PR-ref execution). Nothing further needed from this
+   session; listed here so the planner processes the file.
+
+### Permission Prompts Hit
+
+**None.** No tool call was blocked or required approval this session
+(both repos, all `gh`/`git`/evaluator invocations).
+
+### Process Actions Taken
+
+- [ ] Planner: decide whether "invariants hold on every abort path"
+      becomes a patterns.yml entry (What Should Change 1)
+- [ ] Planner: home the `agentive review-input --repo-root/--output`
+      rider (What Should Change 2)
+- [ ] Planner: process `.kit/context/KIT-0110-MARKETPLACE-FOLLOWUPS.md`
+      (F1–F4)
+- [ ] Operator at merge: mark "Verify published bodies against
+      roster.yaml" REQUIRED in agentive-skills branch protection;
+      `workflow_dispatch` the kit drift guard after #10 lands
+- [ ] KIT-0105 train: use `plugin_resync.py` and cite it in the
+      release record (spec AC, open until that cut)
+
+### Incident Closure
+
+1. **CodeRabbit fair-usage/spending cap blocked #10's review while its
+   commit-status read `pass`** — **not-checkable note already exists**
+   (`scripts/core/doctor.d/80-bot-presence.sh` CodeRabbit-quota note:
+   quota state is not cheaply checkable pre-flight). This incident
+   extends the class with confirming evidence: adaptive fair-usage
+   limits and org spending caps produce the same silent non-review,
+   and the status line says `pass` throughout — the reviewThreads-first
+   triage rule (bot-triage step 0) is what made the absence visible.
+   No new closure needed; recorded here as the class's next face,
+   with the recovery recipe (raise cap → `@coderabbitai review`).
+2. **`agentive review-input` unusable for the marketplace repo (CWD
+   CLAUDE.md auto-detection, CWD-relative output)** — **triage-guide
+   entry already exists**: the code-review-evaluator skill and the fd
+   agent's Phase 5 document manual assembly from
+   `.adversarial/templates/code-review-input-template.md`, which is
+   exactly what was done. The improvement path is the rider in What
+   Should Change 2, tracked as a process action, not an unclassified
+   incident.
+3. **zsh treated `===CLAUDE===` as a word and errored** — known
+   footgun already documented in both planner agents (KIT-0109 retro,
+   `=`-word); confirming evidence only, cost one retried command. No
+   new closure needed.
+
+No other environment incidents this session — the door-data byte-pin
+(`test_door_data_sync.py`) firing on the `engine-consumer.sh` edit was
+the guard working as designed, not an incident.

--- a/.kit/context/reviews/KIT-0110-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0110-evaluator-review.md
@@ -1,0 +1,77 @@
+# KIT-0110 — Evaluator Review Record (PR 1, kit repo)
+
+**Date**: 2026-08-14
+**Agent**: feature-developer-f5
+**Diff shape**: logic (new tool + tests) → full trio, `--format full`
+**Input**: `.adversarial/inputs/KIT-0110-code-review-input.md`
+(commit `1426ec3`)
+
+## Verdicts
+
+| Evaluator | Model | Verdict |
+|---|---|---|
+| code-reviewer-fast | gemini-2.5-flash | CONCERNS |
+| code-reviewer | o3 | FAIL |
+| claude-code | claude-sonnet-4-6 | APPROVED |
+
+Logs: `.adversarial/logs/KIT-0110-code-review-input--{code-reviewer-fast,code-reviewer,claude-code}.md`
+
+## Dispositions (every finding verified against code before acting)
+
+### Actioned
+
+1. **`_entry_bounds` unanchored matching** (claude-code, LOW —
+   CONFIRMED latent): a `why: >-` continuation line beginning
+   `- name:` could open/close an entry early. Fixed: both start and
+   end matches are now anchored to the roster's 2-space list indent;
+   regression test `test_entry_bounds_ignores_lookalike_in_why_text`.
+2. **Missing `git` binary → raw traceback** (kernel of o3 F2):
+   `subprocess.run` raises `FileNotFoundError` uncaught. Fixed: both
+   `_git()` and `merge_three_way()` convert it to a named
+   `ResyncError` ("git is not on PATH"), caught by the `main()`
+   wrapper → clean `EXIT_INTEGRITY`.
+3. **`_spec is None` on the guard import** (claude-code, LOW): now an
+   explicit `ImportError` naming the path.
+4. **`ResyncError` escaping `main()` as traceback** (self-review,
+   pre-trio): `main()` wraps `_main()` and converts to
+   `EXIT_INTEGRITY`.
+
+### Refuted (with reason)
+
+1. **o3 F1 "indented `version:` frontmatter silently ignored"** — an
+   indented `version:` is not a top-level YAML key; the zero-indent
+   regex matches the only legal form. The cited "legal YAML with
+   optional indentation" is not legal YAML for a mapping key.
+2. **o3 F2 as stated ("merge-file rc=1 with empty stdout classified as
+   conflict")** — rc 1 means exactly 1 conflict by the documented
+   contract, and conflict output always carries the merged content;
+   the only real failure shape (missing git binary) is fixed above.
+3. **o3 F3 "spaces/control chars in source reach git"** — list-arg
+   subprocess, no shell; git receives the pathspec literally. A
+   nonexistent path fails the rev walk → loud base-not-found, never
+   silent.
+4. **fast F1 `plugin_body_relpath` KeyError** — `name` is guaranteed
+   by the guard's `_validate_components` before any call.
+5. **fast F4 / claude-code "YAML injection via set_entry_field"** —
+   evaluator self-refuted: hashes are hex-only, `kit_version` is
+   quoted, the version regex excludes quotes/newlines.
+
+### Declined (out of contract, recorded)
+
+1. **CRLF preservation on roster rewrite** (o3) — the roster is
+   LF-committed in movito/agentive-skills; newline-convention
+   detection is speculative surface.
+2. **History-walk depth limit** (claude-code) — infrequent local tool;
+   walk length is bounded by per-file commit count.
+3. **4-space field indent assumption** (claude-code) — the roster's
+   established format is the tool's documented contract; the guard's
+   parser and this tool share it.
+4. **Import-time `exec_module` of the guard** (claude-code, MEDIUM) —
+   the guard is `__main__`-guarded with no module-level side effects;
+   the pattern is the kit's established scripts/local convention
+   (same load in `tests/test_plugin_drift.py`).
+
+## Known blind spot note
+
+No CSS/dual-render surface in this diff; the known evaluator blind
+spot does not apply.

--- a/.kit/context/reviews/KIT-0110-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0110-evaluator-review.md
@@ -75,3 +75,68 @@ Logs: `.adversarial/logs/KIT-0110-code-review-input--{code-reviewer-fast,code-re
 
 No CSS/dual-render surface in this diff; the known evaluator blind
 spot does not apply.
+
+---
+
+# PR 2 (marketplace repo, movito/agentive-skills) — Gate 5 record
+
+**Date**: 2026-08-14
+**Diff shape**: logic (new verify script + first CI workflow + roster
+column/header) → fast + deep, hand-assembled full-content input
+(`.adversarial/inputs/KIT-0110-pr2-code-review-input.md`; the
+marketplace repo has no helper infra)
+
+## Verdicts
+
+| Evaluator | Model | Verdict |
+|---|---|---|
+| code-reviewer-fast | gemini-2.5-flash | CONCERNS |
+| code-reviewer | o3 | FAIL |
+
+Logs: `.adversarial/logs/KIT-0110-pr2-code-review-input--{code-reviewer-fast,code-reviewer}.md`
+claude-code tier skipped: the script's security surface (local file
+hashing, no network, no subprocess) is a strict subset of PR 1's,
+which claude-code APPROVED the same day.
+
+## Dispositions
+
+### Actioned
+
+1. **Narrow globs let extra files ship undetected** (o3 + fast,
+   CONVERGENT — CONFIRMED): `agents/*.md` / `skills/*/SKILL.md` missed
+   `skills/x/HOWTO.md`, `agents/notes.txt`. Fixed: the unrostered scan
+   now walks `agents/`, `commands/`, `skills/` recursively and flags
+   EVERY non-rostered file. Falsified live: planted
+   `skills/self-review/HOWTO.md` + `agents/.evil.md` → both flagged,
+   exit 1; removed → 27 verified, exit 0.
+2. **Leading-dot component names produce hidden shipped files** (o3 —
+   CONFIRMED latent): `_SAFE_NAME` tightened to forbid a leading dot,
+   in the marketplace script AND kit-side `plugin_resync.py` (fix the
+   class, not the instance).
+
+### Refuted (with reason)
+
+1. **o3 headline "dot-prefixed bodies escape `Path.glob`"** — verified
+   empirically: `pathlib.Path.glob('*.md')` DOES match `.evil.md`
+   (dotfile-skipping is the `glob` module's behavior, not pathlib's).
+   The FAIL's stated mechanism is wrong; the surviving kernel is the
+   extra-file gap actioned above.
+2. **fast "`body_relpath` implicitly returns None on unknown kind"** —
+   it cannot: the final branch is an unconditional return, and
+   `load_components` rejects unknown kinds for shipped entries before
+   any call.
+3. **fast "missing `ships` silently treated as false"** — intentional;
+   identical semantics to the kit guard's parser.
+
+### Declined (out of contract, recorded)
+
+1. **Hard-coded plugin dir breaks forks** (o3) — this repo IS the
+   single-plugin marketplace; a fork edits one constant.
+2. **2 GB body OOM / streamed hashing** (o3) — repo-controlled
+   markdown bodies; speculative surface.
+3. **Duplicate ships:false entries abort** (o3) — strictness is
+   deliberate: the roster is a decision record; duplicates in it are a
+   defect worth loudness.
+4. **Unit-test gaps** (o3) — the marketplace repo has no test infra by
+   design (KIT-0109 retro item 3 notes the tradeoff); the falsification
+   runs above are the test story, recorded in the PR body.

--- a/.kit/tasks/4-in-review/KIT-0110-release-signal-integrity.md
+++ b/.kit/tasks/4-in-review/KIT-0110-release-signal-integrity.md
@@ -1,6 +1,6 @@
 # KIT-0110: Release tooling + verification — `plugin_resync.py` and the guard's blind half
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: medium-high — **sequence BEFORE the KIT-0105 release**,
 so that train is the first release cut with real tooling instead of a
 fourth hand-rolled resync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`scripts/local/plugin_resync.py` — the release resync tool**
+  (KIT-0110 R1): codifies the method three releases ran as hand-rolled
+  `/tmp` tooling. Work-list from roster hashes (never `git diff`,
+  KIT-0099); three-way merge per drifted component (base = the kit
+  file's historical content matching the rostered `kit_sha256`, found
+  by history-walk + hash-match; theirs = kit working tree; ours = the
+  published plugin body) so the KIT-ADR-0025 generalization is never
+  flattened by a copy; conflicts surfaced as `<body>.conflict` beside
+  an untouched published body, never auto-resolved; base-not-found
+  fails loud naming the component, with nothing written. Maintains the
+  roster's hash columns: `kit_sha256`/`kit_version` refreshed on clean
+  merges, and the new `plugin_sha256` column (hash of each shipped
+  body) written for every shipped component — the input for the
+  marketplace-side CI check that closes the drift guard's blind half
+  (KIT-0109 retro: a bump-hashes-forget-bodies release previously went
+  green with stale content published). `--dry-run` emits the work-list
+  only; `--hashes-only` refreshes the column without touching bodies.
+  Reuses the drift guard's roster parser so tool and guard cannot
+  disagree about the schema. The guard's header now states the
+  division of verification (kit ↔ roster here; published bodies
+  marketplace-side), and its PyYAML error message points at the kit's
+  `.venv`.
 - **Markdown lint owned locally — KIT-0094** (passenger on the
   KIT-0104 prose-sweep PR): `.markdownlint-cli2.jsonc` runs the same
   tool CodeRabbit runs, scoped to live markdown (historical records,

--- a/packages/agentive-kit/src/agentive_kit/door/engines/engine-consumer.sh
+++ b/packages/agentive-kit/src/agentive_kit/door/engines/engine-consumer.sh
@@ -490,6 +490,7 @@ rm -f "$TARGET/.github/workflows/sync-core-scripts.yml"
 # would otherwise leave the orphaned tests behind in existing consumers.
 rm -f "$TARGET/tests/test_kit_markers.py" \
       "$TARGET/tests/test_plugin_drift.py" \
+      "$TARGET/tests/test_plugin_resync.py" \
       "$TARGET/tests/test_bootstrap_consumer.py" \
       "$TARGET/tests/test_bootstrap_shapes.py" \
       "$TARGET/tests/test_bots_conformance.py" \
@@ -502,6 +503,7 @@ rm -f "$TARGET/tests/test_kit_markers.py" \
       "$TARGET/tests/test_setup_door.py"
 "${RSYNC_BASE[@]}" --exclude='test_kit_markers.py' \
     --exclude='test_plugin_drift.py' \
+    --exclude='test_plugin_resync.py' \
     --exclude='test_bootstrap_consumer.py' \
     --exclude='test_bootstrap_shapes.py' \
     --exclude='test_bots_conformance.py' \

--- a/scripts/local/check_plugin_drift.py
+++ b/scripts/local/check_plugin_drift.py
@@ -20,6 +20,17 @@ June→August 2026 staleness (plugin shipping v6/v7-era agents, no planner)
 recurs silently without it. Kit-internal: lives in ``scripts/local/`` and is
 NOT synced to consumer projects (their ``.claude/`` comes from the plugin).
 
+**Division of verification (KIT-0110)**: this guard verifies KIT ↔ ROSTER
+only — each shipped entry's ``kit_sha256`` against the kit source tree. It
+never opens the published plugin bodies, and deliberately cannot: those
+differ from canon by design (generalization per KIT-ADR-0025), so a
+kit-side byte comparison would always fail. The published bodies are
+verified MARKETPLACE-side instead: ``roster.yaml`` records each shipped
+body's ``plugin_sha256`` (maintained by ``plugin_resync.py``), and CI in
+movito/agentive-skills compares recorded vs actual. A
+bump-hashes-forget-bodies release is caught there, not here (KIT-0109
+retro: this guard alone goes green over stale published content).
+
 Runs in CI only — it fetches the roster over the network by default, so it
 must never be wired into pre-commit. Exit codes follow the kit convention:
 ``0`` in sync, ``1`` drift detected, ``2`` usage/environment error,
@@ -80,7 +91,10 @@ def parse_roster(text: str) -> list[dict]:
     try:
         import yaml
     except ImportError as exc:  # pragma: no cover - environment guard
-        print("ERROR: PyYAML is required (pip install pyyaml).")
+        print(
+            "ERROR: PyYAML is required — the kit ships it in .venv "
+            "(run via .venv/bin/python), or pip install pyyaml."
+        )
         raise SystemExit(EXIT_USAGE) from exc
     try:
         data = yaml.safe_load(text)

--- a/scripts/local/engine-consumer.sh
+++ b/scripts/local/engine-consumer.sh
@@ -490,6 +490,7 @@ rm -f "$TARGET/.github/workflows/sync-core-scripts.yml"
 # would otherwise leave the orphaned tests behind in existing consumers.
 rm -f "$TARGET/tests/test_kit_markers.py" \
       "$TARGET/tests/test_plugin_drift.py" \
+      "$TARGET/tests/test_plugin_resync.py" \
       "$TARGET/tests/test_bootstrap_consumer.py" \
       "$TARGET/tests/test_bootstrap_shapes.py" \
       "$TARGET/tests/test_bots_conformance.py" \
@@ -502,6 +503,7 @@ rm -f "$TARGET/tests/test_kit_markers.py" \
       "$TARGET/tests/test_setup_door.py"
 "${RSYNC_BASE[@]}" --exclude='test_kit_markers.py' \
     --exclude='test_plugin_drift.py' \
+    --exclude='test_plugin_resync.py' \
     --exclude='test_bootstrap_consumer.py' \
     --exclude='test_bootstrap_shapes.py' \
     --exclude='test_bots_conformance.py' \

--- a/scripts/local/plugin_resync.py
+++ b/scripts/local/plugin_resync.py
@@ -55,6 +55,8 @@ from pathlib import Path
 # roster is (KIT-0110 evaluator F3).
 _GUARD_PATH = Path(__file__).resolve().parent / "check_plugin_drift.py"
 _spec = importlib.util.spec_from_file_location("check_plugin_drift", _GUARD_PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"cannot load the drift guard from {_GUARD_PATH}")
 _guard = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_guard)
 
@@ -81,10 +83,13 @@ def sha256_bytes(data: bytes) -> str:
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["git", "-C", str(repo), *args],
-        capture_output=True,
-    )
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        raise ResyncError("git is not on PATH — the resync needs it") from exc
 
 
 def plugin_body_relpath(comp: dict) -> str:
@@ -158,21 +163,22 @@ def merge_three_way(ours: bytes, base: bytes, theirs: bytes) -> tuple[bytes, boo
         paths = (tdp / "ours", tdp / "base", tdp / "theirs")
         for path, data in zip(paths, (ours, base, theirs)):
             path.write_bytes(data)
-        proc = subprocess.run(
-            [
-                "git",
-                "merge-file",
-                "--stdout",
-                "-L",
-                "plugin (published)",
-                "-L",
-                "base (rostered kit)",
-                "-L",
-                "kit (current)",
-                *(str(p) for p in paths),
-            ],
-            capture_output=True,
-        )
+        cmd = [
+            "git",
+            "merge-file",
+            "--stdout",
+            "-L",
+            "plugin (published)",
+            "-L",
+            "base (rostered kit)",
+            "-L",
+            "kit (current)",
+            *(str(p) for p in paths),
+        ]
+        try:
+            proc = subprocess.run(cmd, capture_output=True)
+        except FileNotFoundError as exc:
+            raise ResyncError("git is not on PATH — the resync needs it") from exc
     if proc.returncode == 255 or proc.returncode < 0:
         raise ResyncError(
             f"git merge-file failed: {proc.stderr.decode('utf-8', 'replace').strip()}"
@@ -195,19 +201,26 @@ def frontmatter_version(text: str) -> str | None:
 
 
 def _entry_bounds(lines: list[str], name: str) -> tuple[int, int]:
-    """Start/end line indices of a component's roster entry."""
+    """Start/end line indices of a component's roster entry.
+
+    Both matches are anchored to the roster's 2-space list indent so a
+    ``why: >-`` continuation line that happens to begin with ``- name:``
+    (indented deeper) can never open or close an entry (KIT-0110
+    evaluator: latent split risk in unanchored matching).
+    """
     start = None
     for i, line in enumerate(lines):
-        # `==` on the stripped line: exact-entry match, so `feature-developer`
-        # can never claim `feature-developer-f5`'s block.
-        if line.strip() == f"- name: {name}":
+        # `==` (rstrip only): exact-entry match at the list indent, so
+        # `feature-developer` can never claim `feature-developer-f5`'s
+        # block and a deeper-indented lookalike never matches.
+        if line.rstrip() == f"  - name: {name}":
             start = i
             break
     if start is None:
         raise ResyncError(f"{name}: no roster entry found for update")
     end = len(lines)
     for i in range(start + 1, len(lines)):
-        if lines[i].lstrip().startswith("- name:"):
+        if lines[i].startswith("  - name:"):
             end = i
             break
     return start, end

--- a/scripts/local/plugin_resync.py
+++ b/scripts/local/plugin_resync.py
@@ -64,8 +64,10 @@ PLUGIN_REL = "plugins/agentive-workflow"
 ROSTER_REL = f"{PLUGIN_REL}/roster.yaml"
 
 # Component names become file paths under the plugin tree; refuse anything
-# that could traverse (the roster is data, not trusted input).
-_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+# that could traverse (the roster is data, not trusted input). No leading
+# dot: a hidden shipped file is never a legitimate component (KIT-0110
+# evaluator; same rule as the marketplace-side verify script).
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 EXIT_OK = 0
 EXIT_CONFLICTS = 1

--- a/scripts/local/plugin_resync.py
+++ b/scripts/local/plugin_resync.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Plugin resync tool (KIT-0110): codify the release resync method.
+
+Three releases (2.0.2 → 2.0.4) ran this method as hand-rolled ``/tmp``
+tooling — the kit's own third-occurrence rule. What it does, per shipped
+component in ``plugins/agentive-workflow/roster.yaml``:
+
+1. **Work-list from roster hashes, never ``git diff``** (KIT-0099): a
+   component is drifted when the sha256 of its kit source file no longer
+   matches the rostered ``kit_sha256``.
+2. **Three-way merge, never copy** (KIT-0109): base = the kit file's
+   content at the previously-rostered hash, theirs = the kit working
+   tree, ours = the published plugin body. A straight copy would flatten
+   the KIT-ADR-0025 generalization the plugin bodies legitimately carry.
+   ``kit_sha256`` is a CONTENT hash, not a git blob id — the base is
+   found by walking the kit file's history and hashing each version
+   until it matches (``find_base_content``). No historical match is a
+   loud per-component failure (exit 3), never a silent copy.
+3. **Conflicts are surfaced, not solved**: a conflicting merge leaves
+   the published body untouched and writes the conflict-marked result
+   next to it as ``<body>.conflict`` for the human (exit 1).
+4. **Roster maintenance**: cleanly resynced entries get their
+   ``kit_sha256`` (and ``kit_version``, from the kit file's frontmatter)
+   refreshed, and every shipped entry gets ``plugin_sha256`` — the hash
+   of the published body — recomputed. That column is what the
+   marketplace-side CI check verifies (the drift guard's blind half;
+   see the division-of-verification note in ``check_plugin_drift.py``).
+
+Modes: default = full resync; ``--dry-run`` emits the work-list only;
+``--hashes-only`` skips all body writes and only refreshes the
+``plugin_sha256`` column (used to populate the column without touching
+content).
+
+Kit-internal: lives in ``scripts/local/`` and is NOT synced to consumer
+projects. Both repos are local checkouts — no network. Exit codes follow
+the kit convention: ``0`` success, ``1`` conflicts surfaced, ``2``
+usage/environment error, ``3`` integrity error (base not found, or a
+published body missing in ``--hashes-only`` mode), ``4`` roster
+read/parse error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Reuse the drift guard's roster parser (same schema, same validation) so
+# the resync tool and the guard can never disagree about what a valid
+# roster is (KIT-0110 evaluator F3).
+_GUARD_PATH = Path(__file__).resolve().parent / "check_plugin_drift.py"
+_spec = importlib.util.spec_from_file_location("check_plugin_drift", _GUARD_PATH)
+_guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guard)
+
+PLUGIN_REL = "plugins/agentive-workflow"
+ROSTER_REL = f"{PLUGIN_REL}/roster.yaml"
+
+# Component names become file paths under the plugin tree; refuse anything
+# that could traverse (the roster is data, not trusted input).
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+EXIT_OK = 0
+EXIT_CONFLICTS = 1
+EXIT_USAGE = 2
+EXIT_INTEGRITY = 3
+EXIT_ROSTER_IO = 4
+
+
+class ResyncError(Exception):
+    """A per-component or environment failure worth naming loudly."""
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+    )
+
+
+def plugin_body_relpath(comp: dict) -> str:
+    """Relative path (under the plugin dir) of a component's shipped body."""
+    kind = comp.get("kind")
+    name = comp["name"]
+    if kind == "agent":
+        return f"agents/{name}.md"
+    if kind == "command":
+        return f"commands/{name}.md"
+    if kind == "skill":
+        return f"skills/{name}/SKILL.md"
+    raise ResyncError(f"{name}: unknown kind {kind!r} — cannot derive body path")
+
+
+def validate_shipped(components: list[dict]) -> None:
+    """Resync-specific validation on top of the guard's schema checks.
+
+    The guard validates names/sources/hashes generically; the resync tool
+    additionally derives filesystem paths from ``kind`` + ``name``, so
+    both must be safe before any path is built.
+    """
+    problems: list[str] = []
+    for comp in components:
+        if not comp.get("ships", False):
+            continue
+        name = comp.get("name", "<unnamed>")
+        if not _SAFE_NAME.match(name):
+            problems.append(f"{name!r}: unsafe component name for path use")
+        if comp.get("kind") not in ("agent", "command", "skill"):
+            problems.append(f"{name}: unknown kind {comp.get('kind')!r}")
+    if problems:
+        print("ERROR: roster records unusable for resync:")
+        for p in problems:
+            print(f"  - {p}")
+        raise SystemExit(EXIT_ROSTER_IO)
+
+
+def find_base_content(kit_root: Path, source: str, want_sha256: str) -> bytes | None:
+    """Return the historical kit content whose sha256 matches the roster.
+
+    ``kit_sha256`` is a content hash, not a git blob id, so the base is
+    found by walking the file's history (``git log --format=%H --
+    <path>``) and hashing each version (``git show <rev>:<path>``) until
+    one matches. Returns None when no historical version matches — the
+    caller must fail loud, never fall back to a copy.
+    """
+    proc = _git(kit_root, "log", "--format=%H", "--", source)
+    if proc.returncode != 0:
+        raise ResyncError(
+            f"git log failed for {source} in {kit_root}: "
+            f"{proc.stderr.decode('utf-8', 'replace').strip()}"
+        )
+    for rev in proc.stdout.decode("utf-8").split():
+        shown = _git(kit_root, "show", f"{rev}:{source}")
+        if shown.returncode != 0:
+            continue  # path absent at this rev (e.g. a deletion commit)
+        if sha256_bytes(shown.stdout) == want_sha256:
+            return shown.stdout
+    return None
+
+
+def merge_three_way(ours: bytes, base: bytes, theirs: bytes) -> tuple[bytes, bool]:
+    """git merge-file: apply base→theirs (kit) changes onto ours (plugin).
+
+    Returns (merged_bytes, clean). git merge-file exits with the number
+    of conflicts (0..127) or 255 on error.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        paths = (tdp / "ours", tdp / "base", tdp / "theirs")
+        for path, data in zip(paths, (ours, base, theirs)):
+            path.write_bytes(data)
+        proc = subprocess.run(
+            [
+                "git",
+                "merge-file",
+                "--stdout",
+                "-L",
+                "plugin (published)",
+                "-L",
+                "base (rostered kit)",
+                "-L",
+                "kit (current)",
+                *(str(p) for p in paths),
+            ],
+            capture_output=True,
+        )
+    if proc.returncode == 255 or proc.returncode < 0:
+        raise ResyncError(
+            f"git merge-file failed: {proc.stderr.decode('utf-8', 'replace').strip()}"
+        )
+    return proc.stdout, proc.returncode == 0
+
+
+def frontmatter_version(text: str) -> str | None:
+    """Extract ``version:`` from a component file's YAML frontmatter."""
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None
+    for line in text[4:end].splitlines():
+        match = re.match(r"^version:\s*[\"']?([^\"'\n]+?)[\"']?\s*$", line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _entry_bounds(lines: list[str], name: str) -> tuple[int, int]:
+    """Start/end line indices of a component's roster entry."""
+    start = None
+    for i, line in enumerate(lines):
+        # `==` on the stripped line: exact-entry match, so `feature-developer`
+        # can never claim `feature-developer-f5`'s block.
+        if line.strip() == f"- name: {name}":
+            start = i
+            break
+    if start is None:
+        raise ResyncError(f"{name}: no roster entry found for update")
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if lines[i].lstrip().startswith("- name:"):
+            end = i
+            break
+    return start, end
+
+
+# Insertion anchors per field: a missing field is inserted directly after
+# the first anchor present, keeping the roster's established field order
+# (name, kind, ships, source, kit_version, kit_sha256, plugin_sha256, why).
+_FIELD_ANCHORS = {
+    "plugin_sha256": ("kit_sha256", "kit_version", "source"),
+    "kit_sha256": ("kit_version", "source"),
+    "kit_version": ("source",),
+}
+
+
+def set_entry_field(lines: list[str], name: str, field: str, value: str) -> None:
+    """Replace or insert one ``field: value`` line in a component's entry.
+
+    Textual, not YAML-roundtrip: the roster's header comments and field
+    order are part of its contract and a safe_load/dump cycle would
+    destroy them.
+    """
+    start, end = _entry_bounds(lines, name)
+    new_line = f"    {field}: {value}"
+    for i in range(start + 1, end):
+        if lines[i].lstrip().startswith(f"{field}:"):
+            lines[i] = new_line
+            return
+    for anchor in _FIELD_ANCHORS.get(field, ()):
+        for i in range(start + 1, end):
+            if lines[i].lstrip().startswith(f"{anchor}:"):
+                lines.insert(i + 1, new_line)
+                return
+    lines.insert(start + 1, new_line)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: never lets a ResyncError escape as a traceback."""
+    try:
+        return _main(argv)
+    except ResyncError as exc:
+        print(f"ERROR: {exc}")
+        return EXIT_INTEGRITY
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resync drifted kit components into the published "
+        "plugin via three-way merge, and maintain roster.yaml's hash "
+        "columns (kit_sha256 + plugin_sha256)."
+    )
+    parser.add_argument(
+        "--kit-root",
+        default=str(Path(__file__).resolve().parent.parent.parent),
+        help="kit repo root (default: this checkout)",
+    )
+    parser.add_argument(
+        "--marketplace-root",
+        required=True,
+        help="local checkout of the marketplace repo (movito/agentive-skills)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="emit the work-list only; write nothing",
+    )
+    parser.add_argument(
+        "--hashes-only",
+        action="store_true",
+        help="skip all body writes; only refresh the plugin_sha256 column",
+    )
+    args = parser.parse_args(argv)
+
+    kit_root = Path(args.kit_root)
+    marketplace_root = Path(args.marketplace_root)
+    plugin_dir = marketplace_root / PLUGIN_REL
+    roster_path = marketplace_root / ROSTER_REL
+
+    if not (kit_root / ".claude").is_dir():
+        print(f"ERROR: {kit_root} has no .claude/ directory — wrong --kit-root?")
+        return EXIT_USAGE
+    if not (kit_root / ".git").exists():
+        print(f"ERROR: {kit_root} is not a git checkout — history walk impossible.")
+        return EXIT_USAGE
+    if not roster_path.is_file():
+        print(f"ERROR: no roster at {roster_path} — wrong --marketplace-root?")
+        return EXIT_USAGE
+
+    roster_text = roster_path.read_text(encoding="utf-8")
+    components = _guard.parse_roster(roster_text)  # SystemExit 2/4 on bad roster
+    validate_shipped(components)
+
+    shipped = [c for c in components if c.get("ships", False)]
+
+    # ---- Work-list: roster-hash delta, never git diff (KIT-0099) ----
+    drifted: list[dict] = []
+    for comp in shipped:
+        source = comp.get("source")
+        recorded = comp.get("kit_sha256")
+        if source is None or recorded is None:
+            print(
+                f"ERROR: {comp['name']}: ships=true but roster lacks "
+                "source/kit_sha256 — fix the roster first (the drift guard "
+                "flags this too)."
+            )
+            return EXIT_ROSTER_IO
+        kit_file = kit_root / source
+        if not kit_file.is_file():
+            print(
+                f"ERROR: {comp['name']}: rostered source {source} is missing "
+                "from the kit — resolve the rename/deletion before resyncing."
+            )
+            return EXIT_INTEGRITY
+        if sha256_bytes(kit_file.read_bytes()) != recorded:
+            drifted.append(comp)
+
+    if drifted:
+        print(f"work-list: {len(drifted)} drifted component(s)")
+        for comp in drifted:
+            print(f"  - {comp['name']} ({comp['source']})")
+    else:
+        print("work-list: empty — kit matches the rostered hashes.")
+
+    if args.dry_run:
+        return EXIT_OK
+
+    roster_lines = roster_text.splitlines()
+
+    if args.hashes_only:
+        if drifted:
+            print(
+                "note: --hashes-only leaves the above drift untouched; the "
+                "column is computed from the published bodies as they are."
+            )
+        missing = []
+        for comp in shipped:
+            body = plugin_dir / plugin_body_relpath(comp)
+            if not body.is_file():
+                missing.append(f"{comp['name']}: no published body at {body}")
+                continue
+            set_entry_field(
+                roster_lines,
+                comp["name"],
+                "plugin_sha256",
+                sha256_bytes(body.read_bytes()),
+            )
+        if missing:
+            print("ERROR: cannot hash missing bodies (run a full resync):")
+            for m in missing:
+                print(f"  - {m}")
+            return EXIT_INTEGRITY
+        roster_path.write_text("\n".join(roster_lines) + "\n", encoding="utf-8")
+        print(f"plugin_sha256 refreshed for {len(shipped)} shipped component(s).")
+        return EXIT_OK
+
+    # ---- Base lookup for every drifted component BEFORE any write ----
+    # (base-not-found aborts the whole run with nothing written; a silent
+    # partial state would be worse than the drift.)
+    bases: dict[str, bytes | None] = {}
+    not_found: list[str] = []
+    for comp in drifted:
+        body = plugin_dir / plugin_body_relpath(comp)
+        if not body.is_file():
+            bases[comp["name"]] = None  # new component: copy, no merge needed
+            continue
+        base = find_base_content(kit_root, comp["source"], comp["kit_sha256"])
+        if base is None:
+            not_found.append(
+                f"{comp['name']}: no version of {comp['source']} in kit "
+                f"history hashes to rostered {comp['kit_sha256'][:12]}… — "
+                "content never committed, or the file was renamed. Refusing "
+                "to fall back to a copy; fix the roster or history first."
+            )
+            continue
+        bases[comp["name"]] = base
+    if not_found:
+        print("ERROR: three-way merge base not found:")
+        for line in not_found:
+            print(f"  - {line}")
+        return EXIT_INTEGRITY
+
+    # ---- Merge and write ----
+    conflicts: list[str] = []
+    for comp in drifted:
+        name = comp["name"]
+        body = plugin_dir / plugin_body_relpath(comp)
+        theirs = (kit_root / comp["source"]).read_bytes()
+        if not body.is_file():
+            body.parent.mkdir(parents=True, exist_ok=True)
+            body.write_bytes(theirs)
+            print(f"  {name}: COPIED (new component, no published body yet)")
+        else:
+            merged, clean = merge_three_way(body.read_bytes(), bases[name], theirs)
+            if not clean:
+                conflict_path = body.with_name(body.name + ".conflict")
+                conflict_path.write_bytes(merged)
+                conflicts.append(name)
+                print(
+                    f"  {name}: CONFLICT — published body left untouched; "
+                    f"resolve {conflict_path} by hand, then re-run"
+                )
+                continue
+            body.write_bytes(merged)
+            print(f"  {name}: merged clean")
+        new_kit_sha = sha256_bytes(theirs)
+        set_entry_field(roster_lines, name, "kit_sha256", new_kit_sha)
+        version = frontmatter_version(theirs.decode("utf-8", "replace"))
+        if version is not None:
+            set_entry_field(roster_lines, name, "kit_version", f'"{version}"')
+
+    # ---- plugin_sha256 for every shipped component (R2's input) ----
+    for comp in shipped:
+        # Conflicted components keep their current published body, so the
+        # recomputed hash is still the truth about what ships.
+        body = plugin_dir / plugin_body_relpath(comp)
+        if not body.is_file():
+            print(f"ERROR: {comp['name']}: published body still missing at {body}")
+            return EXIT_INTEGRITY
+        set_entry_field(
+            roster_lines,
+            comp["name"],
+            "plugin_sha256",
+            sha256_bytes(body.read_bytes()),
+        )
+
+    roster_path.write_text("\n".join(roster_lines) + "\n", encoding="utf-8")
+
+    if conflicts:
+        print(
+            f"\n{len(conflicts)} conflict(s) surfaced ({', '.join(conflicts)}) — "
+            "roster hash columns updated for clean merges only."
+        )
+        return EXIT_CONFLICTS
+    resynced = len(drifted)
+    print(
+        f"\nresync complete: {resynced} component(s) merged, "
+        f"plugin_sha256 refreshed for {len(shipped)} shipped."
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/local/plugin_resync.py
+++ b/scripts/local/plugin_resync.py
@@ -121,6 +121,8 @@ def validate_shipped(components: list[dict]) -> None:
         name = comp.get("name", "<unnamed>")
         if not _SAFE_NAME.match(name):
             problems.append(f"{name!r}: unsafe component name for path use")
+        # `in` on the kinds tuple: membership check against the known
+        # component kinds, not substring matching (DK rule exception).
         if comp.get("kind") not in ("agent", "command", "skill"):
             problems.append(f"{name}: unknown kind {comp.get('kind')!r}")
     if problems:
@@ -378,6 +380,26 @@ def _main(argv: list[str] | None = None) -> int:
         print(f"plugin_sha256 refreshed for {len(shipped)} shipped component(s).")
         return EXIT_OK
 
+    # ---- Preflight: every shipped body must exist BEFORE any write ----
+    # A drifted component may legitimately lack a body (new component →
+    # copy); a NON-drifted shipped component with no body is an integrity
+    # error, and it must abort here — after the merge loop it would leave
+    # merged bodies on disk with the roster unwritten (bot round 1,
+    # convergent BugBot + CodeRabbit finding).
+    drifted_names = {c["name"] for c in drifted}
+    body_missing = [
+        f"{comp['name']}: rostered as shipped but no body at "
+        f"{plugin_body_relpath(comp)}"
+        for comp in shipped
+        if comp["name"] not in drifted_names
+        and not (plugin_dir / plugin_body_relpath(comp)).is_file()
+    ]
+    if body_missing:
+        print("ERROR: published bodies missing (nothing written):")
+        for line in body_missing:
+            print(f"  - {line}")
+        return EXIT_INTEGRITY
+
     # ---- Base lookup for every drifted component BEFORE any write ----
     # (base-not-found aborts the whole run with nothing written; a silent
     # partial state would be worse than the drift.)
@@ -439,6 +461,8 @@ def _main(argv: list[str] | None = None) -> int:
         # recomputed hash is still the truth about what ships.
         body = plugin_dir / plugin_body_relpath(comp)
         if not body.is_file():
+            # Belt only: the preflight above guarantees non-drifted bodies
+            # exist and the merge loop wrote every drifted one.
             print(f"ERROR: {comp['name']}: published body still missing at {body}")
             return EXIT_INTEGRITY
         set_entry_field(

--- a/tests/test_plugin_resync.py
+++ b/tests/test_plugin_resync.py
@@ -287,6 +287,40 @@ class TestBaseNotFound:
         assert roster.read_text(encoding="utf-8") == before_roster
         assert body.read_text(encoding="utf-8") == PLUGIN_BODY
 
+    def test_missing_body_on_undrifted_component_aborts_before_writes(
+        self, kit, marketplace, capsys
+    ):
+        """Bot round 1 (convergent BugBot + CodeRabbit): a non-drifted
+        shipped component with no published body must abort in preflight —
+        BEFORE the merge loop writes anything — never leave merged bodies
+        on disk with the roster unwritten."""
+        agent2 = kit / ".claude" / "agents" / "settled.md"
+        agent2.write_text("---\nname: settled\n---\nsettled body\n", encoding="utf-8")
+        _git(kit, "add", ".")
+        _git(kit, "commit", "-q", "-m", "add settled")
+        extra = f"""\
+  - name: settled
+    kind: agent
+    ships: true
+    source: .claude/agents/settled.md
+    kit_sha256: {_sha(agent2.read_bytes())}
+    why: >-
+      in-sync component whose body was never copied
+"""
+        # demo-agent IS drifted, so the merge loop would write its body —
+        # the preflight must fire first and write nothing at all.
+        roster = _write_roster(marketplace, _sha(V1_BODY.encode()), extra=extra)
+        before_roster = roster.read_text(encoding="utf-8")
+        body = (
+            marketplace / "plugins" / "agentive-workflow" / "agents" / "demo-agent.md"
+        )
+        assert _run(kit, marketplace) == prs.EXIT_INTEGRITY
+        out = capsys.readouterr().out
+        assert "settled" in out
+        assert "nothing written" in out
+        assert roster.read_text(encoding="utf-8") == before_roster
+        assert body.read_text(encoding="utf-8") == PLUGIN_BODY
+
     def test_missing_kit_source_fails_loud(self, kit, marketplace, capsys):
         _write_roster(marketplace, _sha(V1_BODY.encode()))
         (kit / ".claude" / "agents" / "demo-agent.md").unlink()

--- a/tests/test_plugin_resync.py
+++ b/tests/test_plugin_resync.py
@@ -1,0 +1,407 @@
+"""Tests for scripts/local/plugin_resync.py — the release resync tool.
+
+KIT-0110 R1: the tool derives its work-list from roster hashes (never
+git diff), three-way-merges kit changes onto the published plugin bodies
+(never copies over them), surfaces conflicts for the human, fails loud
+when the merge base can't be recovered from kit history, and maintains
+the roster's ``plugin_sha256`` column (the marketplace CI check's input).
+All tests run against tmp fixture repos — no network.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_MODULE_PATH = REPO_ROOT / "scripts" / "local" / "plugin_resync.py"
+
+# plugin_resync.py is kit-internal (scripts/local is not synced
+# downstream — consumers have no plugin roster to resync). The consumer
+# sync also excludes this test, but guard the load so a stray copy skips
+# cleanly.
+if not _MODULE_PATH.exists():
+    pytest.skip(
+        "plugin_resync.py present only in the kit repo",
+        allow_module_level=True,
+    )
+
+_spec = importlib.util.spec_from_file_location("plugin_resync", _MODULE_PATH)
+prs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prs)
+
+
+V1_BODY = """\
+---
+name: demo-agent
+version: 1.0.0
+---
+# Demo agent
+
+Shared intro line.
+
+## Project Context
+
+Kit-specific context the plugin generalizes away.
+
+## Workflow
+
+Step one.
+"""
+
+# v2 = kit moved on: a new workflow step at the bottom.
+V2_BODY = V1_BODY + "\nStep two (added since the last release).\n"
+
+# The published plugin body: derived from v1, with a legitimate
+# KIT-ADR-0025 generalization in the middle (non-overlapping with the
+# v1→v2 change).
+PLUGIN_BODY = V1_BODY.replace(
+    "Kit-specific context the plugin generalizes away.",
+    "Generalized context for downstream consumers.",
+)
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.invalid",
+            *args,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.fixture
+def kit(tmp_path):
+    """A miniature kit git repo whose one agent has v1 → v2 history."""
+    root = tmp_path / "kit"
+    (root / ".claude" / "agents").mkdir(parents=True)
+    _git(root, "init", "-q")
+    agent = root / ".claude" / "agents" / "demo-agent.md"
+    agent.write_text(V1_BODY, encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "v1")
+    agent.write_text(V2_BODY, encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "v2")
+    return root
+
+
+@pytest.fixture
+def marketplace(tmp_path):
+    """A miniature marketplace checkout: roster + one published body."""
+    root = tmp_path / "marketplace"
+    plugin = root / "plugins" / "agentive-workflow"
+    (plugin / "agents").mkdir(parents=True)
+    (plugin / "agents" / "demo-agent.md").write_text(PLUGIN_BODY, encoding="utf-8")
+    return root
+
+
+def _write_roster(marketplace: Path, kit_sha256: str, extra: str = "") -> Path:
+    roster = marketplace / "plugins" / "agentive-workflow" / "roster.yaml"
+    roster.write_text(
+        f"""\
+# roster header comment — must survive updates
+plugin: agentive-workflow
+plugin_version: "2.0.4"
+components:
+  - name: demo-agent
+    kind: agent
+    ships: true
+    source: .claude/agents/demo-agent.md
+    kit_version: "0.9.0"
+    kit_sha256: {kit_sha256}
+    why: >-
+      test agent
+  - name: kit-side-only
+    kind: agent
+    ships: false
+    source: .claude/agents/kit-side-only.md
+    why: >-
+      stays kit-side
+{extra}""",
+        encoding="utf-8",
+    )
+    return roster
+
+
+def _run(kit: Path, marketplace: Path, *flags: str) -> int:
+    return prs.main(
+        [
+            "--kit-root",
+            str(kit),
+            "--marketplace-root",
+            str(marketplace),
+            *flags,
+        ]
+    )
+
+
+class TestWorkList:
+    def test_in_sync_roster_yields_empty_worklist(self, kit, marketplace, capsys):
+        _write_roster(marketplace, _sha(V2_BODY.encode()))
+        assert _run(kit, marketplace, "--dry-run") == prs.EXIT_OK
+        assert "work-list: empty" in capsys.readouterr().out
+
+    def test_drift_detected_from_roster_hash_not_git_diff(
+        self, kit, marketplace, capsys
+    ):
+        """The delta comes from the rostered hash (KIT-0099), so a stale
+        roster flags drift even with a clean kit working tree."""
+        _write_roster(marketplace, _sha(V1_BODY.encode()))
+        assert _run(kit, marketplace, "--dry-run") == prs.EXIT_OK
+        out = capsys.readouterr().out
+        assert "1 drifted component(s)" in out
+        assert "demo-agent" in out
+
+    def test_dry_run_writes_nothing(self, kit, marketplace):
+        roster = _write_roster(marketplace, _sha(V1_BODY.encode()))
+        before_roster = roster.read_text(encoding="utf-8")
+        body = marketplace / "plugins" / "agentive-workflow" / "agents"
+        before_body = (body / "demo-agent.md").read_text(encoding="utf-8")
+        _run(kit, marketplace, "--dry-run")
+        assert roster.read_text(encoding="utf-8") == before_roster
+        assert (body / "demo-agent.md").read_text(encoding="utf-8") == before_body
+
+
+class TestThreeWayMerge:
+    def test_clean_merge_preserves_generalization(self, kit, marketplace):
+        """THE method (KIT-0109): kit v1→v2 change lands in the plugin
+        body WITHOUT flattening the ADR-0025 generalization."""
+        _write_roster(marketplace, _sha(V1_BODY.encode()))
+        assert _run(kit, marketplace) == prs.EXIT_OK
+        merged = (
+            marketplace / "plugins" / "agentive-workflow" / "agents" / "demo-agent.md"
+        ).read_text(encoding="utf-8")
+        assert "Step two (added since the last release)." in merged
+        assert "Generalized context for downstream consumers." in merged
+        assert "Kit-specific context" not in merged
+
+    def test_clean_merge_updates_roster_columns(self, kit, marketplace):
+        roster = _write_roster(marketplace, _sha(V1_BODY.encode()))
+        assert _run(kit, marketplace) == prs.EXIT_OK
+        text = roster.read_text(encoding="utf-8")
+        merged_body = (
+            marketplace / "plugins" / "agentive-workflow" / "agents" / "demo-agent.md"
+        ).read_bytes()
+        assert f"kit_sha256: {_sha(V2_BODY.encode())}" in text
+        assert f"plugin_sha256: {_sha(merged_body)}" in text
+        # kit_version refreshed from the component's frontmatter
+        assert 'kit_version: "1.0.0"' in text
+        # header comment and kit-side entry survive the textual update
+        assert text.startswith("# roster header comment")
+        assert "kit-side-only" in text
+
+    def test_kit_side_entries_untouched(self, kit, marketplace):
+        roster = _write_roster(marketplace, _sha(V1_BODY.encode()))
+        _run(kit, marketplace)
+        text = roster.read_text(encoding="utf-8")
+        # ships:false entries get no hash columns
+        kit_side = text[text.index("- name: kit-side-only") :]
+        assert "plugin_sha256" not in kit_side
+        assert "kit_sha256" not in kit_side
+
+    def test_conflict_surfaced_not_flattened(self, kit, marketplace, capsys):
+        """THE falsification (spec AC): divergent plugin body + canon
+        change on the same line → conflict surfaced, body untouched,
+        roster hash NOT bumped."""
+        agent = kit / ".claude" / "agents" / "demo-agent.md"
+        conflicted = V2_BODY.replace(
+            "Kit-specific context the plugin generalizes away.",
+            "Kit-specific context, rewritten in canon.",
+        )
+        agent.write_text(conflicted, encoding="utf-8")
+        _git(kit, "add", ".")
+        _git(kit, "commit", "-q", "-m", "v3 touches the generalized line")
+        roster = _write_roster(marketplace, _sha(V1_BODY.encode()))
+        assert _run(kit, marketplace) == prs.EXIT_CONFLICTS
+        out = capsys.readouterr().out
+        assert "CONFLICT" in out
+        body_dir = marketplace / "plugins" / "agentive-workflow" / "agents"
+        # published body untouched
+        assert (body_dir / "demo-agent.md").read_text(encoding="utf-8") == PLUGIN_BODY
+        # conflict-marked merge written beside it for the human
+        conflict_file = body_dir / "demo-agent.md.conflict"
+        assert conflict_file.is_file()
+        assert "<<<<<<<" in conflict_file.read_text(encoding="utf-8")
+        # roster still records the OLD kit hash for the conflicted entry
+        text = roster.read_text(encoding="utf-8")
+        assert f"kit_sha256: {_sha(V1_BODY.encode())}" in text
+        # but plugin_sha256 records the (unchanged) published body honestly
+        assert f"plugin_sha256: {_sha(PLUGIN_BODY.encode())}" in text
+
+    def test_new_component_without_body_is_copied(self, kit, marketplace):
+        """A rostered ships:true component with no published body yet is
+        copied (there is nothing to merge with) — loudly, not silently."""
+        agent2 = kit / ".claude" / "agents" / "brand-new.md"
+        agent2.write_text("---\nname: brand-new\n---\nnew body\n", encoding="utf-8")
+        _git(kit, "add", ".")
+        _git(kit, "commit", "-q", "-m", "add brand-new")
+        extra = f"""\
+  - name: brand-new
+    kind: agent
+    ships: true
+    source: .claude/agents/brand-new.md
+    kit_sha256: {"a" * 64}
+    why: >-
+      new component
+"""
+        _write_roster(marketplace, _sha(V2_BODY.encode()), extra=extra)
+        assert _run(kit, marketplace) == prs.EXIT_OK
+        copied = (
+            marketplace / "plugins" / "agentive-workflow" / "agents" / "brand-new.md"
+        )
+        assert copied.read_text(encoding="utf-8").endswith("new body\n")
+
+
+class TestBaseNotFound:
+    def test_unmatchable_hash_fails_loud_and_writes_nothing(
+        self, kit, marketplace, capsys
+    ):
+        """Spec AC: no historical version matches the rostered hash →
+        loud per-component failure, never a silent copy."""
+        roster = _write_roster(marketplace, "f" * 64)
+        before_roster = roster.read_text(encoding="utf-8")
+        body = (
+            marketplace / "plugins" / "agentive-workflow" / "agents" / "demo-agent.md"
+        )
+        assert _run(kit, marketplace) == prs.EXIT_INTEGRITY
+        out = capsys.readouterr().out
+        assert "demo-agent" in out
+        assert "Refusing" in out
+        assert roster.read_text(encoding="utf-8") == before_roster
+        assert body.read_text(encoding="utf-8") == PLUGIN_BODY
+
+    def test_missing_kit_source_fails_loud(self, kit, marketplace, capsys):
+        _write_roster(marketplace, _sha(V1_BODY.encode()))
+        (kit / ".claude" / "agents" / "demo-agent.md").unlink()
+        assert _run(kit, marketplace) == prs.EXIT_INTEGRITY
+        assert "missing from the kit" in capsys.readouterr().out
+
+
+class TestHashesOnly:
+    def test_column_populated_without_touching_bodies(self, kit, marketplace):
+        """R2's input: --hashes-only writes plugin_sha256 for every
+        shipped component and leaves drifted bodies alone."""
+        roster = _write_roster(marketplace, _sha(V1_BODY.encode()))
+        assert _run(kit, marketplace, "--hashes-only") == prs.EXIT_OK
+        text = roster.read_text(encoding="utf-8")
+        assert f"plugin_sha256: {_sha(PLUGIN_BODY.encode())}" in text
+        # drifted kit hash deliberately untouched in this mode
+        assert f"kit_sha256: {_sha(V1_BODY.encode())}" in text
+        body = (
+            marketplace / "plugins" / "agentive-workflow" / "agents" / "demo-agent.md"
+        )
+        assert body.read_text(encoding="utf-8") == PLUGIN_BODY
+
+    def test_existing_column_is_replaced_not_duplicated(self, kit, marketplace):
+        roster = _write_roster(marketplace, _sha(V2_BODY.encode()))
+        _run(kit, marketplace, "--hashes-only")
+        _run(kit, marketplace, "--hashes-only")
+        text = roster.read_text(encoding="utf-8")
+        assert text.count("plugin_sha256:") == 1
+
+    def test_missing_body_fails_loud(self, kit, marketplace, capsys):
+        _write_roster(marketplace, _sha(V2_BODY.encode()))
+        (
+            marketplace / "plugins" / "agentive-workflow" / "agents" / "demo-agent.md"
+        ).unlink()
+        assert _run(kit, marketplace, "--hashes-only") == prs.EXIT_INTEGRITY
+        assert "run a full resync" in capsys.readouterr().out
+
+
+class TestRosterValidation:
+    def test_malformed_roster_takes_guard_exit(self, kit, marketplace):
+        """Schema validation is the guard's own parser (evaluator F3) —
+        the two tools cannot disagree about what a valid roster is."""
+        roster = marketplace / "plugins" / "agentive-workflow" / "roster.yaml"
+        roster.write_text("components: [null]\n", encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            _run(kit, marketplace)
+        assert exc.value.code == prs.EXIT_ROSTER_IO
+
+    def test_unknown_kind_rejected(self, kit, marketplace):
+        extra = """\
+  - name: oddity
+    kind: gizmo
+    ships: true
+    source: .claude/agents/demo-agent.md
+    kit_sha256: deadbeef
+    why: >-
+      unknown kind
+"""
+        _write_roster(marketplace, _sha(V2_BODY.encode()), extra=extra)
+        with pytest.raises(SystemExit) as exc:
+            _run(kit, marketplace)
+        assert exc.value.code == prs.EXIT_ROSTER_IO
+
+    def test_traversal_name_rejected(self, kit, marketplace):
+        """Component names become body paths — a traversal name must die
+        in validation, never reach the filesystem."""
+        extra = f"""\
+  - name: ../../escape
+    kind: agent
+    ships: true
+    source: .claude/agents/demo-agent.md
+    kit_sha256: {_sha(V2_BODY.encode())}
+    why: >-
+      escape attempt
+"""
+        _write_roster(marketplace, _sha(V2_BODY.encode()), extra=extra)
+        with pytest.raises(SystemExit) as exc:
+            _run(kit, marketplace)
+        assert exc.value.code == prs.EXIT_ROSTER_IO
+
+    def test_missing_roster_is_usage_error(self, kit, tmp_path):
+        empty = tmp_path / "empty-marketplace"
+        empty.mkdir()
+        assert _run(kit, empty) == prs.EXIT_USAGE
+
+    def test_non_git_kit_root_is_usage_error(self, tmp_path, marketplace):
+        bare = tmp_path / "bare-kit"
+        (bare / ".claude").mkdir(parents=True)
+        _write_roster(marketplace, "0" * 64)
+        assert _run(bare, marketplace) == prs.EXIT_USAGE
+
+
+class TestHelpers:
+    def test_frontmatter_version_extracted(self):
+        assert prs.frontmatter_version(V1_BODY) == "1.0.0"
+
+    def test_frontmatter_version_absent(self):
+        assert prs.frontmatter_version("no frontmatter\n") is None
+        assert prs.frontmatter_version("---\nname: x\n---\nbody\n") is None
+
+    def test_entry_bounds_exact_name_match(self):
+        """`demo` must never claim `demo-f5`'s block (== on the stripped
+        line, not startswith)."""
+        lines = [
+            "components:",
+            "  - name: demo",
+            "    kind: agent",
+            "  - name: demo-f5",
+            "    kind: agent",
+        ]
+        start, end = prs._entry_bounds(lines, "demo")
+        assert (start, end) == (1, 3)
+        start, end = prs._entry_bounds(lines, "demo-f5")
+        assert (start, end) == (3, 5)
+
+    def test_skill_body_path(self):
+        comp = {"name": "self-review", "kind": "skill"}
+        assert prs.plugin_body_relpath(comp) == "skills/self-review/SKILL.md"

--- a/tests/test_plugin_resync.py
+++ b/tests/test_plugin_resync.py
@@ -388,8 +388,8 @@ class TestHelpers:
         assert prs.frontmatter_version("---\nname: x\n---\nbody\n") is None
 
     def test_entry_bounds_exact_name_match(self):
-        """`demo` must never claim `demo-f5`'s block (== on the stripped
-        line, not startswith)."""
+        """`demo` must never claim `demo-f5`'s block (== on the
+        indent-anchored line, not startswith)."""
         lines = [
             "components:",
             "  - name: demo",
@@ -401,6 +401,21 @@ class TestHelpers:
         assert (start, end) == (1, 3)
         start, end = prs._entry_bounds(lines, "demo-f5")
         assert (start, end) == (3, 5)
+
+    def test_entry_bounds_ignores_lookalike_in_why_text(self):
+        """A `why: >-` continuation line beginning `- name:` (indented
+        deeper than the list) must neither open nor close an entry."""
+        lines = [
+            "components:",
+            "  - name: demo",
+            "    kind: agent",
+            "    why: >-",
+            "      - name: demo is mentioned here in prose",
+            "  - name: next",
+            "    kind: agent",
+        ]
+        start, end = prs._entry_bounds(lines, "demo")
+        assert (start, end) == (1, 5)
 
     def test_skill_body_path(self):
         comp = {"name": "self-review", "kind": "skill"}


### PR DESCRIPTION
## Summary

- **`scripts/local/plugin_resync.py`** (KIT-0110 R1): the resync method three releases ran as hand-rolled `/tmp` tooling, codified.
  - Work-list from **roster hashes, never `git diff`** (KIT-0099)
  - **Three-way merge, never copy**: base found by history-walk + sha256 match against the rostered `kit_sha256` (a content hash, not a blob id); theirs = kit working tree; ours = published plugin body — the KIT-ADR-0025 generalization is never flattened
  - **Conflicts surfaced, not solved**: `<body>.conflict` written beside an untouched published body, exit 1
  - **Base-not-found fails loud** naming the component, with nothing written — never a silent copy
  - Maintains `kit_sha256`/`kit_version` on clean merges and writes the **`plugin_sha256` column** for every shipped component — the input for the marketplace-side CI check (PR 2 in movito/agentive-skills) that closes the drift guard's blind half (KIT-0109 retro: a bump-hashes-forget-bodies release previously went green with stale content published)
  - `--dry-run` (work-list only), `--hashes-only` (column refresh, zero body writes)
  - Reuses the drift guard's roster parser so tool and guard cannot disagree about the schema (evaluator F3)
- **`check_plugin_drift.py`**: header now states the division of verification (kit ↔ roster here; published bodies marketplace-side); PyYAML error message points at the kit's `.venv` (KIT-0109 rider)
- **Consumer boundary**: new test module-skips outside the kit and is excluded from the consumer tests sync (`engine-consumer.sh` + packaged twin, same commit per the door guard)

## Test plan

- [x] 23 new tests: work-list from hashes, clean merge preserves generalization, conflict falsified (body untouched, `.conflict` written, roster hash not bumped), base-not-found fails loud with nothing written, `--hashes-only` column emission, schema/traversal validation via the guard's parser, anchored entry bounds
- [x] Full `ci-check.sh` green (1133 passed)
- [x] Dry-run against the real repos: work-list empty (kit in sync with 2.0.4 roster)
- [x] Gate 5 trio ran pre-PR; record: `.kit/context/reviews/KIT-0110-evaluator-review.md`

Task: `.kit/tasks/3-in-progress/KIT-0110-release-signal-integrity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dymt1VESFpvEhfiXhDkwLe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 358fb969ff8f10f5c85e0dc459aaa5ce2bc9a5cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->