### PR TITLE
fix(KIT-0113): quiet credential scans + post-seeding doctor in project-intake

### DIFF
--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -442,18 +442,25 @@ exists to catch:
 
 ```bash
 PLANNING="<parent>/<name>-planning"
-git -C "$PLANNING" add -A
-git -C "$PLANNING" grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
-case $? in
-  0) echo "BLOCKED: credential shapes in the files listed above — do not commit" ;;
-  1) git -C "$PLANNING" commit -m "chore: seed project context and backlog from prototype brief" ;;
-  *) echo "BLOCKED: scan failed to run — it has proven nothing" ;;
-esac
+if ! git -C "$PLANNING" add -A; then
+  echo "BLOCKED: staging failed — the index is not what you think, do not commit"
+else
+  git -C "$PLANNING" grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
+  case $? in
+    0) echo "BLOCKED: credential shapes in the files listed above — do not commit" ;;
+    1) git -C "$PLANNING" commit -m "chore: seed project context and backlog from prototype brief" ;;
+    *) echo "BLOCKED: scan failed to run — it has proven nothing" ;;
+  esac
+fi
 ```
 
-The `case` is fail-closed on purpose: an `if`/`else` would send both
-"clean" (1) and "scan errored" (128) down the same branch and commit
-on a scan that never ran. Only exit 1 commits.
+Every abort path here is deliberate. The `case` is fail-closed
+because an `if`/`else` on the scan would send both "clean" (1) and
+"scan errored" (128) down the same branch and commit on a scan that
+never ran — only exit 1 commits. The `add` is checked for the
+adjacent reason: a partially-failed stage leaves an index that is not
+the tree you meant to seed, and a scan of it would authorize an
+incomplete commit while looking green.
 
 The scan between add and commit is the same quiet staged-content
 credential scan as Step 2.3 — same pattern set, same filenames-only

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -203,7 +203,13 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    tracked files — the same quiet form, filenames only:
    `git -C <code-path> grep -lIE '<the Step 2.3 pattern set>'` (a bare
    `git grep` prints the matched LINES, which is the leak this scan
-   exists to prevent). Deep history
+   exists to prevent; no `--cached` here — this scans tracked files,
+   not an index). **Read its exit code exactly as Step 2.3 does** —
+   0 plus filenames means credential shapes were found and the push
+   does NOT happen, 1 with no output means clean, anything else is a
+   broken scan and fails closed. Filenames-only output makes a hit
+   quiet, not harmless: quiet is the point, the block is still
+   mandatory. Deep history
    scanning is the user's call — offer it as a suggestion
    (`gitleaks`/`trufflehog`) rather than running it yourself.
 2. Ensure ignore rules cover secrets and artifacts — create
@@ -222,7 +228,7 @@ All commands target the code folder explicitly (`git -C <code-path>`).
 
    ```bash
    git -C <code-path> add -A
-   git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Z ]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
+   git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
    ```
 
    **Read the exit code — it is inverted from the intuition**: exit 0
@@ -234,11 +240,20 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    stop, never commit on the strength of a scan that errored. Any hit:
    unstage, tell the user **which files matched** — never the matched
    value — and wait. A tracked `.env` bypasses `.gitignore` —
-   `git rm --cached` it first. **Re-run the scan after any
-   remediation**: removing one offending file does not clear hits in
-   the others, and the post-remediation scan — not the original one —
-   is the pass that authorizes the commit. Only then commit
-   (e.g. "chore: import prototype from Cowork handoff").
+   `git rm --cached` it first.
+
+   **Re-scan after remediation, and scan what you will actually
+   commit.** Removing one offending file does not clear hits in the
+   others, so the original scan can never authorize the commit. But
+   note the trap in re-scanning: `--cached` only sees the INDEX, so a
+   scan run right after unstaging the offender passes vacuously — the
+   secret is still sitting in the working tree, and the next `add`
+   would stage it again behind a green scan. So: remediate in the
+   working tree (remove the value, or ignore the file), stage
+   everything that is going to be committed, and only THEN run the
+   authorizing scan. **Nothing may be staged after it** — if you
+   `add` again, that scan is stale and you owe another one. Only then
+   commit (e.g. "chore: import prototype from Cowork handoff").
 4. **Visibility question** (AskUserQuestion): create the GitHub repo
    **private (default, recommended)** or public? Rationale to present:
    the split pair keeps planning artifacts out of this repo precisely
@@ -419,11 +434,26 @@ repo works directly on main — `docs/CROSS-REPO-PATTERN.md`,
 Conventions). Explicit `git -C` here like everywhere else — the CWD
 rule means a bare `git commit` could hit the wrong repository:
 
+The commit is **gated on the scan in the shell, not in prose** — a
+narrative "check the output first" cannot stop a pasted sequence, and
+the scan's exit 0 means a credential WAS found, so an ungated
+`git commit` on the next line would commit exactly what the scan
+exists to catch:
+
 ```bash
-git -C "<parent>/<name>-planning" add -A
-git -C "<parent>/<name>-planning" grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Z ]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
-git -C "<parent>/<name>-planning" commit -m "chore: seed project context and backlog from prototype brief"
+PLANNING="<parent>/<name>-planning"
+git -C "$PLANNING" add -A
+git -C "$PLANNING" grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
+case $? in
+  0) echo "BLOCKED: credential shapes in the files listed above — do not commit" ;;
+  1) git -C "$PLANNING" commit -m "chore: seed project context and backlog from prototype brief" ;;
+  *) echo "BLOCKED: scan failed to run — it has proven nothing" ;;
+esac
 ```
