### PR TITLE
fix(KIT-0113): check `git add -A` in the Step 2.3 scan too (project-intake 1.3.1)

### DIFF
--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -231,8 +231,9 @@ All commands target the code folder explicitly (`git -C <code-path>`).
      echo "BLOCKED: staging failed — the index is not the tree you are importing" >&2
      false
    else
-     git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
-     case $? in
+     scan=0
+     git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}' || scan=$?
+     case $scan in
        0) echo "BLOCKED: credential shapes in the files listed above — do not commit" >&2; false ;;
        1) true ;;  # clean — proceed to the commit described below
        *) echo "BLOCKED: scan failed to run — it has proven nothing" >&2; false ;;
@@ -245,8 +246,16 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    imported, and a clean scan of *that* index would authorize the
    import commit anyway.
 
+   **Do not "simplify" `|| scan=$?` into a bare `grep` followed by
+   `case $?`.** They are equivalent only without `set -e`. Under
+   `set -e` a bare `grep` returning 1 — which is the CLEAN result —
+   aborts the shell before `case` ever runs, so the scan passing is
+   what kills the commit. The `|| scan=$?` form makes the non-zero
+   status part of a compound command, which `set -e` ignores. This
+   was simplified away once and had to be restored (KIT-0113).
+
    **This is Step 4c's gate, copied — not a re-derivation of it.** The
-   `case $?` is what makes the block's own exit status mean something:
+   `case` is what makes the block's own exit status mean something:
    without it the block ends on the `grep`, so it inherits the grep's
    INVERTED status and reports 0 (success) when a credential was found
    and 1 (failure) when the index is clean. Every blocked branch ends
@@ -471,8 +480,9 @@ if ! git -C "$PLANNING" add -A; then
   echo "BLOCKED: staging failed — the index is not what you think, do not commit" >&2
   false
 else
-  git -C "$PLANNING" grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
-  case $? in
+  scan=0
+  git -C "$PLANNING" grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}' || scan=$?
+  case $scan in
     0) echo "BLOCKED: credential shapes in the files listed above — do not commit" >&2; false ;;
     1) git -C "$PLANNING" commit -m "chore: seed project context and backlog from prototype brief" ;;
     *) echo "BLOCKED: scan failed to run — it has proven nothing" >&2; false ;;

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -232,7 +232,11 @@ All commands target the code folder explicitly (`git -C <code-path>`).
      false
    else
      git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
-     # read the exit code below before committing
+     case $? in
+       0) echo "BLOCKED: credential shapes in the files listed above — do not commit" >&2; false ;;
+       1) true ;;  # clean — proceed to the commit described below
+       *) echo "BLOCKED: scan failed to run — it has proven nothing" >&2; false ;;
+     esac
    fi
    ```
 
@@ -241,12 +245,16 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    imported, and a clean scan of *that* index would authorize the
    import commit anyway.
 
-   **Every blocked branch ends in `false`** so the block itself exits
-   non-zero. Without it the branch's last command is `echo`, the whole
-   `if` returns 0, and any wrapper or `set -e` script reads a refusal
-   as success — the block would announce BLOCKED and report OK. `false`
-   rather than `exit 1` because these snippets get pasted into live
-   shells, and `exit` would close the operator's session.
+   **This is Step 4c's gate, copied — not a re-derivation of it.** The
+   `case $?` is what makes the block's own exit status mean something:
+   without it the block ends on the `grep`, so it inherits the grep's
+   INVERTED status and reports 0 (success) when a credential was found
+   and 1 (failure) when the index is clean. Every blocked branch ends
+   in `false` for the same reason — a branch whose last command is
+   `echo` returns 0, so the block would announce BLOCKED and report OK
+   to any wrapper or `set -e` script. `false` rather than `exit 1`
+   because these snippets get pasted into live shells, where `exit`
+   would close the operator's session.
 
    **Read the exit code — it is inverted from the intuition**: exit 0
    with filenames printed means credential shapes WERE found (stop);

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -228,7 +228,8 @@ All commands target the code folder explicitly (`git -C <code-path>`).
 
    ```bash
    if ! git -C <code-path> add -A; then
-     echo "BLOCKED: staging failed — the index is not the tree you are importing"
+     echo "BLOCKED: staging failed — the index is not the tree you are importing" >&2
+     false
    else
      git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
      # read the exit code below before committing
