### PR TITLE
feat(KIT-0105): project-intake becomes location-agnostic (PR 1/3)

### DIFF
--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -260,7 +260,7 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    `origin`, do NOT run `gh repo create` — derive `owner/repo` from
    it per the "already has a remote" rules in Edge cases (github.com
    origins only). Otherwise:
-   `gh repo create <owner>/<name> --private --source <code-path> --push`
+   `gh repo create <owner>/<name> --private --source "<code-path>" --push`
    (or `--public` per the answer). If `gh` is unauthenticated or the
    user defers, print the manual commands and continue — the planning
    repo still records `<owner>/<name>` as the pointer.
@@ -281,10 +281,10 @@ rest, optional offers default to skip-with-notice). The door is a
 package command and runs from wherever you are:
 
 ```bash
-agentive new <parent>/<name>-planning \
+agentive new "<parent>/<name>-planning" \
   --shape planning \
-  --target-path ../<name> \
-  --target-github <owner>/<name>
+  --target-path "../<name>" \
+  --target-github "<owner>/<name>"
 ```
 
 - `--target-path`/`--target-github` are always passed explicitly —
@@ -399,9 +399,9 @@ Conventions). Explicit `git -C` here like everywhere else — the CWD
 rule means a bare `git commit` could hit the wrong repository:
 
 ```bash
-git -C <parent>/<name>-planning add -A
-git -C <parent>/<name>-planning diff --cached   # scan this output
-git -C <parent>/<name>-planning commit -m "chore: seed project context and backlog from prototype brief"
+git -C "<parent>/<name>-planning" add -A
+git -C "<parent>/<name>-planning" diff --cached   # scan this output
+git -C "<parent>/<name>-planning" commit -m "chore: seed project context and backlog from prototype brief"
 ```
 
 The scan between add and commit is the same staged-content credential

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -2,9 +2,9 @@
 name: project-intake
 description: Graduates a prototype into the split pair — plain code repo plus preset-configured planning repo — from a handoff brief and a code folder
 model: claude-sonnet-5
-version: 1.1.0
+version: 1.2.0
 origin: agentive-starter-kit
-last-updated: 2026-08-11
+last-updated: 2026-08-14
 created-by: "@movito (KIT-0066)"
 tools:
   - Read
@@ -48,12 +48,19 @@ operator's split pair, planner-ready in one invocation:
    setup door (the operator preset supplies shape, bots, evaluators,
    and env answers), then seeded from the brief
 
-**You compose the door; you never modify it.** `scripts/local/bootstrap`
-is out of bounds. If the flow exposes a genuine door gap, file a
-follow-up task in `.kit/tasks/1-backlog/` instead of patching the door.
+**You compose the door; you never modify it.** The door is the packaged
+`agentive new` (the `agentive-kit` package) — never patch the package
+or improvise a setup path around it. If the flow exposes a genuine
+door gap, report it to the operator with a ready-to-paste task body
+(a title line, one what/why paragraph, and a "done when" line) — they
+file it in the kit's backlog when they are next in the
+agentive-starter-kit repo.
 
-**Where you run**: from an agentive-starter-kit checkout — the door is
-kit-side only and does not ship to consumer projects.
+**Where you run**: anywhere — this agent ships with the
+`agentive-workflow` plugin, and the door is a package command with no
+path relationship to any kit checkout. The natural home is the
+prototype's own folder: open Claude in the Cowork output folder and
+run the intake in place, where the deliverable already sits.
 
 ## Response Format
 
@@ -62,8 +69,10 @@ Always begin responses with:
 
 ## Why the split pair (and why no kit in the code repo)
 
-The pattern is documented in `docs/CROSS-REPO-PATTERN.md` and is the
-default for production projects (KIT-ADR-0024 §1): planning artifacts
+The pattern is documented in `docs/CROSS-REPO-PATTERN.md` (the door
+seeds that doc into every planning repo it creates — references to it
+below resolve there, not in the prototype folder) and is the default
+for production projects (KIT-ADR-0024 §1): planning artifacts
 (task specs, handoffs, evaluation logs) live in the planning repo;
 the code repo stays clean — collaborators see plain PRs, never `.kit/`
 folders. That separation is also why the code repo can be published