+
+The `case` is fail-closed on purpose: an `if`/`else` would send both
+"clean" (1) and "scan errored" (128) down the same branch and commit
+on a scan that never ran. Only exit 1 commits.
 
 The scan between add and commit is the same quiet staged-content
 credential scan as Step 2.3 — same pattern set, same filenames-only

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -2,9 +2,9 @@
 name: project-intake
 description: Graduates a prototype into the split pair — plain code repo plus preset-configured planning repo — from a handoff brief and a code folder
 model: claude-sonnet-5
-version: 1.2.0
+version: 1.3.0
 origin: agentive-starter-kit
-last-updated: 2026-08-14
+last-updated: 2026-08-16
 created-by: "@movito (KIT-0066)"
 tools:
   - Read
@@ -200,8 +200,10 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    coverage (step 2's check — `.env` and key files must be ignored
    and untracked; a tracked `.env` blocks the push until resolved
    with the user) and run the Step 2.3 credential scan over its
-   tracked files (`git -C <code-path> grep` the same credential
-   patterns listed there). Deep history
+   tracked files — the same quiet form, filenames only:
+   `git -C <code-path> grep -lIE '<the Step 2.3 pattern set>'` (a bare
+   `git grep` prints the matched LINES, which is the leak this scan
+   exists to prevent). Deep history
    scanning is the user's call — offer it as a suggestion
    (`gitleaks`/`trufflehog`) rather than running it yourself.
 2. Ensure ignore rules cover secrets and artifacts — create
@@ -212,12 +214,24 @@ All commands target the code folder explicitly (`git -C <code-path>`).
 3. Stage and scan, then commit. `git -C <code-path> add -A` is
    acceptable here (a fresh import, not selective feature work). Then
    a **mandatory secret scan of the staged files** before the commit
-   — not optional, not a vibe check: grep the staged content for
-   common credential shapes (`sk-`, `ghp_`, `github_pat_`, `xoxb-`,
-   `AKIA`, `BEGIN .* PRIVATE KEY`, long `eyJ` JWT blobs). Any hit:
-   unstage, tell the user, and wait. A tracked `.env` bypasses
-   `.gitignore` — `git rm --cached` it first. Only then commit
-   (e.g. "chore: import prototype from Cowork handoff").
+   — not optional, not a vibe check. Run it as a **quiet scan**: the
+   scan must never put staged bytes in front of the user, because a
+   scan that echoes what it found leaks the credential BEFORE it
+   rejects it. `-l` reports FILENAMES ONLY; never `git diff --cached`,
+   never a grep that prints matched lines.
+
+   ```bash
+   git -C <code-path> add -A
+   git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Z ]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
+   ```
+
+   **Read the exit code — it is inverted from the intuition**: exit 0
+   with filenames printed means credential shapes WERE found (stop);
+   exit 1 with no output means the index is clean (proceed). Any hit:
+   unstage, tell the user **which files matched** — never the matched
+   value — and wait. A tracked `.env` bypasses `.gitignore` —
+   `git rm --cached` it first. Only then commit (e.g. "chore: import
+   prototype from Cowork handoff").
 4. **Visibility question** (AskUserQuestion): create the GitHub repo
    **private (default, recommended)** or public? Rationale to present:
    the split pair keeps planning artifacts out of this repo precisely
@@ -400,13 +414,17 @@ rule means a bare `git commit` could hit the wrong repository:
 
 ```bash
 git -C "<parent>/<name>-planning" add -A
-git -C "<parent>/<name>-planning" diff --cached   # scan this output
+git -C "<parent>/<name>-planning" grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Z ]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
 git -C "<parent>/<name>-planning" commit -m "chore: seed project context and backlog from prototype brief"
 ```
 
-The scan between add and commit is the same staged-content credential
-scan as Step 2.3 — the seeded content is brief-derived, and a brief
-that leaked a value must not land in the planning repo either.
+The scan between add and commit is the same quiet staged-content
+credential scan as Step 2.3 — same pattern set, same filenames-only
+output, same inverted exit reading (0 + filenames = stop; 1 + silence
+= clean), same response to a hit (unstage, name the files not the
+value, wait). The seeded content is brief-derived, and a brief that
+leaked a value must not land in the planning repo either. Keep the two
+sites in step: if you ever change the pattern set, change it in both.
 
 ### Step 5: Finish loudly — ONE verified checklist, ONE command
 
@@ -414,19 +432,45 @@ The completion summary is a single checklist ending in a single
 command (format operator-specified, KIT-0101/KIT-0100 F10). Its
 binding rules:
 
+- **Re-run the doctor before you print anything.** The door's tail was
+  captured BEFORE Step 4 seeded the prefix and the backlog, so it can
+  still WARN about things the seeding has since cured (the empty
+  `TASK_PREFIX`, KIT-0084). Run the doctor again, after the Step 4c
+  seeding commit, **with the planning repo as the working directory**:
+
+  ```bash
+  cd "<parent>/<name>-planning" && agentive doctor
+  ```
+
+  The working directory is load-bearing: the CLI discovers the project
+  from the CWD and exits 1 when it finds none, so this cannot be run
+  from elsewhere via `--root=`. This re-run is **repo-state truth** and
+  it is what the ✓/✗ lines and the launch-line gate below consume. If
+  the `agentive` CLI does not exist, the re-run cannot happen — say so
+  as a ✗ with the install command, and treat the gate as unmet.
 - **Every ✓ line is a claim verified at print time** — check the fact
   (the repo exists, the push landed, the value is set) immediately
   before printing it, never assume it from "that step ran earlier".
 - **Anything outstanding appears IN the same list as ✗** with the
   exact remedy command — including everything the door's tail left
-  open (a missing `agentive` CLI, an uninstalled plugin, doctor
-  FAILs). "Done" and "still needed" must never contradict each other
+  open (a missing `agentive` CLI, an uninstalled plugin) plus every
+  FAIL still standing in the post-seeding re-run. "Done" and "still
+  needed" must never contradict each other
   across two messages: this list is the only completion statement.
-- **Relay the door's doctor tail verbatim** below the checklist —
-  never summarize it away.
-- **The closing launch command prints ONLY when the doctor reported
-  no FAILs** (and the `agentive` CLI exists — without it the doctor
-  could not run at all). It carries its opening prompt: a session
+- **Relay BOTH doctor outputs verbatim** below the checklist, each
+  under its own label — never summarize either away, and never merge
+  them into one block. The door's tail is **install truth** (its exit
+  contract is what says the install succeeded); the post-seeding
+  re-run is **repo-state truth** (what the repo looks like now that
+  Step 4 has filled it). They can legitimately disagree — a WARN in
+  the door's tail that the re-run no longer reports is the seeding
+  working, not a contradiction — which is exactly why the labels
+  matter.
+- **The closing launch command prints ONLY when the POST-SEEDING
+  re-run reported no FAILs** (and the `agentive` CLI exists — without
+  it the re-run could not happen at all, so the gate is unmet). The
+  door's tail never gates this line: it describes a repo state that
+  Step 4 has already moved past. It carries its opening prompt: a session
   cannot speak first, so a bare `claude --agent planner` opens an
   idle prompt that looks broken (KIT-0075; reproduced live under
   native `--agent`, 2026-08-11). When there ARE failures, the last