@@ -239,6 +240,13 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    failed or partial stage leaves an index that is not the tree being
    imported, and a clean scan of *that* index would authorize the
    import commit anyway.
+
+   **Every blocked branch ends in `false`** so the block itself exits
+   non-zero. Without it the branch's last command is `echo`, the whole
+   `if` returns 0, and any wrapper or `set -e` script reads a refusal
+   as success — the block would announce BLOCKED and report OK. `false`
+   rather than `exit 1` because these snippets get pasted into live
+   shells, and `exit` would close the operator's session.
 
    **Read the exit code — it is inverted from the intuition**: exit 0
    with filenames printed means credential shapes WERE found (stop);
@@ -452,13 +460,14 @@ exists to catch:
 ```bash
 PLANNING="<parent>/<name>-planning"
 if ! git -C "$PLANNING" add -A; then
-  echo "BLOCKED: staging failed — the index is not what you think, do not commit"
+  echo "BLOCKED: staging failed — the index is not what you think, do not commit" >&2
+  false
 else
   git -C "$PLANNING" grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
   case $? in
-    0) echo "BLOCKED: credential shapes in the files listed above — do not commit" ;;
+    0) echo "BLOCKED: credential shapes in the files listed above — do not commit" >&2; false ;;
     1) git -C "$PLANNING" commit -m "chore: seed project context and backlog from prototype brief" ;;
-    *) echo "BLOCKED: scan failed to run — it has proven nothing" ;;
+    *) echo "BLOCKED: scan failed to run — it has proven nothing" >&2; false ;;
   esac
 fi
 ```
@@ -469,7 +478,10 @@ because an `if`/`else` on the scan would send both "clean" (1) and
 never ran — only exit 1 commits. The `add` is checked for the
 adjacent reason: a partially-failed stage leaves an index that is not
 the tree you meant to seed, and a scan of it would authorize an
-incomplete commit while looking green.
+incomplete commit while looking green. And **every blocked branch ends
+in `false`**, exactly as in Step 2.3: without it the branch's last
+command is `echo`, the block returns 0, and a wrapper reads "BLOCKED"
+as success.
 
 The scan between add and commit is the same quiet staged-content
 credential scan as Step 2.3 — same pattern set, same filenames-only

--- a/.claude/agents/project-intake.md
+++ b/.claude/agents/project-intake.md
@@ -2,7 +2,7 @@
 name: project-intake
 description: Graduates a prototype into the split pair — plain code repo plus preset-configured planning repo — from a handoff brief and a code folder
 model: claude-sonnet-5
-version: 1.3.0
+version: 1.3.1
 origin: agentive-starter-kit
 last-updated: 2026-08-16
 created-by: "@movito (KIT-0066)"
@@ -227,9 +227,18 @@ All commands target the code folder explicitly (`git -C <code-path>`).
    never a grep that prints matched lines.
 
    ```bash
-   git -C <code-path> add -A
-   git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
+   if ! git -C <code-path> add -A; then
+     echo "BLOCKED: staging failed — the index is not the tree you are importing"
+   else
+     git -C <code-path> grep -lIE --cached 'sk-|ghp_|github_pat_|xoxb-|AKIA|BEGIN [A-Za-z0-9 -]*PRIVATE KEY|eyJ[A-Za-z0-9_-]{20,}'
+     # read the exit code below before committing
+   fi
    ```
+
+   The `add` is checked for the same reason Step 4c checks it: a
+   failed or partial stage leaves an index that is not the tree being
+   imported, and a clean scan of *that* index would authorize the
+   import commit anyway.
 
    **Read the exit code — it is inverted from the intuition**: exit 0
    with filenames printed means credential shapes WERE found (stop);

--- a/.kit/context/patterns.yml
+++ b/.kit/context/patterns.yml
@@ -175,6 +175,25 @@ defensive:
       - "KIT-0069 class greps found ~15% more sites than the audit's 92-finding list (.env.template, bare ./project help form, filename-less prose mentions)"
       - "…and still missed 6 sibling instances that only file-reads/tree-verification caught (6 regressions, all one failure mode)"
     caught_by: "KIT-0069 retro (What Worked 1 + Surprising 5); planner adopted 2026-07-27"