@@ -75,11 +84,17 @@ the `## Target Repository` pointer the door records.
 
 Gather at startup (ask only for what's missing; infer what you can):
 
-1. **Brief path** — the markdown brief produced with
-   `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md`. If not given, look
+1. **Brief path** — the markdown brief produced with the kit's
+   prototype handoff template (seeded into planning repos at
+   `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md`). If not given, look
    for `PROTOTYPE-BRIEF.md` in the code folder root (the template's
    convention).
-2. **Code folder path** — the prototype's files.
+2. **Code folder path** — the prototype's files. If the user gives no
+   path, your own **working directory is the candidate** — the
+   intended flow opens Claude in the prototype folder itself. State
+   the assumption out loud ("treating `<cwd>` as the prototype
+   folder") and have the user confirm it before acting on it — never
+   silently assume.
 3. **Project name** — kebab-case repo name; default: the brief's
    project name, else the code folder's basename. **Validate before
    any shell use**: must match `^[a-z][a-z0-9-]{0,60}$` — no spaces,
@@ -108,17 +123,29 @@ the door verbatim.
 
 ### Step 0: Read the brief, verify the inputs
 
+**Verify the door first**: `command -v agentive`. If the CLI is
+missing, print the install instruction and stop until the operator has
+run it — an absent CLI is an instruction, never a dead end (the door's
+own degradation convention):
+
+```bash
+uv tool install agentive-kit
+```
+
+Everything from Step 3 on runs through that CLI; verifying it now
+beats discovering its absence after the code repo is half-made.
+
 Read the brief in full. Extract: project name, languages, key
 components, domain vocabulary, task prefix, decisions, solid/rough
 state, known issues, dependency and secret NAMES, and the next-steps
 list. Verify the code folder exists (as an absolute path) and skim
-its top level. **Refuse to proceed if the code folder is the kit
-checkout itself or any directory inside it** — the same guard the
-door applies to its own target.
+its top level. **Refuse to proceed if the code folder is an
+agentive-starter-kit checkout or any directory inside one** — the same
+guard the door applies to its own target.
 
 - **Task prefix**: use the brief's suggestion. If absent, derive it
-  with the bootstrap agent's rule (`.claude/agents/bootstrap.md`
-  Step 1): uppercase, no hyphens, max 6 chars — "recipe-api" → RECIPE,
+  from the project name: uppercase, no hyphens, max 6 chars —
+  "recipe-api" → RECIPE,
   "my-cool-app" → MCA. **Validate it HERE**, whichever source it came
   from: must match `^[A-Z][A-Z0-9]{0,5}$`. A malformed brief
   suggestion (lowercase, hyphens, too long) gets re-derived from the
@@ -238,7 +265,7 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    user defers, print the manual commands and continue — the planning
    repo still records `<owner>/<name>` as the pointer.
 6. **Do NOT install the kit here.** No `.kit/`, no `.claude/`, no
-   bootstrap run against this folder (see "Why the split pair" above).
+   door run against this folder (see "Why the split pair" above).
 
 ### Step 3: Planning repo — run the door
 
@@ -248,13 +275,13 @@ must BE the code folder (one directory check). `--target-path
 a nested or moved code folder would record a silently wrong pointer
 in the planning repo's CLAUDE.md.
 
-Then, from the kit checkout root, one door run — flags only, so it is
-non-TTY safe (the door never hangs: every question has a flag, the
-operator preset answers the rest, optional offers default to
-skip-with-notice):
+Then one door run — flags only, so it is non-TTY safe (the door never
+hangs: every question has a flag, the operator preset answers the
+rest, optional offers default to skip-with-notice). The door is a
+package command and runs from wherever you are:
 
 ```bash
-./scripts/local/bootstrap --new <parent>/<name>-planning \
+agentive new <parent>/<name>-planning \
   --shape planning \
   --target-path ../<name> \
   --target-github <owner>/<name>
@@ -268,13 +295,14 @@ skip-with-notice):
   remote's repo name differs from the chosen `<name>`, the remote
   wins — the pointer must name the repo that actually exists.
 - Do NOT pass `--name` or `--prefix`: the door refuses them for the
-  planning shape (`scripts/local/bootstrap:385-386`). The prefix
+  planning shape (its usage error names the illegal pair). The prefix
   lands in Step 4 instead.
-- **Line anchors in this file are dated 2026-07-24** — they locate
-  behavior, they don't define it. If an anchor doesn't match what you
-  see, trust the current file and the door's own errors/`--help`.
-- Do NOT route the brief through `--design-materials` — that flow is
-  adopt+single+python only (`bootstrap:383-384, 394-395, 403-404`).
+- The door's `--help` and its own error messages are authoritative —
+  if anything in this file appears to disagree with them, trust the
+  door.
+- Do NOT route the brief through `--design-materials` — the door
+  refuses it outside its one flow (single-shape python adopts), and
+  the refusal points back at this agent.
 
 **The door's exit contract is your interface** — program against it,
 never re-derive install state:
@@ -339,10 +367,29 @@ match `^[a-z0-9]+(-[a-z0-9]+)*$` and be at most 40 characters. The FULL
 filename must be unique — identical slugs are fine when the `NNNN`
 numbers differ (the number disambiguates); never overwrite an
 existing task file. The resolved path must stay under
-`.kit/tasks/1-backlog/` — no separators or `..` from brief content. Use the task skeleton from
-`.claude/agents/bootstrap.md` Step 9 (`**Status**: Backlog`), carrying
-the entry's title, what/why sentences, and its "done when" line as the
-first acceptance criterion. **Transcription only**: no elaboration, no
+`.kit/tasks/1-backlog/` — no separators or `..` from brief content.
+Each stub uses this skeleton, carrying the entry's title, what/why
+sentences, and its "done when" line as the first acceptance criterion:
+
+```markdown
+# <PREFIX>-NNNN: <entry title, transcribed>
+
+**Status**: Backlog
+**Priority**: medium (default — the planner re-triages)
+**Type**: Feature
+**Created**: <today's date>
+**Source**: prototype handoff brief
+
+## Summary
+
+<the entry's what/why sentences, transcribed>
+
+## Acceptance Criteria
+
+- [ ] <the entry's "done when" line, transcribed>
+```
+
+**Transcription only**: no elaboration, no
 re-prioritization, no decomposition into subtasks. If the backlog ever
 needs a smarter seeder, that is a separate component — not your job.
 
@@ -442,12 +489,16 @@ fixed at session launch — this session cannot become the planner.)
   project-context rules, and tell the user.
 - **Preset absent** (stranger machine): the door still works — required
   answers come from your flags, optional offers default to skip with a
-  notice. Relay the notices; suggest `/setup-preset` for next time.
+  notice. Relay the notices; suggest authoring an operator preset for
+  next time (`/setup-preset`, a builder-side command run in a kit-clone
+  session).
 
 ## Restrictions
 