@@ -447,8 +491,11 @@ Format (✓/✗ per what actually happened; every line verified):
 ✓ Verified the agentive-workflow plugin
 ✗ <anything outstanding> — run: <exact remedy command>
 
-Doctor tail (verbatim):
-<the door's doctor output>
+Doctor tail — the door's install verdict, verbatim:
+<the door's doctor output, as captured at Step 3>
+
+Doctor re-run — planning repo after seeding, verbatim:
+<the output of `agentive doctor` from Step 5's re-run>
 
 You can now start working on <name>. Open a new terminal tab in
 <parent>/<name>-planning and paste:
@@ -456,7 +503,8 @@ You can now start working on <name>. Open a new terminal tab in
   claude --agent planner "Triage the backlog and recommend what to start."
 ```
 
-With doctor FAILs (or no CLI to run it), the closing block is instead:
+With FAILs in the post-seeding re-run (or no CLI to run it), the
+closing block is instead:
 
 ```text
 Resolve the ✗ items above, re-run `agentive doctor` in
@@ -504,4 +552,8 @@ fixed at session launch — this session cannot become the planner.)
 - **Never print, stage, or commit secret values** — names only; the
   door's `env-source` handling owns key material end-to-end
 - **Never re-derive install state** — the door's exit code and doctor
-  tail are the only truth you report
+  tail are the only truth you report about whether the INSTALL
+  succeeded. Re-running `agentive doctor` after the Step 4c seeding
+  commit is not an exception to this: it reports repo state after your
+  own seeding, it is relayed under its own label alongside the door's
+  tail (never in place of it), and it never revises the door's verdict

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -234,8 +234,11 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    stop, never commit on the strength of a scan that errored. Any hit:
    unstage, tell the user **which files matched** — never the matched
    value — and wait. A tracked `.env` bypasses `.gitignore` —