+  harden_twins_by_copy_not_rederivation:
+    rule: >
+      When you harden one site of a duplicated construct, sweep the
+      twins in the SAME commit — and port the hardened form
+      VERBATIM rather than re-deriving an equivalent. Re-derivation
+      is how asymmetry creeps back: the re-derived twin looks
+      right, reads right in review, and quietly drops a property
+      the original had for a reason nobody restates. This is
+      fix_by_class_not_instance applied to a construct rather than
+      a token, plus the clause that class-sweeping alone does not
+      supply — sweeping finds the twin, copying is what makes it
+      actually equivalent. Verify by asserting the twins agree
+      OUTPUT-for-OUTPUT on identical inputs, not by reading them
+      side by side.
+    examples:
+      - "KIT-0113: five consecutive bot rounds, each finding created by the previous fix — leak → ungated commit → unchecked add -A → wrong exit status → inverted exit status"
+      - "The Step 2.3 gate was re-derived from Step 4c's rather than copied; it dropped the `case $?`, so the block inherited git grep's INVERTED status and returned 0 (success) on a credential hit, 1 (failure) on a clean index"
+      - "The re-derived twin had already been reviewed twice by bots and once by the author before the inversion was measured — reading them side by side did not surface it; running both and diffing the status did"
+    caught_by: "KIT-0113 (planner gate-check on PR #136, 2026-08-16); sibling of fix_by_class_not_instance"
   evidence_files_append_only:
     rule: >
       Evidence records (audit records, retros, review records) are

--- a/.kit/context/patterns.yml
+++ b/.kit/context/patterns.yml
@@ -190,16 +190,20 @@ defensive:
       SUGGESTED form: "simplify away the part that looks
       redundant" is re-derivation wearing a tidier hat, and the
       dropped part is usually load-bearing under a condition the
-      suggestion never had to name. Verify by asserting the twins
-      agree OUTPUT-for-OUTPUT on identical inputs, across every
-      ENVIRONMENT the snippet can run in — not by reading them side
-      by side.
+      suggestion never had to name. Verify each twin in an
+      ISOLATED FIXTURE and compare exit status, stdout, stderr, AND
+      the resulting state it was supposed to protect — for
+      identical inputs, across every ENVIRONMENT the snippet can
+      run in. Status parity alone is not equivalence: two gates can
+      agree on every exit code while one of them still commits.
+      Never rely on side-by-side reading.
     examples:
       - "KIT-0113: five consecutive bot rounds, each finding created by the previous fix — leak → ungated commit → unchecked add -A → wrong exit status → inverted exit status"
       - "The Step 2.3 gate was re-derived from Step 4c's rather than copied; it dropped the `case $?`, so the block inherited git grep's INVERTED status and returned 0 (success) on a credential hit, 1 (failure) on a clean index"
       - "The re-derived twin had already been reviewed twice by bots and once by the author before the inversion was measured — reading them side by side did not surface it; running both and diffing the status did"
       - "Second instance, same task: a reviewer's `|| scan=$?` capture was declined as 'a moving part without a job' and simplified to a bare command + `case $?`. Equivalent — except under `set -e`, where the CLEAN exit (1) aborts the shell before `case` runs, so the scan PASSING killed the commit. The reviewer re-found it two PRs later."
       - "Test gap that hid it: the `set -e` check exercised only the ABORT paths, where aborting was the wanted outcome — never the PROCEED path, which was the one breaking. Assert the happy path under the hostile environment too"
+      - "The status-parity test itself was insufficient and a reviewer said so: it stubbed the commit out, so it could not have caught a gate that returned the right code and committed anyway. Re-run against real fixtures — no commit on a hit, commit on clean, secret absent from history, offending file left staged for remediation"
     caught_by: "KIT-0113 (planner gate-check on PR #136, 2026-08-16); sibling of fix_by_class_not_instance"
   evidence_files_append_only:
     rule: >

--- a/.kit/context/patterns.yml
+++ b/.kit/context/patterns.yml
@@ -186,13 +186,20 @@ defensive:
       fix_by_class_not_instance applied to a construct rather than
       a token, plus the clause that class-sweeping alone does not
       supply — sweeping finds the twin, copying is what makes it