-- **Never modify `scripts/local/bootstrap`** or its engines — file a
-  backlog task for genuine gaps instead
+- **Never modify the setup door** — not the `agentive-kit` package,
+  not (in a kit checkout) `scripts/local/bootstrap` or its engines.
+  Report genuine gaps to the operator as a ready-to-paste task body
+  instead
 - **Never delegate via the Task tool** — you run every step yourself
 - **Never install the kit into the code repo**
 - **Never print, stage, or commit secret values** — names only; the

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -1,6 +1,6 @@
 ---
 description: Interview the user and create their new project through the setup door or the intake agent
-version: 1.3.0
+version: 1.4.0
 origin: agentive-starter-kit
 last-updated: 2026-08-14
 created-by: "@movito with feature-developer-f5 (KIT-0067)"
@@ -115,7 +115,9 @@ context of its own. Print the invocation for the user:
 
 ```text
 ⚠️ LAUNCH
-Open a new tab in this kit checkout and paste:
+Open a new tab in the prototype's code folder — the intake agent
+ships with the agentive-workflow plugin and runs right where the
+deliverable sits — and paste:
 
   claude --agent project-intake "Begin the intake. Brief: <path-to-brief.md>  Code: <path-to-code-folder>"
 ```

--- a/.kit/context/KIT-0105-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0105-REVIEW-STARTER.md
@@ -1,0 +1,74 @@
+# KIT-0105 — Review Starter (PR 1 of 3)
+
+**Date**: 2026-08-14
+**From**: feature-developer-f5
+**PR**: https://github.com/movito/agentive-starter-kit/pull/133
+**Branch**: `feature/KIT-0105-intake-into-plugin` (worktree
+`../ask-worktrees/KIT-0105`)
+**Task**: `.kit/tasks/3-in-progress/KIT-0105-project-intake-into-the-plugin.md`
+**Status**: CI green, CodeRabbit APPROVED on head `da9d95d`, BugBot
+clean, 2/2 threads resolved — ready for human review
+
+## What this PR is
+
+PR 1 of the three-PR train: `project-intake` becomes location-agnostic
+(KIT-ADR-0031). F2 (CLI verify-or-instruct + CWD-as-candidate +
+packaged-door composition + inlined kit-tree references), F3 (escape
+hatch → report-to-operator body), F4 (main-branch guard carried
+through, pinned by `TestIntakeAgentContract`), F5 (prose sweep by
+class, end-grep proven, both packaged twins mirrored), F6
+(`TestIntakeAcceptance` — the intake's mechanical spine in CI with the
+seeded-path existence assertion; KIT-ADR-0034's enforcement mechanism).
+
+## Commits
+
+| SHA | What |
+|-----|------|
+| `49045fc` | The rewrite: F2–F6 across agent, docs, templates (+twins), tests, CHANGELOG |
+| `bbe98d7` | Evaluator-driven test polish + Gate 5 review record |
+| `da9d95d` | CodeRabbit round 1: quote user-derived paths in command blocks (by class) |
+
+## Bot rounds
+
+One substantive round (2 threads, both CodeRabbit):
+
+1. **Quote the planning-repo path in the `agentive new` block** —
+   FIXED in `da9d95d`, swept by class (Step 4c `git -C` block and
+   `gh repo create --source` had the same defect).
+2. **Add an installed-console-script smoke test** — DECLINED with
+   reasoning: the suite deliberately pins the in-repo package source;
+   the `[project.scripts]` entry point is smoke-tested where the wheel
+   exists (`publish-agentive-kit.yml`: build → install → `agentive
+   version`).
+
+## Evaluator record
+
+`.kit/context/reviews/KIT-0105-evaluator-review.md` — trio run pre-PR
+(normal tier). claude-code APPROVED (4 cheap fixes applied);
+code-reviewer-fast FAIL and code-reviewer CONCERNS fully dispositioned
+— dominated by pre-existing helpers surfaced by the full-format input
+(the known KIT-0092 artifact) and two refuted claims.
+
+## Points a human reviewer should weigh
+
+1. **The agent-body rewrite is the product** — the intake's contract
+   changed from "run in a kit checkout" to "run anywhere, naturally in
+   the prototype folder". Read Steps 0 and 3 for coherence.
+2. **Drift guard passed on this PR** — `ships: false` files don't
+   count toward drift, so there is NO expected-red window until PR 3
+   flips the roster. No justification line was needed at merge.
+3. **`TestIntakeAcceptance` scope** — it exercises the mechanical
+   spine (git init on main, door run, seeding); the LLM prose work is
+   deliberately out of scope (commented in the fixture).
+4. Agent `version:` bumped 1.1.0 → 1.2.0; `/new-project` 1.3.0 →
+   1.4.0; template 1.0.0 → 1.1.0 (twins mirrored, sync guard green).
+
+## After merge
+
+- PR 2 (canon bundle: KIT-0103 R1 + KIT-0112) needs a **fresh branch
+  off updated main from the planner** — the implementer will not
+  create branches.
+- PR 3 (marketplace release 2.1.0) rides
+  `release/agentive-workflow-2.1.0` in
+  `/Users/broadcaster_three/Github/agentive-skills` (planner-created,
+  verified present).

--- a/.kit/context/reviews/KIT-0105-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0105-evaluator-review.md
@@ -1,0 +1,82 @@
+# KIT-0105 — Evaluator Review Record (PR 1 of 3)
+
+**Date**: 2026-08-14
+**Scope**: PR 1 (kit) — project-intake becomes location-agnostic
+(commit `49045fc` + polish commit)
+**Tier**: normal (code + prose — the trio), per the handoff's process
+citations
+**Input**: `.adversarial/inputs/KIT-0105-code-review-input.md`
+(full format — the diff carries a new test class, so logic-shaped)
+
+## Verdicts
+
+| Evaluator | Verdict | Log |
+|-----------|---------|-----|
+| code-reviewer-fast | FAIL (7 findings) | `.adversarial/logs/KIT-0105-code-review-input--code-reviewer-fast.md` |
+| code-reviewer | CONCERNS (7 findings) | `.adversarial/logs/KIT-0105-code-review-input--code-reviewer.md` |
+| claude-code | APPROVED (6 findings) | `.adversarial/logs/KIT-0105-code-review-input--claude-code.md` |
+
+## Dispositions
+
+### code-reviewer-fast (all 7: no action — verified against the tree)
+
+1. **Prefix re-derivation can produce invalid prefix** — refuted: the
+   project name is validated `^[a-z][a-z0-9-]{0,60}$` before derivation;
+   uppercase-strip-hyphens-truncate of such a name always yields a
+   valid `^[A-Z][A-Z0-9]{0,5}$` prefix. Pre-existing prose besides.
+2. **Long slug after derivation** — pre-existing prose, untouched by
+   this diff; "drop filler words until it fits" IS the recovery path.
+3. **Step 5 planner launch lacks `printf %q`** — refuted: the path in
+   Step 5's closing block is display prose ("open a new terminal tab
+   in <path>"), not a shell argument; the pasted command's argument is
+   a fixed string. Pre-existing text besides.
+4. **Git <2.28 detection** — pre-existing prose; the fallback is
+   already instructed and an LLM agent reads the command's error.
+5. **Empty prototype folder** — speculative/low; Step 0's "skim its
+   top level" is pre-existing and unchanged.
+6. **Symlink obfuscation of the kit-checkout guard** — the Inputs
+   discipline already requires canonicalizing paths to absolute form;
+   the guard is LLM-interpreted prose, pre-existing class.
+7. **`_REF_PATTERN` too narrow** — the helper is PRE-EXISTING
+   (unchanged by this diff); the full-format input made it look new —
+   the known KIT-0092 full-contents artifact.
+
+### code-reviewer (CONCERNS — no action; 5 of 7 target pre-existing code)
+
+1–4. **Regex/link styles, case-sensitive extensions, placeholder
+   breadth, Windows paths** — all in `_REF_PATTERN` /
+   `_is_placeholder` / `_referenced_paths`, which predate this PR
+   (KIT-0093-era helpers). Out of this diff's scope; widening them is
+   its own task if ever warranted.
+5. **`git init -b main` in the fixture assumes git ≥2.28** — the
+   existing suite pins the same assumption (`make_adopt_dir` in
+   `test_setup_door.py`); diverging in one fixture would be
+   inconsistent, and CI images satisfy it.
+6. **TASK_PREFIX replace could no-op and false-pass** — refuted:
+   `test_prefix_and_backlog_seeded` re-reads `.env` and demands the
+   exact `TASK_PREFIX=PROTO` line, so any no-op or double-fill fails
+   loudly. Fail-closed, not false-pass.
+7. **60 s subprocess timeouts brittle** — three local git ops on a
+   tmpdir; 60 s is generous and matches suite norms.
+
+### claude-code (APPROVED — 4 cheap fixes applied, 2 accepted as-is)
+
+1. **HIGH: hardcoded date in `_TASK_STUB`** — comment added ("frozen,
+   not asserted — shape, not freshness").
+2. **MEDIUM: dependent tests confusing on door failure** — accepted:
+   identical shape to the existing `single_scaffold`/
+   `planning_scaffold` fixtures; the first test reports rc + output.
+3. **MEDIUM: `_BRIEF` omits template sections** — comment added
+   (deliberately minimal: the mechanical spine's inputs only; prose
+   extraction is LLM work CI cannot exercise).
+4. **LOW: no `capture_output` on fixture git calls** — applied.
+5. **LOW: `_text()` re-reads per test** — accepted (three cheap reads).
+6. **LOW: exact-string pointer assertion** — comment added (deliberate
+   format-contract pin).
+
+## Note for the planner
+
+The pre-existing-helper findings (deep-reviewer 1–4) are the familiar
+full-format artifact: evaluators treat appended unchanged file contents
+as new code. If `_referenced_paths` breadth ever matters, it is a
+backlog item, not a rider on this train.

--- a/.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md
+++ b/.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md
@@ -1,13 +1,14 @@
 # Prototype Handoff Template
 
-**Version**: 1.0.0
-**Created**: 2026-07-24 (KIT-0066)
+**Version**: 1.1.0
+**Created**: 2026-07-24 (KIT-0066); location-agnostic launch 2026-08-14
+(KIT-0105)
 **Purpose**: Paste-able boilerplate for graduating a prototype out of a
 prototyping conversation (Cowork or any Claude session) into structured
 development.
-**Consumed by**: the `project-intake` agent
-(`.claude/agents/project-intake.md`), which turns the resulting brief +
-the prototype code folder into the split pair — a plain code repo and a
+**Consumed by**: the `project-intake` agent (ships with the
+`agentive-workflow` plugin), which turns the resulting brief + the
+prototype code folder into the split pair — a plain code repo and a
 preset-configured planning repo (`docs/CROSS-REPO-PATTERN.md`).
 
 ---
@@ -19,9 +20,11 @@ preset-configured planning repo (`docs/CROSS-REPO-PATTERN.md`).
 2. Save the brief it returns as `PROTOTYPE-BRIEF.md` — inside the
    prototype code folder is the convention the intake agent looks for
    first, but any saved location works.
-3. Open a new tab from your agentive-starter-kit checkout and paste —
-   the message belongs in the command, since a session cannot speak
-   first and a bare launch just idles:
+3. Open a new tab in the prototype's code folder — the intake agent
+   ships with the `agentive-workflow` plugin, so it runs right where
+   the deliverable sits — and paste — the message belongs in the
+   command, since a session cannot speak first and a bare launch just
+   idles:
 
    ```sh
    claude --agent project-intake "Begin the intake. Brief: <path-to-brief.md>  Code: <path-to-code-folder>"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`project-intake` becomes location-agnostic and ships in the
+  plugin — KIT-ADR-0031** (KIT-0105, PR 1 of 3): the intake agent no
+  longer claims a kit-checkout home. It verifies the `agentive` CLI up
+  front (absence prints the install command — never a dead end), treats
+  its own working directory as the candidate prototype folder when no
+  path is given, composes the packaged door (`agentive new`) instead of
+  `scripts/local/bootstrap`, and reports door gaps to the operator as a
+  ready-to-paste task body instead of filing into a `.kit/` tree it may
+  not have. The intended flow is now real: open Claude in the Cowork
+  output folder and run the intake in place. Every surface that said
+  intake runs from a kit checkout is updated (agent body, handoff
+  template + packaged twin, `docs/STARTING-A-PROJECT.md`,
+  `docs/CROSS-REPO-PATTERN.md` + packaged twin, `/new-project`), the
+  KIT-0081 F3 main-branch guard is carried through unchanged and pinned
+  by contract-string tests, and a new end-to-end intake acceptance test
+  (`TestIntakeAcceptance`) exercises the flow's mechanical spine in CI
+  — create → doctor → seeded-path existence (the KIT-0081 F2 class, by
+  machine; KIT-ADR-0034's enforcement mechanism). The plugin-side
+  roster flip (`ships: true`) and release 2.1.0 land in the
+  agentive-skills marketplace (PR 3).
+
 - **The door ships in the package — KIT-ADR-0030** (KIT-0104, PRs
   #129 + #130 + the prose sweep): the setup door is now `agentive new` /
   `agentive adopt` — same flags, same resolution chain (preset home

--- a/docs/CROSS-REPO-PATTERN.md
+++ b/docs/CROSS-REPO-PATTERN.md
@@ -116,10 +116,10 @@ The template → agent → pair recipe composes the door run above:
    `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` into the prototyping
    conversation; save the structured brief it returns (convention:
    `PROTOTYPE-BRIEF.md` in the code folder).
-2. **Agent**: invoke the `project-intake` agent
-   (`.claude/agents/project-intake.md`) in a new tab from your kit
-   checkout, giving it the brief path, the code folder, and the
-   project name.
+2. **Agent**: invoke the `project-intake` agent (ships with the
+   `agentive-workflow` plugin) in a new tab opened in the prototype's
+   code folder — no kit checkout needed — giving it the brief path,
+   the code folder, and the project name.
 3. **Pair**: the agent creates the code repo (git + GitHub, no kit
    install), runs the door for the planning repo (the operator preset
    answers shape/bots/evaluators/env), fills the planning repo's

--- a/docs/STARTING-A-PROJECT.md
+++ b/docs/STARTING-A-PROJECT.md
@@ -52,12 +52,14 @@ side in one folder, with your operator preset as a visible sibling:
 └── agentive-starter-kit/    ← optional: the kit's development home
 ```
 
-The kit clone is the *development* home for the kit itself — and,
-today, the home of the conversational flows: `/new-project`,
-`/setup-preset`, and the `project-intake` agent are builder-side
-commands whose files live in this repo, so they run in a Claude Code
-session opened there (moving intake into the plugin is KIT-ADR-0031).
-Creating a project never requires it: the door is the package.
+The kit clone is the *development* home for the kit itself — and the
+home of the guided interviews: `/new-project` and `/setup-preset` are
+builder-side commands whose files live in this repo, so they run in a
+Claude Code session opened there. The `project-intake` agent ships
+with the `agentive-workflow` plugin (KIT-ADR-0031) and runs anywhere
+the plugin is installed — its natural home is the prototype's own
+folder. Creating a project never requires the kit clone: the door is
+the package.
 
 ### Where the guided flows run
 
@@ -175,9 +177,12 @@ private planning repo that manages it (why this split: see
    prototype, paste the contents of
    `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` and let it fill the
    template in. Save the result as a markdown file.
-2. **Hand it to the intake agent.** Open a **new tab** in the kit
-   clone and invoke the `project-intake` agent, giving it the brief
-   and the code folder:
+2. **Hand it to the intake agent.** Open a **new tab** in the
+   prototype's code folder — the agent ships with the
+   `agentive-workflow` plugin, so it runs right where the deliverable
+   sits — and invoke the `project-intake` agent, giving it the brief
+   (the code folder itself is the default candidate when you open the
+   tab there):
 
    ```text
    Use the project-intake agent. Brief: ~/Downloads/my-prototype-brief.md
@@ -247,11 +252,12 @@ uv tool install agentive-kit   # or: pipx install agentive-kit
 agentive new ~/Github/my-tool
 ```
 
-Clone the kit only when you want the guided flows — the
+Clone the kit only when you want the guided interviews — the
 `/new-project` interview (the one user-facing entry for every
 situation: prototype, blank pair, single repo — it routes to the
-right flow itself), `/setup-preset`, the `project-intake` agent — or
-to work on the kit itself. See [The sibling
+right flow itself) and `/setup-preset` — or to work on the kit
+itself. (The `project-intake` agent needs no clone: it ships with the
+`agentive-workflow` plugin.) See [The sibling
 layout](#the-sibling-layout) above for the clone command. (The
 retired `create-project` agent's job folded into `/new-project` + the
 door in KIT-0093; if you find a live user-facing reference to it,

--- a/packages/agentive-kit/src/agentive_kit/door/data/docs/CROSS-REPO-PATTERN.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/docs/CROSS-REPO-PATTERN.md
@@ -116,10 +116,10 @@ The template → agent → pair recipe composes the door run above:
    `.kit/templates/PROTOTYPE-HANDOFF-TEMPLATE.md` into the prototyping
    conversation; save the structured brief it returns (convention:
    `PROTOTYPE-BRIEF.md` in the code folder).
-2. **Agent**: invoke the `project-intake` agent
-   (`.claude/agents/project-intake.md`) in a new tab from your kit
-   checkout, giving it the brief path, the code folder, and the
-   project name.
+2. **Agent**: invoke the `project-intake` agent (ships with the
+   `agentive-workflow` plugin) in a new tab opened in the prototype's
+   code folder — no kit checkout needed — giving it the brief path,
+   the code folder, and the project name.
 3. **Pair**: the agent creates the code repo (git + GitHub, no kit
    install), runs the door for the planning repo (the operator preset
    answers shape/bots/evaluators/env), fills the planning repo's

--- a/packages/agentive-kit/src/agentive_kit/door/data/kit-templates/PROTOTYPE-HANDOFF-TEMPLATE.md
+++ b/packages/agentive-kit/src/agentive_kit/door/data/kit-templates/PROTOTYPE-HANDOFF-TEMPLATE.md
@@ -1,13 +1,14 @@
 # Prototype Handoff Template
 
-**Version**: 1.0.0
-**Created**: 2026-07-24 (KIT-0066)
+**Version**: 1.1.0
+**Created**: 2026-07-24 (KIT-0066); location-agnostic launch 2026-08-14
+(KIT-0105)
 **Purpose**: Paste-able boilerplate for graduating a prototype out of a
 prototyping conversation (Cowork or any Claude session) into structured
 development.
-**Consumed by**: the `project-intake` agent
-(`.claude/agents/project-intake.md`), which turns the resulting brief +
-the prototype code folder into the split pair — a plain code repo and a
+**Consumed by**: the `project-intake` agent (ships with the
+`agentive-workflow` plugin), which turns the resulting brief + the
+prototype code folder into the split pair — a plain code repo and a
 preset-configured planning repo (`docs/CROSS-REPO-PATTERN.md`).
 
 ---
@@ -19,9 +20,11 @@ preset-configured planning repo (`docs/CROSS-REPO-PATTERN.md`).
 2. Save the brief it returns as `PROTOTYPE-BRIEF.md` — inside the
    prototype code folder is the convention the intake agent looks for
    first, but any saved location works.
-3. Open a new tab from your agentive-starter-kit checkout and paste —
-   the message belongs in the command, since a session cannot speak
-   first and a bare launch just idles:
+3. Open a new tab in the prototype's code folder — the intake agent
+   ships with the `agentive-workflow` plugin, so it runs right where
+   the deliverable sits — and paste — the message belongs in the
+   command, since a session cannot speak first and a bare launch just
+   idles:
 
    ```sh
    claude --agent project-intake "Begin the intake. Brief: <path-to-brief.md>  Code: <path-to-code-folder>"

--- a/tests/test_scaffold_acceptance.py
+++ b/tests/test_scaffold_acceptance.py
@@ -33,6 +33,7 @@ it is excluded from the consumer tests/ rsync in engine-consumer.sh
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -278,3 +279,192 @@ class TestPackagedWorld:
         assert (
             "agent plugin: verified" in out or "Install the agent plugin:" in out
         ), "door must verify the plugin or instruct installing it"
+
+
+# ── KIT-0105 F6: the intake flow, end-to-end ────────────────────────
+# KIT-ADR-0034's enforcement mechanism: the project-intake agent's
+# mechanical spine — everything CI can exercise of the flow without an
+# LLM — runs on every push against a fixture prototype folder, and the
+# created tree must be usable (create → doctor → every seeded-surface
+# file reference exists: the KIT-0081 F2 class, by machine).
+
+_BRIEF = """\
+# proto-widget
+
+## Project name and purpose
+proto-widget — a fixture prototype for the intake acceptance test.
+
+## Suggested task prefix
+PROTO
+
+## Suggested next steps
+1. Harden the widget. Done when: tests pass in CI.
+"""
+
+_TASK_STUB = """\
+# PROTO-0001: Harden the widget
+
+**Status**: Backlog
+**Priority**: medium (default — the planner re-triages)
+**Type**: Feature
+**Created**: 2026-08-14
+**Source**: prototype handoff brief
+
+## Summary
+
+Harden the widget.
+
+## Acceptance Criteria
+
+- [ ] Tests pass in CI.
+"""
+
+
+@pytest.fixture(scope="module")
+def intake_scaffold(tmp_path_factory):
+    """The intake agent's shell steps, verbatim from its body: code
+    repo inited ON MAIN and committed (Step 2), one flags-only door
+    run with the sibling pointers (Step 3), prefix + backlog seeding
+    (Step 4). Returns (proto, target, result)."""
+    base = tmp_path_factory.mktemp("accept-intake")
+    env = _scrubbed_env(XDG_CONFIG_HOME=str(_git_identity(base)))
+    proto = base / "proto-widget"
+    proto.mkdir()
+    (proto / "widget.py").write_text('print("prototype")\n', encoding="utf-8")
+    (proto / "PROTOTYPE-BRIEF.md").write_text(_BRIEF, encoding="utf-8")
+    for cmd in (
+        ["git", "-C", str(proto), "init", "--quiet", "-b", "main"],
+        ["git", "-C", str(proto), "add", "-A"],
+        ["git", "-C", str(proto), "commit", "--quiet", "-m", "chore: import"],
+    ):
+        subprocess.run(cmd, check=True, timeout=60, env=env)
+    target = base / "proto-widget-planning"
+    result = run_door(
+        "--new",
+        str(target),
+        "--shape",
+        "planning",
+        "--target-path",
+        "../proto-widget",
+        "--target-github",
+        "example/proto-widget",
+        env=env,
+    )
+    # Step 4's mechanical parts — only meaningful on a created tree;
+    # a failed door run is reported by the first test, not masked here
+    if result.returncode == 0 and target.is_dir():
+        env_file = target / ".env"
+        if env_file.is_file():
+            content = env_file.read_text(encoding="utf-8")
+            env_file.write_text(
+                content.replace("TASK_PREFIX=", "TASK_PREFIX=PROTO", 1),
+                encoding="utf-8",
+            )
+        backlog = target / ".kit" / "tasks" / "1-backlog"
+        if backlog.is_dir():
+            (backlog / "PROTO-0001-harden-widget.md").write_text(
+                _TASK_STUB, encoding="utf-8"
+            )
+    return proto, target, result
+
+
+@pytest.mark.slow
+class TestIntakeAcceptance:
+    """The intake acceptance criteria of KIT-0105, by machine."""
+
+    def test_door_run_succeeds_from_outside_any_kit_tree(self, intake_scaffold):
+        """AC: the intake completes from a folder with no path
+        relationship to any kit checkout — the door run targets a
+        scratch tree far from this repo."""
+        proto, target, result = intake_scaffold
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "Install complete:" in result.stdout
+
+    def test_code_repo_on_main_and_kit_free(self, intake_scaffold):
+        """AC (KIT-0081 F3 carried through): the code repo's branch IS
+        main after the agent's prescribed init — and it stays kit-free
+        (no .kit/, no .claude/)."""
+        proto, target, result = intake_scaffold
+        branch = subprocess.run(
+            ["git", "-C", str(proto), "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert branch.stdout.strip() == "main"
+        assert not (proto / ".kit").exists(), "no kit install in the code repo"
+        assert not (proto / ".claude").exists(), "no agent copies in the code repo"
+
+    def test_sibling_pointer_resolves(self, intake_scaffold):
+        """The recorded ../<name> pointer must resolve to the actual
+        prototype folder — a wrong pointer is the silent failure the
+        agent's Step 3 re-assertion exists to prevent."""
+        proto, target, result = intake_scaffold
+        text = (target / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "- **Path**: `../proto-widget`" in text
+        assert (target.parent / "proto-widget").resolve() == proto.resolve()
+
+    def test_doctor_ran_or_cli_instructed(self, intake_scaffold):
+        """create → doctor: the door either ran the doctor in the
+        created tree or printed the CLI install instruction — the
+        degradation pattern, never silence."""
+        proto, target, result = intake_scaffold
+        out = result.stdout
+        assert (
+            "Doctor verdict:" in out
+            or "Install the lifecycle CLI: uv tool install agentive-kit" in out
+            or "uv tool upgrade agentive-kit" in out
+        ), "door must run doctor or instruct installing/upgrading the CLI"
+
+    def test_seeded_paths_exist(self, intake_scaffold):
+        """AC (the KIT-0081 F2 class, by machine): every file path a
+        seeded guidance surface references exists in the created tree
+        — including after the intake's own seeding."""
+        proto, target, result = intake_scaffold
+        missing = _referenced_paths(target)
+        assert not missing, f"dangling references in intake scaffold: {missing}"
+
+    def test_prefix_and_backlog_seeded(self, intake_scaffold):
+        """The planning repo opens planner-ready: prefix filled (the
+        door seeds it empty on the planning shape — KIT-0084) and ≥1
+        backlog task from the brief."""
+        proto, target, result = intake_scaffold
+        lines = (target / ".env").read_text(encoding="utf-8").splitlines()
+        assert "TASK_PREFIX=PROTO" in lines
+        stub = target / ".kit" / "tasks" / "1-backlog" / "PROTO-0001-harden-widget.md"
+        assert stub.is_file()
+        assert "**Status**: Backlog" in stub.read_text(encoding="utf-8")
+
+
+# ── KIT-0105 F4: contract strings the agent body must keep ──────────
+
+_INTAKE_AGENT = (
+    Path(__file__).resolve().parent.parent / ".claude" / "agents" / "project-intake.md"
+)
+
+
+class TestIntakeAgentContract:
+    """The location-agnostic rewrite (KIT-0105) must not lose the
+    guards that predate it. Prose contracts, pinned as strings — the
+    same discipline as the door's contract lines above."""
+
+    def _text(self) -> str:
+        return _INTAKE_AGENT.read_text(encoding="utf-8")
+
+    def test_main_branch_guard_held_through_move(self):
+        """KIT-0081 F3, carried through the move unchanged (F4: test,
+        not fix): init lands on main even without init.defaultBranch,
+        and the pre-push verification demands the branch BE main."""
+        text = self._text()
+        assert "init.defaultBranch=main" in text
+        assert "`git -C <code-path> branch --show-current` must print `main`" in text
+
+    def test_missing_cli_instructs_never_dead_ends(self):
+        """F2/AC: a missing `agentive` CLI produces the printed
+        install command — the degradation convention, not a failure."""
+        assert "uv tool install agentive-kit" in self._text()
+
+    def test_no_kit_checkout_residence_claim(self):
+        """F5, pinned for this file: the agent must never again claim
+        to run FROM a kit checkout (it ships in the plugin)."""
+        assert "from an agentive-starter-kit checkout" not in self._text()

--- a/tests/test_scaffold_acceptance.py
+++ b/tests/test_scaffold_acceptance.py
@@ -288,6 +288,10 @@ class TestPackagedWorld:
 # created tree must be usable (create → doctor → every seeded-surface
 # file reference exists: the KIT-0081 F2 class, by machine).
 
+# Deliberately minimal: only the sections the MECHANICAL spine consumes
+# (name, prefix, next steps). The agent's prose-extraction of the full
+# template (languages, decisions, solid/rough, …) is LLM work this test
+# cannot exercise — that gap is the fixture's scope, not an oversight.
 _BRIEF = """\
 # proto-widget
 
@@ -301,6 +305,8 @@ PROTO
 1. Harden the widget. Done when: tests pass in CI.
 """
 
+# The Created date is frozen, not asserted — the stub simulates agent
+# output shape, not agent output freshness.
 _TASK_STUB = """\
 # PROTO-0001: Harden the widget
 
@@ -337,7 +343,7 @@ def intake_scaffold(tmp_path_factory):
         ["git", "-C", str(proto), "add", "-A"],
         ["git", "-C", str(proto), "commit", "--quiet", "-m", "chore: import"],
     ):
-        subprocess.run(cmd, check=True, timeout=60, env=env)
+        subprocess.run(cmd, check=True, timeout=60, env=env, capture_output=True)
     target = base / "proto-widget-planning"
     result = run_door(
         "--new",
@@ -401,6 +407,8 @@ class TestIntakeAcceptance:
         agent's Step 3 re-assertion exists to prevent."""
         proto, target, result = intake_scaffold
         text = (target / "CLAUDE.md").read_text(encoding="utf-8")
+        # deliberate format-contract pin on the door's Target Repository
+        # section (same discipline as the door's printed contract lines)
         assert "- **Path**: `../proto-widget`" in text
         assert (target.parent / "proto-widget").resolve() == proto.resolve()
 


### PR DESCRIPTION
## Summary

The last structural piece of the KIT-ADR-0030–0034 arc (KIT-ADR-0031): `project-intake` no longer claims a kit-checkout home, so the intended flow becomes real — **open Claude in the Cowork output folder and run the intake in place**. Plugin roster flip + release 2.1.0 follow in PR 3 (agentive-skills); the canon-fix bundle is PR 2.

- **F2 — location-agnostic agent**: verifies the `agentive` CLI up front (absence prints `uv tool install agentive-kit` — never a dead end, the door's own degradation convention); treats its working directory as the candidate prototype folder when no path is given (stated + confirmed, never assumed); composes the packaged door (`agentive new`) instead of `scripts/local/bootstrap`; kit-tree path references inlined (prefix rule, task-stub skeleton)
- **F3 — escape hatch re-homed**: door gaps are reported to the operator as a ready-to-paste task body instead of filed into a `.kit/` tree the agent may not have
- **F4 — main-branch guard carried through** (test, not fix): `init.defaultBranch`/`branch --show-current` guard text unchanged, pinned by `TestIntakeAgentContract` contract strings
- **F5 — prose sweep by class**: every live surface that said intake runs from a kit checkout updated — agent body, `PROTOTYPE-HANDOFF-TEMPLATE` (+ packaged twin), `docs/STARTING-A-PROJECT.md`, `docs/CROSS-REPO-PATTERN.md` (+ packaged twin), `/new-project`. End grep proves the class closed; `test_door_data_sync.py` green on both twins
- **F6 — intake acceptance test** (`TestIntakeAcceptance`, KIT-ADR-0034's enforcement mechanism): the flow's mechanical spine in CI — code repo inited ON MAIN and committed, flags-only door run with sibling pointers, create → doctor-or-instruct → seeded-path existence (the KIT-0081 F2 class, by machine), prefix + backlog seeding

## Test plan

- [x] `pytest tests/` full suite: 1145 passed (fast + slow), 0 failures
- [x] `test_door_data_sync.py`: 29 passed (packaged twins byte-identical)
- [x] New: 6 `TestIntakeAcceptance` + 3 `TestIntakeAgentContract` tests
- [x] black / isort / flake8 / pattern lint / markdownlint clean (pre-commit)
- [x] Evaluator trio run pre-PR; record at `.kit/context/reviews/KIT-0105-evaluator-review.md` (claude-code APPROVED; other findings dispositioned — mostly pre-existing helpers surfaced by full-format input)

## Notes for reviewers

- The plugin drift guard goes red after this merges — **by design**; PR 3 (agentive-skills release 2.1.0) greens it.
- Task spec: `.kit/tasks/3-in-progress/KIT-0105-project-intake-into-the-plugin.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178EH5vDKWsQidAr24dRoHr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bbe98d7d2b5c22dc1badb8890055ae15c37eb2f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->