-   `git rm --cached` it first. Only then commit (e.g. "chore: import
-   prototype from Cowork handoff").
+   `git rm --cached` it first. **Re-run the scan after any
+   remediation**: removing one offending file does not clear hits in
+   the others, and the post-remediation scan — not the original one —
+   is the pass that authorizes the commit. Only then commit
+   (e.g. "chore: import prototype from Cowork handoff").
 4. **Visibility question** (AskUserQuestion): create the GitHub repo
    **private (default, recommended)** or public? Rationale to present:
    the split pair keeps planning artifacts out of this repo precisely
@@ -458,9 +461,11 @@ binding rules:
   root at all. Those are different situations: the first is a repo
   that needs fixing, the second is a re-run that never happened. Read
   the `DOCTOR:` verdict lines to tell them apart. A re-run that could
-  not execute — no `agentive` CLI, wrong directory, driver error — is
-  **not** a pass: say so as a ✗ with the remedy command, and treat the
-  launch gate as unmet.
+  not execute — no `agentive` CLI, a `cd` that failed, a driver error
+  — is **not** a pass: say so as a ✗ with the remedy command, and
+  treat the launch gate as unmet. WARNs do not block: a warnings-only
+  re-run (exit 2) still prints the launch command, with the WARNs
+  listed as informational rather than as ✗ items.
 - **Every ✓ line is a claim verified at print time** — check the fact
   (the repo exists, the push landed, the value is set) immediately
   before printing it, never assume it from "that step ran earlier".

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -227,7 +227,11 @@ All commands target the code folder explicitly (`git -C <code-path>`).
 
    **Read the exit code — it is inverted from the intuition**: exit 0
    with filenames printed means credential shapes WERE found (stop);
-   exit 1 with no output means the index is clean (proceed). Any hit:
+   exit 1 with no output means the index is clean (proceed). **Any
+   other exit is a broken scan, not a pass** — `git` exits 128 for a
+   bad path, a missing repo, or a permission error, and a scan that
+   did not run has proven nothing. Fail closed: report the error and
+   stop, never commit on the strength of a scan that errored. Any hit:
    unstage, tell the user **which files matched** — never the matched
    value — and wait. A tracked `.env` bypasses `.gitignore` —
    `git rm --cached` it first. Only then commit (e.g. "chore: import
@@ -421,8 +425,8 @@ git -C "<parent>/<name>-planning" commit -m "chore: seed project context and bac
 The scan between add and commit is the same quiet staged-content
 credential scan as Step 2.3 — same pattern set, same filenames-only
 output, same inverted exit reading (0 + filenames = stop; 1 + silence
-= clean), same response to a hit (unstage, name the files not the
-value, wait). The seeded content is brief-derived, and a brief that
+= clean; anything else = broken scan, fail closed), same response to a
+hit (unstage, name the files not the value, wait). The seeded content is brief-derived, and a brief that
 leaked a value must not land in the planning repo either. Keep the two
 sites in step: if you ever change the pattern set, change it in both.
 
@@ -443,11 +447,20 @@ binding rules:
   ```
 
   The working directory is load-bearing: the CLI discovers the project
-  from the CWD and exits 1 when it finds none, so this cannot be run
+  from the CWD and refuses when it finds none, so this cannot be run
   from elsewhere via `--root=`. This re-run is **repo-state truth** and
-  it is what the ✓/✗ lines and the launch-line gate below consume. If
-  the `agentive` CLI does not exist, the re-run cannot happen — say so
-  as a ✗ with the install command, and treat the gate as unmet.
+  it is what the ✓/✗ lines and the launch-line gate below consume.
+
+  **Gate on the doctor's OUTPUT, not on its exit code alone.** Exit 1
+  is overloaded — the doctor's own contract uses it for "at least one
+  check FAILed" (0 = all PASS/SKIP, 2 = warnings only, 3 = driver or
+  usage error), but the CLI also exits 1 when it cannot find a project
+  root at all. Those are different situations: the first is a repo
+  that needs fixing, the second is a re-run that never happened. Read
+  the `DOCTOR:` verdict lines to tell them apart. A re-run that could
+  not execute — no `agentive` CLI, wrong directory, driver error — is
+  **not** a pass: say so as a ✗ with the remedy command, and treat the
+  launch gate as unmet.
 - **Every ✓ line is a claim verified at print time** — check the fact
   (the repo exists, the push landed, the value is set) immediately
   before printing it, never assume it from "that step ran earlier".

--- a/.kit/context/KIT-0113-HANDOFF-feature-developer.md
+++ b/.kit/context/KIT-0113-HANDOFF-feature-developer.md
@@ -5,7 +5,7 @@ delegate or spawn other agents.**
 
 **Date**: 2026-08-16
 **From**: planner-f5  **To**: feature-developer
-**Task**: .kit/tasks/3-in-progress/KIT-0113-project-intake-hardening.md
+**Task**: .kit/tasks/4-in-review/KIT-0113-project-intake-hardening.md
 **Status**: Ready
 **Evaluation**: N/A — skipped (single-file canon fix; both findings
 bot-sourced and already characterized; class grep defined in the spec)

--- a/.kit/context/KIT-0113-REVIEW-STARTER.md
+++ b/.kit/context/KIT-0113-REVIEW-STARTER.md
@@ -1,0 +1,80 @@
+# KIT-0113 — Review Starter (leg 1)
+
+**PR**: https://github.com/movito/agentive-starter-kit/pull/135
+**Branch**: `feature/KIT-0113-intake-hardening` → `main`
+**Head**: `675f7ab`
+**Task**: `.kit/tasks/4-in-review/KIT-0113-project-intake-hardening.md`
+**Review record**: `.kit/context/reviews/KIT-0113-evaluator-review.md`
+
+## What changed
+
+One file — `.claude/agents/project-intake.md` (1.2.0 → 1.3.0) — plus
+the review record.
+
+- **R1**: three sites echoed staged content or matched credential
+  lines into the transcript. All three now scan quietly
+  (`git grep -lIE`, filenames only), and the Step 4c commit is gated
+  on the scan **in the shell**, not in prose.
+- **R2**: Step 5 gated on the door's doctor tail, captured before
+  Step 4's seeding. It now re-runs `agentive doctor` after the seeding
+  commit and gates on that, relaying both outputs under distinct
+  labels (install truth vs repo-state truth).
+
+## Gate status
+
+| Gate | State |
+|------|-------|
+| Tests (3.10 / 3.12 / 3.14) | ✅ pass |
+| Lint & format | ✅ pass |
+| CodeRabbit | ✅ APPROVED on head `675f7ab` (SHA-matched) |
+| Cursor BugBot | ✅ clean |
+| Review threads | ✅ 7/7 replied + resolved, `hasNextPage` false |
+| Evaluators | ✅ 2 tiers pre-PR, findings dispositioned |
+| Plugin drift guard | ❌ **red by design** — see below |
+
+## The one open item: drift guard
+
+Red because this PR changes a rostered `.claude/` component while the
+published plugin is still 2.1.0. That is the guard working, not
+breaking. Per the POSTURE ruling in `.github/workflows/plugin-drift.yml`
+(operator, 2026-08-14) the guard stays REQUIRED and the remedy is
+cadence: a justification comment is posted on the PR, and **leg 2 cuts
+plugin release 2.1.1 immediately after merge**.
+
+**This needs an explicit merge decision** — the check is required, so
+merging happens over a known-red guard by the ruling's own provision.
+
+## Leg 2 readiness (blocked on merge)
+
+- Marketplace repo `~/Github/agentive-skills` verified **clean on
+  `main`** (it is a plain clone; prior sessions have left it on
+  feature branches).
+- Plan: `scripts/local/plugin_resync.py` three-way merge (never copy),
+  plugin 2.1.0 → 2.1.1 across all four version fields, CHANGELOG with
+  explicit empty categories, `verify_plugin_integrity.py` 28/28.
+- `project-intake` carries no published adaptation, so a clean merge
+  is expected — but the tool says so, not me.
+
+## What a reviewer should look hardest at
+
+1. **The Step 4c shell gate** — it is the piece that changed most
+   across bot rounds. `case $?` rather than `if`/`else` is deliberate
+   (an else branch would commit on a scan that errored). Verified
+   against four paths; table in the review record.
+2. **The pattern set is duplicated at two sites** and kept in sync by
+   an in-document instruction. A markdown agent body has no DRY
+   mechanism. If that trade is unacceptable, it wants a follow-up
+   task, not a change here.
+3. **Declined evaluator findings** — two security findings asking to
+   *narrow* the credential regex were declined on fail-closed grounds.
+   Reasoning is recorded; disagreement is legitimate and reversible.
+
+## Notes for the retro
+
+Three bot rounds against a one-round baseline. Each round found a real
+defect, and rounds 2–3 landed on code that did not exist until the
+previous round's fix — introducing a shell gate to close a leak
+created a new surface (unchecked `add -A`) for the next round. Also:
+CodeRabbit refuted a "verified" claim of mine that was wrong, and
+chasing it exposed a genuine coverage regression in the PEM pattern
+(6/8 where the original was 7/8). Worth carrying into patterns.

--- a/.kit/context/reviews/KIT-0113-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0113-evaluator-review.md
@@ -119,3 +119,32 @@ Against a true non-repo:
 | staged secret present (exit 0) | BLOCKED (credential found) |
 | clean index (exit 1) | COMMIT would run |
 | not a git repository (exit 128) | BLOCKED (scan failed to run) |
+
+## Bot round 2 — PR #135 (CodeRabbit 1)
+
+One new thread; the six from round 1 stayed resolved.
+
+| Bot | Finding | Fix |
+|-----|---------|-----|
+| CodeRabbit Major | `git add -A` was unchecked in the Step 4c gate. A partially-failed stage leaves a stale/partial index; the scan then validates *that*, and exit 1 authorizes a commit that is not the tree meant to be seeded. | **ACCEPTED.** Wrapped the gate in `if ! git -C "$PLANNING" add -A`. Classified correctly by the bot as data integrity rather than credential leak — the scan still examines exactly what would be committed, so this cannot leak a secret; what it can do is ship a silently incomplete seeding commit. |
+
+**Simplified from the suggested fix.** CodeRabbit's diff captured the
+scan status into a `scan_status` variable via an `if`/`else` before
+branching. That is unnecessary here: `case $?` already follows the
+`git grep` directly, with no intervening command, so `$?` is the
+scan's status. Adopted the guard, dropped the extra variable — same
+behavior, one less moving part.
+
+Re-tested across four paths after the change:
+
+| Case | Result |
+|------|--------|
+| staged secret present | BLOCKED (credential found) |
+| clean index | COMMIT would run |
+| not a git repo (add fails first) | BLOCKED (staging failed) |
+| path does not exist | BLOCKED (staging failed) |
+
+Note the abort ordering shifted: a non-repo now fails at `add` rather
+than reaching the scan's 128 branch. Both block, so the invariant
+holds either way — but the `*)` scan-error branch is still load-bearing
+for the case where staging succeeds and the scan itself breaks.

--- a/.kit/context/reviews/KIT-0113-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0113-evaluator-review.md
@@ -1,0 +1,70 @@
+# KIT-0113 — Evaluator Review Record
+
+**Date**: 2026-08-16
+**Agent**: feature-developer
+**Change**: `.claude/agents/project-intake.md` — R1 quiet credential
+scans, R2 post-seeding doctor, component 1.2.0 → 1.3.0
+**Input**: `.adversarial/inputs/KIT-0113-code-review-input.md`
+(`--format diff` — a prose/contract diff; `full` would have fed the
+evaluators ~550 lines of unchanged agent body and invited findings
+about text the diff never touched, KIT-0092)
+
+## Tiers run
+
+| Evaluator | Verdict | Log |
+|-----------|---------|-----|
+| `code-reviewer-fast` | CONCERNS | `.adversarial/logs/KIT-0113-code-review-input--code-reviewer-fast.md` |
+| `claude-code` (security) | CHANGES_REQUESTED | `.adversarial/logs/KIT-0113-code-review-input--claude-code.md` |
+| `code-reviewer` (deep, ~$0.33) | **SKIPPED** | — |
+
+**Deep-tier skip reason**: the diff is a single markdown agent body —
+no executable surface, no logic paths to trace. The security tier was
+run *instead* because the change is entirely about credential
+handling, which is where the real risk sits. The ordering rule was
+honoured: both tiers ran before the PR opened.
+
+## Round 1 — `code-reviewer-fast` (CONCERNS)
+
+Five findings, four of them one class (unhandled non-0/1 exit codes on
+the scan commands) plus one on overloaded doctor exit codes.
+
+| # | Finding | Disposition |
+|---|---------|-------------|
+| 1–4 | Scans define behavior only for exit 0/1; `git` exits 128 on bad path / missing repo / permission error, leaving behavior undefined | **ACCEPTED** — real. A scan that did not run has proven nothing. Added an explicit fail-closed clause: any exit other than 0/1 is a broken scan, report and stop, never commit on it. Commit `c8ee531`. |
+| 5 | `agentive doctor` exit 1 is ambiguous | **ACCEPTED** — and verified against the implementation: exit 1 genuinely IS overloaded. The driver's contract (`doctor/__init__.py:539–543`) uses 1 for "at least one FAIL" (0 = PASS/SKIP, 2 = warnings only, 3 = driver error), while `_project_root()` (`cli.py:74–80`) also exits 1 when it finds no project root. Step 5 now gates on the `DOCTOR:` verdict lines, not the exit code alone. Commit `c8ee531`. |
+
+## Round 2 — `claude-code` security (CHANGES_REQUESTED)
+
+Two accepted, five declined. The two blocking findings were both
+proposals to *narrow* the credential regex — declined on fail-closed
+grounds, reasoning recorded below.
+
+| Severity | Finding | Disposition |
+|----------|---------|-------------|
+| HIGH | `eyJ[A-Za-z0-9_-]{20,}` is structurally incomplete (no `.` separator) and false-positives on any base64 JSON; tighten to require three JWT segments | **DECLINED.** For a *detection* scan, matching the header segment is sufficient to flag the file — the `.` is needed to parse a JWT, not to spot one. Requiring three segments would narrow detection, i.e. fail open, which is the wrong bias for a credential gate. False positives here cost one user glance at a filename; false negatives cost a leaked credential. The `eyJ` shape is also inherited from the pre-existing prose pattern ("long `eyJ` JWT blobs"), which this change merely made executable. |
+| HIGH | `BEGIN [A-Z ]*PRIVATE KEY` lacks the PEM `-----` delimiters, false-positiving on docs | **DECLINED**, same fail-closed reasoning — and the evaluator itself concedes the cost is "annoying but not a security regression." Note the new pattern is already strictly *broader* than the one it replaces: verified live, `BEGIN [A-Z ]*PRIVATE KEY` matches 3/3 PEM header forms where the old `BEGIN .* PRIVATE KEY` matched 2/3 (it missed bare `BEGIN PRIVATE KEY`). |
+| HIGH | `git grep --cached` on an empty index exits 1, indistinguishable from clean | **DECLINED** — self-limiting. Nothing staged means `git commit` fails on its own, so the "scan passed but nothing was committed" state cannot ship a credential. The evaluator concedes an empty commit is harmless. |
+| MEDIUM | Pattern set duplicated across two sites, manual sync is fragile | **DECLINED** — already mitigated in-document with an explicit "change it in both" instruction, and the two literals are byte-identical (verified by grep count = 2). A markdown agent body has no DRY mechanism; the suggested line-number cross-references would themselves drift. |
+| MEDIUM | A failed `cd` short-circuits `&&` so the doctor never runs; the fail-closed posture should cover it | **ALREADY ADDRESSED** in `c8ee531` (the evaluator read the pre-fix hunk). Wording sharpened from "wrong directory" to "a `cd` that failed" for precision. |
+| LOW | Exit 2 (warnings only) not addressed in the launch gate — agent must infer | **ACCEPTED.** Added one line: a warnings-only re-run still prints the launch command, WARNs listed as informational rather than ✗. |
+| LOW | No instruction to re-scan after remediation | **ACCEPTED** — genuinely good catch. Removing one offending file does not clear hits in the others. Added: the post-remediation scan, not the original, is the pass that authorizes the commit. |
+
+### Note on the evaluator's "unverifiable" list
+
+`claude-code` flagged the `agentive doctor` exit-code contract as
+unverifiable from the diff and warned "if the contract differs, the
+gate logic is wrong." It was verified directly against the
+implementation before the claim was written into the agent body —
+see the round-1 finding 5 row for file and line anchors.
+
+## Verification performed beyond the evaluators
+
+The scan command was executed live in a scratch repo rather than
+reasoned about, since displayed commands are contracts:
+
+- planted `ghp_…` in a staged file → printed `leak.py` and nothing
+  else (filename only, zero secret bytes), exit 0
+- unstaged it → no output, exit 1
+
+This is what established the inverted-exit reading now documented at
+both scan sites.

--- a/.kit/context/reviews/KIT-0113-evaluator-review.md
+++ b/.kit/context/reviews/KIT-0113-evaluator-review.md
@@ -42,7 +42,7 @@ grounds, reasoning recorded below.
 | Severity | Finding | Disposition |
 |----------|---------|-------------|
 | HIGH | `eyJ[A-Za-z0-9_-]{20,}` is structurally incomplete (no `.` separator) and false-positives on any base64 JSON; tighten to require three JWT segments | **DECLINED.** For a *detection* scan, matching the header segment is sufficient to flag the file — the `.` is needed to parse a JWT, not to spot one. Requiring three segments would narrow detection, i.e. fail open, which is the wrong bias for a credential gate. False positives here cost one user glance at a filename; false negatives cost a leaked credential. The `eyJ` shape is also inherited from the pre-existing prose pattern ("long `eyJ` JWT blobs"), which this change merely made executable. |
-| HIGH | `BEGIN [A-Z ]*PRIVATE KEY` lacks the PEM `-----` delimiters, false-positiving on docs | **DECLINED**, same fail-closed reasoning — and the evaluator itself concedes the cost is "annoying but not a security regression." Note the new pattern is already strictly *broader* than the one it replaces: verified live, `BEGIN [A-Z ]*PRIVATE KEY` matches 3/3 PEM header forms where the old `BEGIN .* PRIVATE KEY` matched 2/3 (it missed bare `BEGIN PRIVATE KEY`). |
+| HIGH | `BEGIN [A-Z ]*PRIVATE KEY` lacks the PEM `-----` delimiters, false-positiving on docs | **DECLINED**, same fail-closed reasoning — the evaluator itself concedes the cost is "annoying but not a security regression." ⚠️ **But see the bot round below**: the claim originally recorded here — that this pattern was "strictly broader" than the `BEGIN .* PRIVATE KEY` it replaced — was WRONG, and CodeRabbit caught it. Corrected there. |
 | HIGH | `git grep --cached` on an empty index exits 1, indistinguishable from clean | **DECLINED** — self-limiting. Nothing staged means `git commit` fails on its own, so the "scan passed but nothing was committed" state cannot ship a credential. The evaluator concedes an empty commit is harmless. |
 | MEDIUM | Pattern set duplicated across two sites, manual sync is fragile | **DECLINED** — already mitigated in-document with an explicit "change it in both" instruction, and the two literals are byte-identical (verified by grep count = 2). A markdown agent body has no DRY mechanism; the suggested line-number cross-references would themselves drift. |
 | MEDIUM | A failed `cd` short-circuits `&&` so the doctor never runs; the fail-closed posture should cover it | **ALREADY ADDRESSED** in `c8ee531` (the evaluator read the pre-fix hunk). Wording sharpened from "wrong directory" to "a `cd` that failed" for precision. |
@@ -68,3 +68,54 @@ reasoned about, since displayed commands are contracts:
 
 This is what established the inverted-exit reading now documented at
 both scan sites.
+
+## Bot round 1 — PR #135 (BugBot 3 + CodeRabbit 3)
+
+Bot truth taken from the `reviewThreads` GraphQL query with
+`hasNextPage` fail-closed counting, **not** the check statuses: the
+Cursor BugBot check reported `skipping` while its three threads were
+already posted — another face of the lying-status class.
+
+All six threads accepted. Two of CodeRabbit's were convergent with
+BugBot's, so the substantive findings are four:
+
+| # | Bot(s) | Finding | Fix |
+|---|--------|---------|-----|
+| 1 | BugBot High + CodeRabbit Major | Step 4c ran `add` → scan → `commit` as one pasteable block with no gate. Under the inverted reading, a hit exits 0 — which *looks* like success — so a faithful run commits the staged secret. | Replaced the block with a shell-level `case $?` gate. **Prose cannot stop a pasted sequence** (CodeRabbit's phrasing, and it is right); the gate now lives in the shell. `case` not `if`: an `if`/`else` sends both "clean" (1) and "scan errored" (128) down the same branch and commits on a scan that never ran. |
+| 2 | BugBot High | The Step 2.1 pre-existing-repo scan was switched to `-l` but never got the inverted-exit / fail-closed rules, so a hit could read as success and the push proceed. | Gave it the exit contract by explicit reference to Step 2.3, plus a note that it takes no `--cached` (it scans tracked files, not an index). |
+| 3 | BugBot Medium + CodeRabbit Major | The "re-scan after remediation" instruction — added in evaluator round 2 — could itself false-pass: `--cached` sees only the index, so a scan run right after *unstaging* the offender passes vacuously while the secret sits in the working tree, ready to be re-`add`ed behind a green scan. | Rewrote the sequence to: remediate in the working tree → stage everything to be committed → scan → commit, with "nothing may be staged after the authorizing scan". |
+| 4 | CodeRabbit Minor | The review record's claim that the new PEM pattern was "strictly broader" than the old one was **false**. | Correct, and it exposed a real regression — see below. |
+
+### Finding 4 corrected a regression, not just a claim
+
+CodeRabbit's point: `BEGIN .* PRIVATE KEY` also matched labels with
+lowercase or punctuation, which `[A-Z ]*` rejects. Neither pattern was
+a superset of the other — so the change had *narrowed* coverage for
+those labels while widening it for the bare form.
+
+Re-tested over an 8-fixture PEM set (bare, RSA, OPENSSH, EC, DSA,
+ENCRYPTED, lowercase `rsa`, `X-509`):
+
+| Pattern | Matches |
+|---------|---------|
+| `BEGIN .* PRIVATE KEY` (original) | 7/8 — misses bare `BEGIN PRIVATE KEY` |
+| `BEGIN [A-Z ]*PRIVATE KEY` (this PR, round 1) | **6/8** — misses lowercase `rsa` and `X-509` |
+| `BEGIN [A-Za-z0-9 -]*PRIVATE KEY` (adopted) | **8/8** |
+
+Both scan sites now carry the 8/8 form, and the "strictly broader"
+claim above is retracted — the adopted pattern is a genuine superset
+of both predecessors, which the original was not.
+
+### Gate verified live
+
+The `case` gate was executed against all three exit classes rather
+than assumed, and the first run **found a bug in the test, which is
+how the fixture caught a real subtlety**: a directory nested inside
+another git repo returns exit 1 (empty index for that path), not 128.
+Against a true non-repo:
+
+| Case | Result |
+|------|--------|
+| staged secret present (exit 0) | BLOCKED (credential found) |
+| clean index (exit 1) | COMMIT would run |
+| not a git repository (exit 128) | BLOCKED (scan failed to run) |

--- a/.kit/tasks/4-in-review/KIT-0113-project-intake-hardening.md
+++ b/.kit/tasks/4-in-review/KIT-0113-project-intake-hardening.md
@@ -1,6 +1,6 @@
 # KIT-0113: project-intake hardening — quiet credential scan + post-seeding doctor
 
-**Status**: In Progress
+**Status**: In Review
 **Priority**: medium (one Critical-severity bot finding; contained — operator's own transcript)
 **Type**: Canon fix (`.claude/agents/project-intake.md`)
 **Estimated Effort**: ~1 h


### PR DESCRIPTION
Two hardening fixes to `.claude/agents/project-intake.md`, plus the component version bump. Leg 1 of 2 — leg 2 cuts plugin release 2.1.1 so the fix actually ships.

Source: CodeRabbit on `agentive-skills#11`, threads `PRRT_kwDOSj0O5s6ZiCNh` (Critical) + `PRRT_kwDOSj0O5s6ZiCNi`, declined at the marketplace per KIT-0097 (fix-here-then-release).