-      actually equivalent. Verify by asserting the twins agree
-      OUTPUT-for-OUTPUT on identical inputs, not by reading them
-      side by side.
+      actually equivalent. The same rule governs a reviewer's
+      SUGGESTED form: "simplify away the part that looks
+      redundant" is re-derivation wearing a tidier hat, and the
+      dropped part is usually load-bearing under a condition the
+      suggestion never had to name. Verify by asserting the twins
+      agree OUTPUT-for-OUTPUT on identical inputs, across every
+      ENVIRONMENT the snippet can run in — not by reading them side
+      by side.
     examples:
       - "KIT-0113: five consecutive bot rounds, each finding created by the previous fix — leak → ungated commit → unchecked add -A → wrong exit status → inverted exit status"
       - "The Step 2.3 gate was re-derived from Step 4c's rather than copied; it dropped the `case $?`, so the block inherited git grep's INVERTED status and returned 0 (success) on a credential hit, 1 (failure) on a clean index"
       - "The re-derived twin had already been reviewed twice by bots and once by the author before the inversion was measured — reading them side by side did not surface it; running both and diffing the status did"
+      - "Second instance, same task: a reviewer's `|| scan=$?` capture was declined as 'a moving part without a job' and simplified to a bare command + `case $?`. Equivalent — except under `set -e`, where the CLEAN exit (1) aborts the shell before `case` runs, so the scan PASSING killed the commit. The reviewer re-found it two PRs later."
+      - "Test gap that hid it: the `set -e` check exercised only the ABORT paths, where aborting was the wanted outcome — never the PROCEED path, which was the one breaking. Assert the happy path under the hostile environment too"
     caught_by: "KIT-0113 (planner gate-check on PR #136, 2026-08-16); sibling of fix_by_class_not_instance"
   evidence_files_append_only:
     rule: >


### PR DESCRIPTION
Follow-on to #135, found by BugBot reviewing the 2.1.1 release PR ([agentive-skills#12](https://github.com/movito/agentive-skills/pull/12)). One-line class fix; `project-intake` 1.3.0 → 1.3.1.

## The gap

#135's last bot round added an `if ! git add -A` guard to the **Step 4c** seeding gate. It never applied the same guard to **Step 2.3**, the twin scan that covers the code-repo import — so #135 shipped a hardened gate next to an unhardened one, with its own rationale sitting right there explaining why the unhardened form is unsafe.

BugBot's framing, and it's correct: a failed or partial `add -A` leaves an index that is not the tree being imported, and a clean `--cached` scan of *that* index still clears the commit path, because the prose treats exit 1 as "proceed".

Step 2.3 is arguably the worse of the two to leave unguarded — it covers the wholesale import of a prototype folder, which is where unreviewed third-party content actually enters.

## The fix

Step 2.3 now uses the same structure as Step 4c, with the reason stated inline so the two read as one rule rather than two conventions:

```bash
if ! git -C <code-path> add -A; then
  echo "BLOCKED: staging failed — the index is not the tree you are importing"
else
  git -C <code-path> grep -lIE --cached '<patterns>'
  # read the exit code below before committing
fi
```

## Why it lands here and not in the plugin

The finding was reported against the published copy, but the plugin copy is **resync-only** per KIT-0113's out-of-scope rule — it changes only via `scripts/local/plugin_resync.py`. So the fix lands in the kit first and reaches the pending 2.1.1 release through a re-resync **before that release merges**. Net effect: 2.1.1 ships `project-intake` 1.3.1, not a known-asymmetric 1.3.0.

## Verification

Guard semantics re-tested across four paths (same fixture set as #135):

| Case | Result |
|------|--------|
| staged secret present | BLOCKED (credential found) |
| clean index | COMMIT would run |
| not a git repo (add fails first) | BLOCKED (staging failed) |
| path does not exist | BLOCKED (staging failed) |

Local suite: 1045 passed, 13 skipped. Full pre-commit gauntlet green.

## Expected-red drift guard

Same situation as #135 and the same justification: this changes a rostered `.claude/` component while the published plugin is 2.1.0, so the guard is legitimately failing per the POSTURE ruling in `.github/workflows/plugin-drift.yml`. The remedy is already in flight — [agentive-skills#12](https://github.com/movito/agentive-skills/pull/12) is open and will be re-synced onto this commit before merging, taking the guard green.

## Test plan

- [x] Guard verified across four exit paths
- [x] Frontmatter 1.3.0 → 1.3.1
- [x] Full fast suite green
- [ ] CI green
- [ ] Re-resync into the 2.1.1 release PR

Task: `.kit/tasks/4-in-review/KIT-0113-project-intake-hardening.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoKAFARQUDs4r6dpjzN9re

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fd7b16602d69f6028d28e1499bf89e2130f6ba1e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->