## R1 — quiet credential scans (Critical)

The agent told itself to print staged content into the transcript, which leaks a credential **before** the scan rejects it. Three sites, not the two in the spec:

| Site | Was | Now |
|------|-----|-----|
| Step 2.3 staged scan | grep echoing matched lines | `git grep -lIE --cached` — filenames only |
| Step 4c seeding scan | `git diff --cached  # scan this output` | same quiet form |
| Step 2.1 pre-existing-repo scan | bare `git grep` (prints matched **lines**) | same quiet form |

The third site was **outside the spec's class grep** — it delegated to "the same credential patterns" without specifying `-l`, so a bare `git grep` would have printed matched lines. Same leak class, found by widening the sweep to every `grep` instruction in the body.

### Acceptance falsifier

```
$ grep -n "diff --cached\|staged" .claude/agents/project-intake.md
222:   a **mandatory secret scan of the staged files** before the commit
224:   scan must never put staged bytes in front of the user, because a
226:   rejects it. `-l` reports FILENAMES ONLY; never `git diff --cached`,
254:   authorizing scan. **Nothing may be staged after it** — if you
465:The scan between add and commit is the same quiet staged-content
```

Zero echoing instructions remain — every hit is a prohibition or a description. The widened sweep (`grep -n "grep"`) shows every scan instruction now carries `-l`.

### Verified live, not reasoned about

Displayed commands are contracts, so the scan was run in a scratch repo before being written in:

- planted `ghp_…` in a staged file → printed `leak.py` and nothing else, exit **0**
- unstaged it → no output, exit **1**

That inverted exit reading (0 + filenames = stop; 1 + silence = clean) is now documented at both primary sites, along with fail-closed handling: any other exit is a broken scan, never a pass.

**Private-key pattern** (corrected after bot round 1): now `BEGIN [A-Za-z0-9 -]*PRIVATE KEY`. My first attempt at this was `[A-Z ]*`, which I described as "strictly broader" than the original `BEGIN .* PRIVATE KEY` — CodeRabbit correctly refuted that, and chasing it down showed the round-1 pattern had actually *narrowed* coverage for lowercase and punctuated labels. Re-tested over an 8-fixture PEM set (bare, RSA, OPENSSH, EC, DSA, ENCRYPTED, lowercase `rsa`, `X-509`):

| Pattern | Matches |
|---------|---------|
| `BEGIN .* PRIVATE KEY` (original) | 7/8 — misses bare `BEGIN PRIVATE KEY` |
| `BEGIN [A-Z ]*PRIVATE KEY` (round 1) | **6/8** |
| `BEGIN [A-Za-z0-9 -]*PRIVATE KEY` (adopted) | **8/8** |

The adopted form is a genuine superset of both predecessors.

## R2 — post-seeding doctor

Step 5 gated its checklist and launch line on the door's doctor tail, which is captured **before** Step 4 seeds the prefix and backlog — so it relayed WARNs the seeding had already cured (empty `TASK_PREFIX`, KIT-0084).

Step 5 now re-runs `agentive doctor` after the seeding commit and gates on that. The door's tail is still relayed verbatim, and the two are labeled so they can't be conflated:

```
Doctor tail — the door's install verdict, verbatim:
<the door's doctor output, as captured at Step 3>

Doctor re-run — planning repo after seeding, verbatim:
<the output of `agentive doctor` from Step 5's re-run>
```

Door tail = **install truth** (its exit contract is what says the install succeeded). Re-run = **repo-state truth**. They can legitimately disagree — a WARN the re-run no longer reports is the seeding working, which is exactly why the labels matter.

Two implementation details verified against the source rather than assumed:

- **The re-run needs the planning repo as CWD.** `_project_root()` (`cli.py:74-80`) resolves from the CWD and exits 1 when it finds none, and `--root=` wouldn't help anyway: `doctor_dir` is computed from `project_dir` at `doctor/__init__.py:548`, *before* `--root=` is parsed at `:565`, so `--root=` would diagnose one repo with another's check set.
- **Exit 1 is overloaded.** The driver uses it for "at least one FAIL" (`:539-543`: 0 = PASS/SKIP, 2 = warnings only, 3 = driver error) while the CLI also exits 1 for "no project root". Step 5 gates on the `DOCTOR:` verdict lines, not the exit code alone.

The `## Restrictions` section forbade exactly what R2 requires ("never re-derive install state") — reconciled rather than left contradicting: the re-run reports repo state after our own seeding, sits alongside the door's tail, and never revises the door's verdict.

## Evaluators

Ran before the PR opened. Record with the full disposition table: `.kit/context/reviews/KIT-0113-evaluator-review.md`.

| Tier | Verdict | Outcome |
|------|---------|---------|
| `code-reviewer-fast` | CONCERNS | 5 findings, **all accepted** — fail-closed on non-0/1 exits, doctor exit-1 disambiguation |
| `claude-code` (security) | CHANGES_REQUESTED | 2 accepted (re-scan after remediation, WARN-only gate), 5 declined with reasoning |
| `code-reviewer` (deep) | **skipped** | Single markdown agent body, no executable surface. The security tier was run instead — the change is entirely credential handling, which is where the risk sits. |

Both blocking security findings were proposals to **narrow** the credential regex (require three JWT segments; require PEM `-----` delimiters). Declined on fail-closed grounds: for a detection scan, breadth is the correct bias — a false positive costs one glance at a filename, a false negative costs a leaked credential. The evaluator itself concedes the PEM case is "annoying but not a security regression."

## Scope

- Component frontmatter `1.2.0` → `1.3.0` (R2 adds behavior; manual until KIT-0111)
- No packaged twin — `find packages -name project-intake.md` returns nothing
- No test pins the changed prose; `TestIntakeAgentContract` passes untouched
- Local: 1045 passed, 13 skipped; markdownlint + full pre-commit gauntlet green

## Test plan

- [x] Acceptance class grep returns zero echoing instructions
- [x] Quiet scan verified live (hit → filename only; clean → silence)
- [x] Private-key regex verified 8/8 over the PEM fixture set (superset of both predecessors)
- [x] Shell `case` gate verified against all three exit classes (hit / clean / scan-errored)
- [x] Doctor exit contract + `--root=` ordering verified against source
- [x] Full fast suite green
- [ ] CI green on GitHub
- [x] Bot rounds resolved (7 threads over 3 rounds, all replied + resolved; CodeRabbit APPROVED on head)

Task: `.kit/tasks/3-in-progress/KIT-0113-project-intake-hardening.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoKAFARQUDs4r6dpjzN9re

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 15bd04a786775ddd006c769efee116f3883c4cbe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->